### PR TITLE
UNST-9114 shear stress to WAQ with fetch based models

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -2097,9 +2097,6 @@ contains
       call prop_get(md_ptr, 'output', 'Wrimap_nudging', jamapnudge, success)
       call prop_get(md_ptr, 'output', 'Wrimap_pure1d_debug', jamapPure1D_debug, success)
       call prop_get(md_ptr, 'output', 'Wrimap_waves', jamapwav, success)
-      jamapwav_hwav = 0
-      jamapwav_twav = 0
-      jamapwav_phiwav = 0
       call prop_get(md_ptr, 'output', 'Wrimap_DTcell', jamapdtcell, success)
       epswetout = epshs ! the same as numerical threshold to counts as 'wet'.
       call prop_get(md_ptr, 'output', 'Wrimap_wet_waterdepth_threshold', epswetout, success)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -6223,17 +6223,17 @@ contains
 
          if (jawave > NO_WAVES .and. jamapwav > 0) then
             if (flowWithoutWaves) then ! Check the external forcing wave quantities and their associated arrays
-               if (jamapwav_hwav > 0 .and. allocated(hwav)) then
+               if (allocated(hwav)) then
                   if (jamapsigwav == 0) then
                      ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_hwav, nc_precision, UNC_LOC_S, 'hwav', 'sea_surface_wave_rms_height', 'RMS wave height', 'm', jabndnd=jabndnd_) ! not CF
                   else
                      ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_hwav, nc_precision, UNC_LOC_S, 'hwav', 'sea_surface_wave_significant_height', 'Significant wave height', 'm', jabndnd=jabndnd_)
                   end if
                end if
-               if (jamapwav_twav > 0 .and. allocated(twav)) then
+               if (allocated(twav)) then
                   ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, nc_precision, UNC_LOC_S, 'tp', 'sea_surface_wave_period_at_variance_spectral_density_maximum', 'Peak wave period', 's')
                end if
-               if (jamapwav_phiwav > 0 .and. allocated(phiwav)) then
+               if (allocated(phiwav)) then
                   ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_thetamean, nc_precision, UNC_LOC_S, 'thetamean', 'sea_surface_wave_from_direction', 'Wave from direction', 'degree')
                end if
             else ! flow with waves
@@ -7642,7 +7642,7 @@ contains
          end if
          !
          if (flowWithoutWaves) then ! Check the external forcing wave quantities and their associated arrays
-            if (jamapwav_hwav > 0 .and. allocated(hwav)) then
+            if (allocated(hwav)) then
                if (allocated(wa)) then
                   deallocate (wa, stat=ierr)
                end if
@@ -7650,13 +7650,13 @@ contains
                wa = wavfac * hwav
                ierr = unc_put_var_map(mapids%ncid, mapids%id_tsp, mapids%id_hwav, UNC_LOC_S, wa, jabndnd=jabndnd_)
             end if
-            if (jamapwav_twav > 0 .and. allocated(twav)) then
+            if (allocated(twav)) then
                ierr = unc_put_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, UNC_LOC_S, twav, jabndnd=jabndnd_)
             end if
-            if (jamapwav_phiwav > 0 .and. allocated(phiwav)) then
+            if (allocated(phiwav)) then
                ierr = unc_put_var_map(mapids%ncid, mapids%id_tsp, mapids%id_phiwav, UNC_LOC_S, phiwav, jabndnd=jabndnd_)
             end if
-         else ! flowWithoutWaves
+         else ! no flowWithoutWaves
             if (allocated(wa)) then
                deallocate (wa, stat=ierr)
             end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
@@ -43,7 +43,6 @@ contains
       use m_transport
       use m_partitioninfo
       use unstruc_model
-      use m_flowparameters, only: jawriteDetailedTimers
       use unstruc_files, only: mdia
       use m_flowtimes
       use timers
@@ -69,7 +68,6 @@ contains
 
       call mess(LEVEL_INFO, 'Initialising water quality processes')
 
-      jawriteDetailedTimers = 1
       if (timon) call timstrt("fm_wq_processes_ini_sub", ithndl)
 
       ibflag = 0

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -246,7 +246,7 @@ contains
          end do
       end if
 
-      if ((jawave == WAVE_FETCH_HURDLE .or. jawave == WAVE_FETCH_YOUNG) .and. .not. flowWithoutWaves) then
+      if ((jawave == WAVE_FETCH_HURDLE .or. jawave == WAVE_FETCH_YOUNG)) then ! .and. .not. flowWithoutWaves) then
          call tauwavefetch(time_in_seconds)
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -7036,15 +7036,12 @@ contains
       case ('hrms', 'wavesignificantheight')
          itemPtr1 => item_hrms
          dataPtr1 => hwavcom
-         jamapwav_hwav = 1
       case ('tp', 'tps', 'rtp', 'waveperiod')
          itemPtr1 => item_tp
          dataPtr1 => twavcom
-         jamapwav_twav = 1
       case ('dir', 'wavedirection')
          itemPtr1 => item_dir
          dataPtr1 => phiwav
-         jamapwav_phiwav = 1
          ! wave height needed as the weighting factor for direction interpolation
          itemPtr2 => item_hrms
          dataPtr2 => hwavcom


### PR DESCRIPTION
# What was done 
The combination of fetch based wave modelling and passing data to WAQ did not work as expected.

Changes:
- Do not automatically switch on detailed timers for all waq runs
- Also run fetch models when requested when flowwithoutwaves=1 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
UNST-9114