### PR TITLE
UNST-9104: Fix functionality documentation files for a few test cases

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -243,7 +243,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f004_c083_trachytopes_spatially_varying_25" ref="dflowfm_default">
-      <path version="2025-04-09T14:25:11.235000">e02_dflowfm/f004_bottomfriction/c083_trachytopes_spatially_varying_25</path>
+      <path version="2025-08-19T09:01:30.028000">e02_dflowfm/f004_bottomfriction/c083_trachytopes_spatially_varying_25</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/tt3_his.nc" type="netCDF">
@@ -262,7 +262,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f004_c084_trachytopes_spatially_varying_50" ref="dflowfm_default">
-      <path version="2025-04-09T14:25:11.235000">e02_dflowfm/f004_bottomfriction/c084_trachytopes_spatially_varying_50</path>
+      <path version="2025-08-19T09:01:41.459000">e02_dflowfm/f004_bottomfriction/c084_trachytopes_spatially_varying_50</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/tt3_his.nc" type="netCDF">
@@ -1333,7 +1333,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f005_c083_qhbnd_doubleboundary" ref="dflowfm_default">
-      <path version="2025-07-08T08:48:13.734000">e02_dflowfm/f005_boundary_conditions/c083_qhbnd_doubleboundary</path>
+      <path version="2025-08-19T09:01:48.680000">e02_dflowfm/f005_boundary_conditions/c083_qhbnd_doubleboundary</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/simplechannel_his.nc" type="netCDF">


### PR DESCRIPTION
# What was done 

Updated test cases:

- s3://dsc-testbench/cases/e02_dflowfm/f004_bottomfriction/c082_trachytopes_spatially_varying_1
    - move `.png` from `./comparison/` to `./doc/figures`
    - updated reference to png file in `./doc/chapters/case_text.tex`
    - remove directory `./comparison`
- s3://dsc-testbench/cases/e02_dflowfm/f004_bottomfriction/c083_trachytopes_spatially_varying_25
    - move `.png` from `./comparison/` to `./doc/figures`
    - remove directory `./comparison`
- s3://dsc-testbench/cases/e02_dflowfm/f004_bottomfriction/c084_trachytopes_spatially_varying_50
    - move `.png` from `./comparison/` to `./doc/figures`
    - remove directory `./comparison`
- s3://dsc-testbench/cases/e02_dflowfm/f005_boundary_conditions/c083_qhbnd_doubleboundary
    - move `.png` from `./validation/` to `./doc/figures`
    - updated reference to png file in `./doc/chapters/case_text.tex`
    - remove directory `./validation`

I have updated the timestamps in the testbench configs of all test cases except e02_f004_c082 (because it does not seem to appear in any testbench config XML)

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
