### PR TITLE
Read the name of the boundary as a whole line

### DIFF
--- a/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_bnd.f90
+++ b/src/utils_lgpl/io_hyd/packages/io_hyd/src/read_bnd.f90
@@ -86,14 +86,18 @@
       openbndsect%openbndlin_coll%openbndlin_pnts => null()
       do i_sect = 1 , no_sect
 
-         if ( gettoken( openbndsect%name, ierr) .ne. 0 ) then
+         ! The boundary name appears on the next line by its own, but may contain
+         ! spaces, so read the whole line
+         read( ilun(1), '(a)', iostat = ierr ) openbndsect%name
+         openbndsect%name = adjustl(openbndsect%name)
+         if ( ierr /= 0 ) then
             write(lunrep,*) ' error reading boundary file:',trim(file_bnd%name)
             write(lunrep,*) ' character expected with name of section'
             goto 200
          endif
          if ( gettoken( no_bnd, ierr) .ne. 0 ) then
             write(lunrep,*) ' error reading boundary file:',trim(file_bnd%name)
-            write(lunrep,*) ' expected integer with number of boundary in this section'
+            write(lunrep,*) ' expected integer with number of boundary points in this section'
             goto 200
          endif
 


### PR DESCRIPTION
Because the name of a boundary may include spaces and it appears on a line by its own, we can read the entire line and extract the name from there.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
