### PR TITLE
Adjust open method to force replacement of output files

### DIFF
--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_cco.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_cco.f90
@@ -68,7 +68,7 @@
       npart = 0
       rdum  = 0.0
 
-      call file_cco%open()
+      call file_cco%open(replace = .true.)
       lun    = file_cco%unit
       filtyp = file_cco%type
 

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_data.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_data.f90
@@ -83,7 +83,7 @@
 !     initialise file
 !
       num_local_vars  = num_exchanges_u_dir + num_exchanges_v_dir + num_exchanges_z_dir
-      call afile%open()
+      call afile%open(replace = .true.)
       lun    = afile%unit
       filtyp = afile%type
       filnam = afile%name

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_lga.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_lga.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine write_lga ( file_lga, num_columns  , num_rows  , num_layers , nosegl, &
                              num_exchanges_u_dir    , num_exchanges_v_dir  , num_exchanges_z_dir  , lgrid )
@@ -77,7 +77,7 @@
 !
 !     initialise file
 !
-      call file_lga%open()
+      call file_lga%open(replace = .true.)
       lun    = file_lga%unit
       filtyp = file_lga%type
 !

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_lgt.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_lgt.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine write_lgt ( file_lgt, num_columns  , num_rows  , num_layers )
 !
@@ -71,7 +71,7 @@
 !
 !     initialise file
 !
-      call file_lgt%open()
+      call file_lgt%open(replace = .true.)
       lun    = file_lgt%unit
       filtyp = file_lgt%type
 !

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_poi.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_poi.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine write_poi ( file_poi , num_exchanges   , num_exchanges_u_dir  , num_exchanges_v_dir  , num_exchanges_z_dir  , ipoint   )
 !
@@ -69,7 +69,7 @@
 !
 !     initialise file
 !
-      call file_poi%open()
+      call file_poi%open(replace = .true.)
       lun    = file_poi%unit
       filtyp = file_poi%type
       filnam = file_poi%name

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_srf.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_srf.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine write_srf ( file_srf, num_columns  , num_rows  , nosegl, surf  )
 !
@@ -64,7 +64,7 @@
 
       ! initialise file
 
-      call file_srf%open()
+      call file_srf%open(replace = .true.)
       lun    = file_srf%unit
       filtyp = file_srf%type
 
@@ -116,7 +116,7 @@
 
       ! initialise file
 
-      call file_hsrf%open()
+      call file_hsrf%open(replace = .true.)
       lun    = file_hsrf%unit
       filtyp = file_hsrf%type
 

--- a/src/utils_lgpl/waq_hyd_data/waq_file.f90
+++ b/src/utils_lgpl/waq_hyd_data/waq_file.f90
@@ -78,22 +78,40 @@ module m_waq_file
 
 contains
 
-    subroutine open_waq_file(self)
+    subroutine open_waq_file(self, replace)
         !! if successful, the file is opened and the status is set to 1
 
         class(t_file), intent(inout) :: self               ! the file to be opened
+        logical, optional            :: replace            ! is an existing (binary) file to be replaced?
 
         integer :: io_error                  ! error indicator
         character(len = 1000) :: message      ! error message
         integer :: file_unit                 ! unit number report file
+        logical :: exists, replace_
 
         if (self%status == 0) then
             if (self%type == FT_ASC) then
                 open(newunit = self%unit, file = self%name, status = 'unknown', iostat = io_error, &
                         iomsg = message)
             elseif (self%type == FT_BIN) then
-                open(newunit = self%unit, file = self%name, status = 'unknown', access = 'stream', &
-                        iostat = io_error, iomsg = message)
+                replace_ = .false.
+                if ( present(replace) ) then
+                    replace_ = replace
+                endif
+
+                if ( replace_ ) then
+                    inquire( file = self%name, exist = exists )
+                    if ( exists ) then
+                        open(newunit = self%unit, file = self%name, status = 'replace', access = 'stream', &
+                                iostat = io_error, iomsg = message)
+                    else
+                        open(newunit = self%unit, file = self%name, status = 'unknown', access = 'stream', &
+                                iostat = io_error, iomsg = message)
+                    endif
+                else
+                    open(newunit = self%unit, file = self%name, status = 'unknown', access = 'stream', &
+                            iostat = io_error, iomsg = message)
+                endif
             elseif (self%type == FT_UNF) then
                 open(newunit = self%unit, file = self%name, status = 'unknown', form = 'unformatted', &
                         iostat = io_error, iomsg = message)


### PR DESCRIPTION
Adjust the open method to the derived type t_file, so that binary files may be replaced when they will be rewritten. This has to do with a peculiarity of binary files in Fortran ("access = 'stream'").

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
