### PR TITLE
Extend waqmerge and companions to treat the flow velocities as well

### DIFF
--- a/src/tools_gpl/waq_tools/agrhyd/agr_hyd_init.f90
+++ b/src/tools_gpl/waq_tools/agrhyd/agr_hyd_init.f90
@@ -246,6 +246,12 @@
       else
          output_hyd%vdf_present = .false.
       endif
+      if ( input_hyd%vel_present ) then
+         output_hyd%vel_present = .true.
+         allocate(output_hyd%vel(output_hyd%num_cells))
+      else
+         output_hyd%vel_present = .false.
+      endif
 !     allocate(hyd%wasteflow(hyd%wasteload_coll%actual_size))
 
       ! cco information

--- a/src/tools_gpl/waq_tools/agrhyd/agr_hyd_step.f90
+++ b/src/tools_gpl/waq_tools/agrhyd/agr_hyd_step.f90
@@ -133,6 +133,19 @@ subroutine agr_hyd_step(input_hyd, ipnt, ipnt_q, ipnt_vdf, ipnt_tau, output_hyd)
                 rwork, output_hyd%tem)
     endif
 
+    ! flow velocities, averaged with volume
+
+    if (input_hyd%vel_present) then
+        call aggregate_extended(input_hyd%num_cells, output_hyd%num_cells, &
+                1, 1, &
+                1, 1, &
+                1, 1, &
+                1, 1, &
+                ipnt, AGGREGATION_TYPE_WEIGHTED_AVERAGE, &
+                input_hyd%vel, input_hyd%volume, &
+                rwork, output_hyd%vel)
+    endif
+
     ! tau, only do last layer, other layers 0.0
 
     !     if ( input_hyd%tau_present ) then

--- a/src/tools_gpl/waq_tools/ddcouple/ddcouple.f90
+++ b/src/tools_gpl/waq_tools/ddcouple/ddcouple.f90
@@ -1250,6 +1250,7 @@ program ddcouple
         if (hyd%tem_present) allocate(hyd%tem(hyd%num_cells), stat = ierr_alloc) ; if (ierr_alloc /= 0) goto 990
         if (hyd%tau_present) allocate(hyd%tau(hyd%num_cells), stat = ierr_alloc) ; if (ierr_alloc /= 0) goto 990
         if (hyd%vdf_present) allocate(hyd%vdf(hyd%num_cells), stat = ierr_alloc) ; if (ierr_alloc /= 0) goto 990
+        if (hyd%vel_present) allocate(hyd%vel(hyd%num_cells), stat = ierr_alloc) ; if (ierr_alloc /= 0) goto 990
 
         hyd%area = 0.0
         hyd%flow = 0.0
@@ -1258,6 +1259,7 @@ program ddcouple
         if (hyd%tem_present) hyd%tem = 0.0
         if (hyd%tau_present) hyd%tau = 0.0
         if (hyd%vdf_present) hyd%vdf = 0.0
+        if (hyd%vel_present) hyd%vel = 0.0
 
         ! time loop
 

--- a/src/tools_gpl/waq_tools/ddcouple/from_ddb2.f90
+++ b/src/tools_gpl/waq_tools/ddcouple/from_ddb2.f90
@@ -68,6 +68,7 @@
       hyd%tem_present    = .true.
       hyd%tau_present    = .true.
       hyd%vdf_present    = .true.
+      hyd%vel_present    = .true.
       hyd%wasteload_coll%current_size = 0
       hyd%wasteload_coll%maxsize = 0
 
@@ -128,6 +129,7 @@
          if ( .not. domain_hyd%tem_present ) hyd%tem_present = .false.
          if ( .not. domain_hyd%tau_present ) hyd%tau_present = .false.
          if ( .not. domain_hyd%vdf_present ) hyd%vdf_present = .false.
+         if ( .not. domain_hyd%vel_present ) hyd%vdf_present = .false.
 
          if ( n_mode ) then
             if ( parallel ) then

--- a/src/tools_gpl/waq_tools/ddcouple/merge_step.f90
+++ b/src/tools_gpl/waq_tools/ddcouple/merge_step.f90
@@ -73,6 +73,7 @@
             if ( hyd%tem_present ) hyd%tem(iseg) = domain_hyd%tem(iseg_domain)
             if ( hyd%tau_present ) hyd%tau(iseg) = domain_hyd%tau(iseg_domain)
             if ( hyd%vdf_present ) hyd%vdf(iseg) = domain_hyd%vdf(iseg_domain)
+            if ( hyd%vel_present ) hyd%vel(iseg) = domain_hyd%vel(iseg_domain)
          enddo
       enddo
 

--- a/src/tools_gpl/waq_tools/ddcouple/write_hyd.f90
+++ b/src/tools_gpl/waq_tools/ddcouple/write_hyd.f90
@@ -124,6 +124,11 @@
       else
          write(lunhyd,'(a,'' '''''',a,'''''''')') vert_diffusion_file, 'none'
       endif
+      if ( hyd%vel_present ) then
+         write(lunhyd,'(a,'' '''''',a,'''''''')') velocities_file, trim(hyd%file_vel%name)
+      else
+         write(lunhyd,'(a,'' '''''',a,'''''''')') velocities_file, 'none'
+      endif
       write(lunhyd,'(a,'' '''''',a,'''''''')') surfaces_file, trim(hyd%file_srf%name)
       write(lunhyd,'(a,'' '''''',a,'''''''')') total_grid_file, trim(hyd%file_lgt%name)
       write(lunhyd,'(a,'' '''''',a,'''''''')') discharges_file, trim(hyd%file_src%name)

--- a/src/tools_gpl/waq_tools/waqmerge/merge_step_unstruc.f90
+++ b/src/tools_gpl/waq_tools/waqmerge/merge_step_unstruc.f90
@@ -76,6 +76,7 @@
                   if ( hyd%tem_present ) hyd%tem(iseg) = domain_hyd%tem(iseg_domain)
                   if ( hyd%tau_present ) hyd%tau(iseg) = domain_hyd%tau(iseg_domain)
                   if ( hyd%vdf_present ) hyd%vdf(iseg) = domain_hyd%vdf(iseg_domain)
+                  if ( hyd%vel_present ) hyd%vel(iseg) = domain_hyd%vel(iseg_domain)
                   if ( ilay .ne. num_layers ) then
                      iq_domain = domain_hyd%num_exchanges_u_dir + iseg_domain
                      iq_glob   = hyd%num_exchanges_u_dir        + iseg

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/copy_hyd_step.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/copy_hyd_step.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine copy_hyd_step(input_hyd, output_hyd)
 
@@ -93,6 +93,14 @@
       if ( input_hyd%vdf_present ) then
          do iseg = 1, input_hyd%num_cells
             output_hyd%vdf(iseg) = input_hyd%vdf(iseg)
+         end do
+      endif
+
+      ! flow velocities
+
+      if ( input_hyd%vel_present ) then
+         do iseg = 1, input_hyd%num_cells
+            output_hyd%vel(iseg) = input_hyd%vel(iseg)
          end do
       endif
 

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/m_hyd_keys.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/m_hyd_keys.f90
@@ -58,6 +58,7 @@
       character(len=*), parameter :: salinity_file = 'salinity-file'
       character(len=*), parameter :: temperature_file = 'temperature-file'
       character(len=*), parameter :: vert_diffusion_file = 'vert-diffusion-file'
+      character(len=*), parameter :: velocities_file = 'velocities-file'
       character(len=*), parameter :: surfaces_file = 'surfaces-file'
       character(len=*), parameter :: total_grid_file = 'total-grid-file'
       character(len=*), parameter :: discharges_file = 'discharges-file'

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/merge_domains.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/merge_domains.f90
@@ -124,6 +124,7 @@
       hyd%tem_present = d_hyd%tem_present
       hyd%tau_present = d_hyd%tau_present
       hyd%vdf_present = d_hyd%vdf_present
+      hyd%vel_present = d_hyd%vel_present
       hyd%description = ' '
       hyd%hyd_ref     = d_hyd%hyd_ref
       hyd%hyd_start   = d_hyd%hyd_start
@@ -669,6 +670,7 @@
       if (hyd%tem_present) allocate(hyd%tem(hyd%num_cells))
       if (hyd%tau_present) allocate(hyd%tau(hyd%num_cells))
       if (hyd%vdf_present) allocate(hyd%vdf(hyd%num_cells))
+      if (hyd%vel_present) allocate(hyd%vel(hyd%num_cells))
 
       ! time independent items
       hyd%atr_type = ATR_FM
@@ -773,6 +775,7 @@
       hyd%tem_present = domain_hyd_coll%hyd_pnts(1)%tem_present
       hyd%tau_present = domain_hyd_coll%hyd_pnts(1)%tau_present
       hyd%vdf_present = domain_hyd_coll%hyd_pnts(1)%vdf_present
+      hyd%vel_present = domain_hyd_coll%hyd_pnts(1)%vel_present
       hyd%description = ' '
       hyd%hyd_ref     = domain_hyd_coll%hyd_pnts(1)%hyd_ref
       hyd%hyd_start   = domain_hyd_coll%hyd_pnts(1)%hyd_start
@@ -1136,6 +1139,7 @@
       if (hyd%tem_present) allocate(hyd%tem(hyd%num_cells))
       if (hyd%tau_present) allocate(hyd%tau(hyd%num_cells))
       if (hyd%vdf_present) allocate(hyd%vdf(hyd%num_cells))
+      if (hyd%vel_present) allocate(hyd%vel(hyd%num_cells))
 
       ! time independent items
       hyd%atr_type = ATR_FM

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd.f90
@@ -120,6 +120,7 @@
       hyd%file_sal=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
       hyd%file_tem=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
       hyd%file_vdf=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
+      hyd%file_vel=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
       hyd%file_srf=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
       hyd%file_hsrf=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
       hyd%file_lgt=t_file(' ',' ',0,ft_dat,FILE_STAT_UNOPENED)
@@ -360,6 +361,17 @@
             else
                hyd%file_vdf%name = ' '
                hyd%vdf_present = .false.
+            endif
+
+         elseif ( ctoken == velocities_file) then
+            ! vdf file
+            if ( gettoken(ctoken, ierr) .ne. 0 ) goto 900
+            if ( ctoken.ne. 'none' ) then
+               hyd%file_vel%name = trim(filpath)//ctoken
+               hyd%vel_present = .true.
+            else
+               hyd%file_vel%name = ' '
+               hyd%vel_present = .false.
             endif
 
          elseif ( ctoken == surfaces_file) then

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd_init.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd_init.f90
@@ -152,6 +152,7 @@
       allocate(hyd%tem(hyd%num_cells),stat=ierr_alloc) ; if ( ierr_alloc .ne. 0 ) goto 970
       allocate(hyd%tau(hyd%num_cells),stat=ierr_alloc) ; if ( ierr_alloc .ne. 0 ) goto 970
       allocate(hyd%vdf(hyd%num_cells),stat=ierr_alloc) ; if ( ierr_alloc .ne. 0 ) goto 970
+      allocate(hyd%vel(hyd%num_cells),stat=ierr_alloc) ; if ( ierr_alloc .ne. 0 ) goto 970
       allocate(hyd%attributes(hyd%num_cells),stat=ierr_alloc) ; if ( ierr_alloc .ne. 0 ) goto 970
 !     allocate(hyd%wasteflow(hyd%wasteload_coll%actual_size))
 

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd_step.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_hyd_step.f90
@@ -96,6 +96,15 @@ subroutine read_hyd_step(hyd, itime, iend)
         endif
     endif
 
+    if (hyd%vel_present) then
+        call hyd%file_vel%open()
+        read(hyd%file_vel%unit, iostat = ierr) itime, (hyd%vel(i), i = 1, hyd%num_cells)
+        if (ierr /= 0) then
+            write(*, *) 'ERROR: reading vel file: ', hyd%file_vel%unit, trim(hyd%file_vel%name)
+            call stop_with_error()
+        endif
+    endif
+
     if (hyd%vdf_present) then
         call hyd%file_vdf%open()
         read(hyd%file_vdf%unit, iostat = ierr) itime, (hyd%vdf(i), i = 1, hyd%num_cells)

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/set_hyd.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/set_hyd.f90
@@ -1,33 +1,33 @@
       subroutine set_hyd(hyd,name)
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
-   
+!
+!
+
       ! function : set the filenames of the hyd file
 
       ! global declarations
@@ -80,7 +80,7 @@
          hyd%file_geo%name = trim(name)//'_waqgeom.nc'
          hyd%file_lga%name = trim(name)//'.bnd'
          hyd%file_cco%name = trim(name)//'_waqgeom.nc'
-      end if                  
+      end if
       hyd%file_vol%name = trim(name)//'.vol'
       hyd%file_are%name = trim(name)//'.are'
       hyd%file_flo%name = trim(name)//'.flo'
@@ -89,6 +89,7 @@
       hyd%file_sal%name = trim(name)//'.sal'
       hyd%file_tem%name = trim(name)//'.tem'
       hyd%file_vdf%name = trim(name)//'.vdf'
+      hyd%file_vel%name = trim(name)//'.vel'
       if (hyd%geometry .eq. HYD_GEOM_CURVI) then
       hyd%file_srf%name = trim(name)//'.srf'
       else if (hyd%geometry .eq. HYD_GEOM_UNSTRUC) then
@@ -118,6 +119,7 @@
       hyd%file_sal%type = ft_dat
       hyd%file_tem%type = ft_dat
       hyd%file_vdf%type = ft_dat
+      hyd%file_vel%type = ft_dat
       hyd%file_srf%type = ft_dat
       hyd%file_hsrf%type = ft_dat
       hyd%file_lgt%type = ft_dat
@@ -143,6 +145,7 @@
       hyd%file_sal%status = 0
       hyd%file_tem%status = 0
       hyd%file_vdf%status = 0
+      hyd%file_vel%status = 0
       hyd%file_srf%status = 0
       hyd%file_hsrf%status = 0
       hyd%file_lgt%status = 0

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_hyd.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_hyd.f90
@@ -140,6 +140,11 @@
       else
          write(lunhyd,'(a,''     '',a)') vert_diffusion_file, 'none'
       endif
+      if ( hyd%vel_present ) then
+         call remove_path(hyd%file_vel%name,filename) ; write(lunhyd,'(a,'' '''''',a,'''''''')') velocities_file, trim(filename)
+      else
+         write(lunhyd,'(a,''     '',a)') velocities_file, 'none'
+      endif
       if (hyd%geometry .eq. HYD_GEOM_CURVI) then
          call remove_path(hyd%file_srf%name,filename) ; write(lunhyd,'(a,'' '''''',a,'''''''')') surfaces_file, trim(filename)
       else if (hyd%geometry .eq. HYD_GEOM_UNSTRUC) then

--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_hyd_step.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/write_hyd_step.f90
@@ -1,31 +1,31 @@
 !----- GPL ---------------------------------------------------------------------
-!                                                                               
-!  Copyright (C)  Stichting Deltares, 2011-2025.                                
-!                                                                               
-!  This program is free software: you can redistribute it and/or modify         
-!  it under the terms of the GNU General Public License as published by         
-!  the Free Software Foundation version 3.                                      
-!                                                                               
-!  This program is distributed in the hope that it will be useful,              
-!  but WITHOUT ANY WARRANTY; without even the implied warranty of               
-!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the                
-!  GNU General Public License for more details.                                 
-!                                                                               
-!  You should have received a copy of the GNU General Public License            
-!  along with this program.  If not, see <http://www.gnu.org/licenses/>.        
-!                                                                               
-!  contact: delft3d.support@deltares.nl                                         
-!  Stichting Deltares                                                           
-!  P.O. Box 177                                                                 
-!  2600 MH Delft, The Netherlands                                               
-!                                                                               
-!  All indications and logos of, and references to, "Delft3D" and "Deltares"    
-!  are registered trademarks of Stichting Deltares, and remain the property of  
-!  Stichting Deltares. All rights reserved.                                     
-!                                                                               
+!
+!  Copyright (C)  Stichting Deltares, 2011-2025.
+!
+!  This program is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU General Public License as published by
+!  the Free Software Foundation version 3.
+!
+!  This program is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU General Public License for more details.
+!
+!  You should have received a copy of the GNU General Public License
+!  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D" and "Deltares"
+!  are registered trademarks of Stichting Deltares, and remain the property of
+!  Stichting Deltares. All rights reserved.
+!
 !-------------------------------------------------------------------------------
-!  
-!  
+!
+!
 
       subroutine write_hyd_step(hyd, itime)
 
@@ -69,6 +69,11 @@
       if ( hyd%vdf_present ) then
          valnam(1) = 'vdf'
          call write_data ( hyd%file_vdf, itime, notim, hyd%num_cells, 0, 0, 1, 1, 0, valnam, hyd%vdf,1)
+      endif
+
+      if ( hyd%vel_present ) then
+         valnam(1) = 'velocities'
+         call write_data ( hyd%file_vel, itime, notim, hyd%num_cells, 0, 0, 1, 1, 0, valnam, hyd%vel,1)
       endif
 
       return

--- a/src/utils_lgpl/waq_hyd_data/hydrodynamics_utils.f90
+++ b/src/utils_lgpl/waq_hyd_data/hydrodynamics_utils.f90
@@ -146,6 +146,7 @@ module m_hydmod
         type(t_file) :: file_sal               ! salinity-file
         type(t_file) :: file_tem               ! temperature-file
         type(t_file) :: file_vdf               ! vert-diffusion-file
+        type(t_file) :: file_vel               ! velocities-file
         type(t_file) :: file_srf               ! surfaces-file
         type(t_file) :: file_hsrf              ! horizontal-surfaces-file
         type(t_file) :: file_lgt               ! total-grid-file
@@ -161,6 +162,7 @@ module m_hydmod
         logical :: tem_present            ! indication if temperature is availeble
         logical :: tau_present            ! indication if tau is availeble
         logical :: vdf_present            ! indication if vertical diffusion is availeble
+        logical :: vel_present            ! indication if velocities are availeble
         real :: min_vdf_upper          ! minimum-vert-diffusion-upper-layer
         real :: min_vdf_lower          ! minimum-vert-diffusion-lower-layer
         real :: min_vdf_interface      ! minimum-vert-diffusion-interface-depth
@@ -194,6 +196,7 @@ module m_hydmod
         real, pointer :: tem(:)                 ! tem
         real, pointer :: tau(:)                 ! tau
         real, pointer :: vdf(:)                 ! vdf
+        real, pointer :: vel(:)                 ! flow velocities
         integer, pointer :: lgrid(:, :)             ! active grid table
         integer, pointer :: ipoint(:, :)            ! pointer table
         real, pointer :: xdepth(:, :)            ! x coordinates depth points


### PR DESCRIPTION
Waqmerge treats several scalar parameters from the hydrodynamic model output, but it should also handle the flow velocities. Since ddcouple and agrhyd are related in functionality, I have taken the liberty to apply the same extension to them.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
