### PR TITLE
DEVOPSDSC-725: Increase (4G -> 6G) shared memory for dwaves parallel fm example

### DIFF
--- a/examples/dflowfm/09_dflowfm_parallel_dwaves/run_docker.sh
+++ b/examples/dflowfm/09_dflowfm_parallel_dwaves/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 4G"
+docker_options="--shm-size 6G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.


### PR DESCRIPTION
DEVOPSDSC-725

This pull request makes a minor adjustment to the Docker run script for parallel D-Flow FM runs. The shared memory allocated to the container has been increased from 4GB to 6GB to better support parallel execution.