### PR TITLE
DEVOPSDSC-428 Update syntax of release image.

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -147,7 +147,7 @@ object Publish : BuildType({
             """.trimIndent()
         }
         dockerCommand {
-            name = "Push generic and specific images"
+            name = "Push release image"
             commandType = push {
                 namesAndTags = """
                     "%destination_image_specific%"


### PR DESCRIPTION
The weekly image will have tags that include 'pre-release' and the DIMRset id, for example: 2.29.16-pre-release. This means that the current tag 'weekly' should be replaced by 'pre-release'."

Daily/latest tags are no longer published in the 'delft3d' harbor repository.