### PR TITLE
Tc/bugfix/devopsdsc 714 continue container pipeline when push fails

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -172,6 +172,7 @@ object Publish : BuildType({
                     sed -i 's@^image=[^ ]*@image=%destination_image_specific%@' ${'$'}file
                 done
             """.trimIndent()
+            executionMode = BuildStep.ExecutionMode.ALWAYS
         }
         script {
             name = "Replace branding delft3dfm->dhydro"
@@ -185,6 +186,7 @@ object Publish : BuildType({
                     src/scripts_lgpl/singularity/readme.txt \
                     src/scripts_lgpl/singularity/submit_singularity_h7.sh
             """.trimIndent()
+            executionMode = BuildStep.ExecutionMode.ALWAYS
         }
         exec {
             name = "Create Docker ZIP file in /opt/Testdata/DIMR/DIMR_collectors/DIMRset_lnx64_Docker/"
@@ -194,6 +196,7 @@ object Publish : BuildType({
                 --release-version %release_version%
                 --commit-id-short %commit_id_short%
             """.trimIndent()
+            executionMode = BuildStep.ExecutionMode.ALWAYS
         }
         script {
             name = "Copy Apptainer packages to share"
@@ -209,6 +212,7 @@ object Publish : BuildType({
                 # Copy the artifact to network
                 cp -vf %brand%_%release_type%-%release_version%.tar.gz /opt/Testdata/DIMR/DIMR_collectors/DIMRset_lnx64_Singularity
             """.trimIndent()
+            executionMode = BuildStep.ExecutionMode.ALWAYS
         }
     }
 })


### PR DESCRIPTION
This pull request updates the TeamCity build configuration in ci/teamcity/Delft3D/publish.kt to ensure that several build steps always run, regardless of previous step outcomes. This change increases the robustness and consistency of the publishing pipeline by setting the execution mode of key steps to ALWAYS.

This caused a problem in a recent weekly release:
https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_Publish/6119198
It should be properly fixed as part of this ticket:
https://issuetracker.deltares.nl/browse/DEVOPSDSC-715