### PR TITLE
Revert "Only take Lib, Share, and Bin folders. don't include the test dir."

### DIFF
--- a/ci/teamcity/Delft3D/linux/collect.kt
+++ b/ci/teamcity/Delft3D/linux/collect.kt
@@ -97,11 +97,7 @@ object LinuxCollect : BuildType({
             }
 
             artifacts {
-                artifactRules = """
-                    oss_artifacts_lnx64_*.tar.gz!lnx64/bin/** => lnx64/bin
-                    oss_artifacts_lnx64_*.tar.gz!lnx64/lib/** => lnx64/lib
-                    ?:oss_artifacts_lnx64_*.tar.gz!lnx64/share/** => lnx64/share
-                """.trimIndent()
+                artifactRules = "oss_artifacts_lnx64_*.tar.gz!lnx64/** => lnx64"
             }
         }
     }


### PR DESCRIPTION
Revert for now, to find a better solution without breaking the Linux unit tests.