### PR TITLE
UNST-9183 Adjust default for [processes] ThetaVertical to 0.55 (instead of 0.0)

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -181,7 +181,7 @@ module unstruc_model
    character(len=255) :: md_oplfile = ' ' !< [-] open process library dll/so file
    character(len=255) :: md_blmfile = ' ' !< [-] BLOOM aglae species definition file
    character(len=255) :: md_sttfile = ' ' !< statistics definition file
-   real(kind=dp) :: md_thetav_waq = 0.0_dp !< thetav for waq
+   real(kind=dp) :: md_thetav_waq = 0.55_dp !< thetav for waq (same as default for salinity and temperature)
    real(kind=dp) :: md_dt_waqproc = 0.0_dp !< processes time step
    real(kind=dp) :: md_dt_waqbal = 0.0_dp !< mass balance output time step (old)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
@@ -1807,7 +1807,7 @@ contains
       md_subfile = ''
       md_ehofile = ''
       md_sttfile = ''
-      md_thetav_waq = 0d0
+      md_thetav_waq = 0.55d0 ! thetav for waq (same as default for salinity and temperature)
       md_dt_waqproc = 0d0
 
       return


### PR DESCRIPTION
# What was done 

Default for [processes] ThetaVertical was changed from 0.0 to 0.55 (same as default for salinity and temperature). This should increase robustness.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
