### PR TITLE
UNST-8833: clean up unnecessary debug line

### DIFF
--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90
@@ -3996,7 +3996,6 @@ contains
          do idim = 1, ndim
             ierror = nf90_inquire_dimension(fileReaderPtr%fileHandle, idim, len=fileReaderPtr%dim_length(idim))
             ierror = nf90_inquire_dimension(fileReaderPtr%fileHandle, idim, name=dim_name)
-            write(*,*) trim(dim_name)
             ! Find dimension matching columns and rows
             select case (str_tolower(trim(dim_name)))
             case ('x', 'longitude', 'lon', 'projected_x', 'xc', 'grid_longitude', 'projection_x_coordinate')


### PR DESCRIPTION
# What was done 

Remove unnecessary debug line from ec_provider.f90; the debug line prints dimension names to the screen. It was useful during development, but this is no longer necessary.
 

# Evidence of the work done 
See the following log files channelled from the screen:
[screen_org.log](https://github.com/user-attachments/files/22363803/screen_org.log)
[screen.log](https://github.com/user-attachments/files/22363832/screen.log)
With the fix, screen.log, the dimension names are no longer printed.

# Tests 
- [ ] Tests updated 
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-8833