### PR TITLE
UNST-8768: `extforce-convert` lim waves cases

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dfm_lim_waves.xml
+++ b/test/deltares_testbench/configs/include/dimr_dfm_lim_waves.xml
@@ -1,6 +1,6 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
 	<testCase name="e02_f043_c01_WAQ_2D" ref="dflowfm_fetch_limited_waves">
-      <path version="2024-08-26T11:45:00">e02_dflowfm/f043_fetch_limited_waves/c01_WAQ_2D/</path>
+      <path version="2025-08-01T15:14:31.052000">e02_dflowfm/f043_fetch_limited_waves/c01_WAQ_2D/</path>
       <maxRunTime>7.5000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_fetchwave1/fetchwave1_map.nc" type="netCDF">
@@ -14,7 +14,7 @@
       </checks>
     </testCase>
 	<testCase name="e02_f043_c02_WAQ_3D" ref="dflowfm_fetch_limited_waves">
-      <path version="2024-08-26T12:25:00">e02_dflowfm/f043_fetch_limited_waves/c02_WAQ_3D/</path>
+      <path version="2025-08-01T15:14:41.726000">e02_dflowfm/f043_fetch_limited_waves/c02_WAQ_3D/</path>
       <maxRunTime>7.5000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_fetchwave1/fetchwave1_map.nc" type="netCDF">
@@ -28,7 +28,7 @@
       </checks>
     </testCase>
 	<testCase name="e02_f043_c03_WAQ_3D" ref="dflowfm_fetch_limited_waves">
-      <path version="2024-08-26T12:30:00">e02_dflowfm/f043_fetch_limited_waves/c03_WAQ_3D/</path>
+      <path version="2025-08-01T15:14:47.040000">e02_dflowfm/f043_fetch_limited_waves/c03_WAQ_3D/</path>
       <maxRunTime>7.5000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_fetchwave1/fetchwave1_map.nc" type="netCDF">
@@ -42,7 +42,7 @@
       </checks>
     </testCase>
 	<testCase name="e02_f043_c04" ref="dflowfm_fetch_limited_waves">
-      <path version="2024-08-26T12:35:00">e02_dflowfm/f043_fetch_limited_waves/c04/</path>
+      <path version="2025-08-01T15:14:50.355000">e02_dflowfm/f043_fetch_limited_waves/c04/</path>
       <maxRunTime>7.5000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_fetchwave1/fetchwave1_map.nc" type="netCDF">
@@ -55,7 +55,7 @@
       </checks>
     </testCase>
 	<testCase name="e02_f043_c05" ref="dflowfm_fetch_limited_waves">
-      <path version="2024-08-26T12:55:00">e02_dflowfm/f043_fetch_limited_waves/c05/</path>
+      <path version="2025-08-01T15:14:52.831000">e02_dflowfm/f043_fetch_limited_waves/c05/</path>
       <maxRunTime>7.5000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_fetchwave1/fetchwave1_map.nc" type="netCDF">


### PR DESCRIPTION
# What was done 

Converted all the cases in `configs/dimr/dimr_dflowfm_lim_waves_{lnx,win}64.xml`

- e02_f043_c01
- e02_f043_c02
- e02_f043_c03
- e02_f043_c04
- e02_f043_c05

The conversion with `extforce-convert` emptied the existing `.bc` files for some reason. So they were error-ing at first. Copying the `.bc` files back from the old case data fixed them. ~TODO: report issue to HYDROLIB-core issue board.~

UPDATE: Created HYDROLIB-core issue: https://github.com/Deltares/HYDROLIB-core/issues/900


# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
