### PR TITLE
UNST-9226: fix issue of long loop in ecConverterUpdateWeightFactors

### DIFF
--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -529,6 +529,9 @@ contains
                      if (cx + rd >= x0 .and. cx - rd <= x1 .and. cy + rd >= y0 .and. cy - rd <= y1) then ! check if source point within the rectangle of interest
                         call make_queryvector_kdtree(treeinst, cx, cy, jsferic)
                         nresult = kdtree2_r_count(treeinst%tree, treeinst%qv, r2)
+                        if (nresult == 0) then
+                           cycle
+                        end if
                         call realloc_results_kdtree(treeinst, nresult)
                         call kdtree2_n_nearest(treeinst%tree, treeinst%qv, nresult, treeinst%results)
                         ! loop over find results with pinpok


### PR DESCRIPTION
# What was done 
- skip loop of updating weight factors for meteo locations that are not located within model area
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9226