### PR TITLE
Use AlmaLinux 10 container as test environment and published container

### DIFF
--- a/ci/teamcity/Delft3D/linux/dockerLegacyScriptTest.kt
+++ b/ci/teamcity/Delft3D/linux/dockerLegacyScriptTest.kt
@@ -33,7 +33,7 @@ object LinuxLegacyDockerTest : BuildType({
         select(
             name = "distribution",
             label = "Distribution",
-            value = "alma8",
+            value = "alma10",
             display = ParameterDisplay.PROMPT,
             options = listOf(
                 "AlmaLinux 8" to "alma8",

--- a/ci/teamcity/Delft3D/linux/test.kt
+++ b/ci/teamcity/Delft3D/linux/test.kt
@@ -52,7 +52,7 @@ object LinuxTest : BuildType({
         select(
             name = "distribution",
             label = "Distribution",
-            value = "alma8",
+            value = "alma10",
             display = ParameterDisplay.PROMPT,
             options = listOf(
                 "AlmaLinux 8" to "alma8",

--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -59,7 +59,7 @@ object Publish : BuildType({
             display = ParameterDisplay.PROMPT)
         param("reverse.dep.*.product", "all-testbench")
         param("commit_id_short", "%dep.${LinuxBuild.id}.commit_id_short%")
-        param("source_image", "containers.deltares.nl/delft3d-dev/test/delft3d-test-container:alma8-%dep.${LinuxBuild.id}.product%-%build.vcs.number%")
+        param("source_image", "containers.deltares.nl/delft3d-dev/test/delft3d-test-container:alma10-%dep.${LinuxBuild.id}.product%-%build.vcs.number%")
         param("destination_image_generic", "containers.deltares.nl/delft3d/%brand%:%release_type%")
         param("destination_image_specific", "containers.deltares.nl/delft3d/%brand%:%release_type%-%release_version%")
     }


### PR DESCRIPTION
This pull request updates the default Linux distribution used in several TeamCity build configurations from AlmaLinux 8 to AlmaLinux 10. The changes ensure consistency across the test and publishing pipelines by updating both parameter defaults and container image tags.