### PR TITLE
Increase shared mem for parallel Docker example cases.

### DIFF
--- a/examples/dflowfm/02_dflowfm_parallel/run_docker.sh
+++ b/examples/dflowfm/02_dflowfm_parallel/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 4G"
+docker_options="--shm-size 8G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.

--- a/examples/dflowfm/04_dflowfm_dwaq_parallel/run_docker.sh
+++ b/examples/dflowfm/04_dflowfm_dwaq_parallel/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 4G"
+docker_options="--shm-size 8G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.

--- a/examples/dflowfm/06_dflowfm_dwaq-BLOOM_parallel/run_docker.sh
+++ b/examples/dflowfm/06_dflowfm_dwaq-BLOOM_parallel/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 4G"
+docker_options="--shm-size 8G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.

--- a/examples/dflowfm/09_dflowfm_parallel_dwaves/run_docker.sh
+++ b/examples/dflowfm/09_dflowfm_parallel_dwaves/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 6G"
+docker_options="--shm-size 8G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.

--- a/examples/dflowfm/11_dflowfm_parallel_drtc_dwaves/run_docker.sh
+++ b/examples/dflowfm/11_dflowfm_parallel_drtc_dwaves/run_docker.sh
@@ -9,7 +9,7 @@
 image=containers.deltares.nl/delft3d/delft3dfm:daily
 
 # Additional options, like increased shared memory for parallel runs.
-docker_options="--shm-size 4G"
+docker_options="--shm-size 8G"
 
 # Directory containing the entire model, that will be mounted inside the container.
 # Default: the location of this script.


### PR DESCRIPTION
There are sometimes segfaults, only for the parallel cases.

e.g. https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_LinuxRunAllContainerExamples/6194606

For our regular testbenches we use 8G and we don't see these crashes there, so therefore we increased it here too.