### PR TITLE
Fix path for validate signing.

### DIFF
--- a/ci/teamcity/Delft3D/windows/collect.kt
+++ b/ci/teamcity/Delft3D/windows/collect.kt
@@ -56,7 +56,7 @@ object WindowsCollect : BuildType({
             command = file {
                 filename = "ci/python/ci_tools/dimrset_delivery/validate_signing.py"
                 scriptArguments = """
-                    "ci\\python\\ci_tools\\dimrset_delivery\\src\\%dep.${WindowsBuild.id}.product%-binaries.json" 
+                    "ci\\python\\ci_tools\\dimrset_delivery\\%dep.${WindowsBuild.id}.product%-binaries.json" 
                     "C:\\Program Files\\Microsoft Visual Studio\\2022\\Professional\\Common7\\Tools\\VsDevCmd.bat"
                     "x64"
                 """.trimIndent()


### PR DESCRIPTION
Fix for Windows collector: https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_WindowsCollect/6194589?showLog=6194589_290_266.275&logFilter=debug&logView=flowAware