### PR TITLE
UNST-8996: Typo in XML fixed

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -3036,7 +3036,7 @@
         </file>
       </checks>
     </testCase>
-    <testCase name="e02_f011_c019_windxy_in_u_and_v" ref="dflowfm_default">
+    <testCase name="e02_f011_c019_wind_in_bc" ref="dflowfm_default">
       <path version="2025-08-05T11:38:13.904000">e02_dflowfm/f011_wind/c019_wind_in_bc</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>


### PR DESCRIPTION
# What was done 

The testname e02_f011_c019_windxy_in_u_and_v is changed into e02_f011_c019_wind_in_bc, now the testname is consistent with the location of the test
 
# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [x] Tests updated \
e02_f011_c019_wind_in_bc
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-8996