### PR TITLE
DELWAQ-989 Extent string for identification text

### DIFF
--- a/src/engines_gpl/waq/wq_processes/wq_processes_initialise.f90
+++ b/src/engines_gpl/waq/wq_processes/wq_processes_initialise.f90
@@ -184,7 +184,7 @@ contains
         character(len=80)   swinam
         character(len=80)   blmnam
         character(len=80)   line
-        character(len=80)   identification_text
+        character(len=200)  identification_text
         character(len=20)   rundat
         character(:), allocatable :: config
         logical :: parsing_error, laswi, swi_nopro
@@ -263,7 +263,7 @@ contains
 
         ! Header for lsp
         call getidentification(identification_text)
-        write(lunlsp, '(XA/)') identification_text
+        write(lunlsp, '(XA/)') trim(identification_text)
         call write_date_time(rundat)
         write (lunlsp, '(A,A/)') ' Execution start: ', rundat
 


### PR DESCRIPTION
# What was done 

<a short description with bullets> 
- Extent string for identification text to accommodate the long git hashes, and added a trim to the writing statement
 
# Evidence of the work done 
- [x]	Clear from the issue description 

# Tests 
- [x]	Not applicable 

# Documentation  
- [x]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/DELWAQ-989