### PR TITLE
UNST-8770: extforce-convert cases in dimr_dflowfm_parallel_{win,lnx}64.xml

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
@@ -1,6 +1,6 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
     <testCase name="e02_f012_c0322" ref="postproc">
-        <path version="2024-08-23T16:40:00">e02_dflowfm/f012_inout/c0322_alloutrealistic_f12_e02_3dom</path>
+        <path version="2025-09-05T12:19:37.625000">e02_dflowfm/f012_inout/c0322_alloutrealistic_f12_e02_3dom</path>
         <programs>
           <program ref="dimr" seq="1">
             <arguments>
@@ -88,7 +88,7 @@
     </testCase>
     
     <testCase name="e02_f012_c0325" ref="dimr">
-        <path version="2024-01-11T16:40:00">e02_dflowfm/f012_inout/c0325_alloutrealistic_f12_e02_3dom_classmap</path>
+        <path version="2025-09-05T12:19:49.689000">e02_dflowfm/f012_inout/c0325_alloutrealistic_f12_e02_3dom_classmap</path>
          <checks>
             <file name="dflowfmoutput/classmap_0000.nc" type="NETCDF">
                 <parameters>
@@ -181,7 +181,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f014_c041_westerscheldt_structures" ref="dimr">
-      <path version="2024-01-11T16:40:00">e02_dflowfm/f014_parallel/c041_westerscheldt_structures</path>
+      <path version="2025-09-05T12:19:04.049000">e02_dflowfm/f014_parallel/c041_westerscheldt_structures</path>
       <programs>
         <program ref="dflowfm" seq="1">
           <arguments>
@@ -227,7 +227,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f014_c100" ref="dimr">
-        <path version="2025-08-25T08:22:17.858000">e02_dflowfm/f014_parallel/c100_guayas_model</path>
+        <path version="2025-09-05T12:19:45.737000">e02_dflowfm/f014_parallel/c100_guayas_model</path>
         <programs>
           <program ref="dimr">
              <arguments>
@@ -259,7 +259,7 @@
         </checks>
     </testCase>
     <testCase name="e02_f014_c101_icg7" ref="dimr">
-        <path version="2025-08-25T08:25:31.807000">e02_dflowfm/f014_parallel/c101_guayas_model_icgsolver7</path>
+        <path version="2025-09-05T12:19:26.525000">e02_dflowfm/f014_parallel/c101_guayas_model_icgsolver7</path>
         <programs>
           <program ref="dimr">
              <arguments>
@@ -291,7 +291,7 @@
         </checks>
     </testCase>
     <testCase name="e02_f014_c120" ref="dimr">
-        <path version="2024-01-11T16:40:00">e02_dflowfm/f014_parallel/c120_trachytopes_discharge_dependent</path>
+        <path version="2025-09-05T12:19:18.739000">e02_dflowfm/f014_parallel/c120_trachytopes_discharge_dependent</path>
         <programs>
           <program ref="dimr">
              <arguments>
@@ -332,7 +332,7 @@
          </checks>
     </testCase>
     <testCase name="e02_f014_c150" ref="dimr">
-        <path version="2024-08-26T16:55:00">e02_dflowfm/f014_parallel/c150_longculvert_parallel</path>
+        <path version="2025-09-05T12:19:33.056000">e02_dflowfm/f014_parallel/c150_longculvert_parallel</path>
         <programs>
           <program ref="dimr">
              <arguments>


### PR DESCRIPTION
# What was done 

Ran extforce convert on the following (7) cases, and uploaded the result to MinIO. On my laptop, they still pass the testbench on linux.
- e02_f012_c0322
- e02_f012_c0325
- e02_f014_c041_westerscheldt_structures
- e02_f014_c100
- e02_f014_c101_icg7
- e02_f014_c120
- e02_f014_c150
 
The remaining (5) cases in the issue do not require conversion/updating the case data. These cases do not have an old external forcings file.

# Evidence of the work done 

- [x]	Added diffs of the updated test case files.

# Tests 
- [x] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
