### PR TITLE
UNST-9127: avoid numbered references to User Manual in error messages.

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_deprecated_keywords.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_deprecated_keywords.f90
@@ -16,8 +16,8 @@ contains
       end if
       allocate (deprecated_mdu_keywords%deprecated_keyword_list(100), deprecated_ext_keywords%deprecated_keyword_list(100))
 
-      deprecated_mdu_keywords%additional_information = 'Check Section A.4 in the User Manual for information on how to update this input file.'
-      deprecated_ext_keywords%additional_information = 'Check Section C.5 in the User Manual for information on how to update this input file.'
+      deprecated_mdu_keywords%additional_information = 'Check the User Manual appendix about the Master Definition file for information on how to update this input file.'
+      deprecated_ext_keywords%additional_information = 'Check the User Manual appendix about the external forcings file for information on how to update this input file.'
       deprecated_mdu_keywords%count = 0
       deprecated_ext_keywords%count = 0
 


### PR DESCRIPTION
Instead of attempting to achieve uniform section numbers in LaTeX (not a good idea), I've removed the hardcoded section number references from backend error messages and replaced them by a description instead.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ X]	Not applicable 

# Issue link
Closes UNST-9127.