### PR TITLE
Fixed bug where mpiCommVar was set to a random pointer if the setting…

### DIFF
--- a/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
@@ -332,7 +332,10 @@ void Dimr::createDistributeMPISubGroupCommunicator(dimr_component* component, bo
         throw Exception(true, Exception::ERR_MPI, "createDistributeMPISubGroupCommunicator: undefined component.");
     }
     bool multipleProcessesCheck = isMaster || component->numProcesses > 1;
-    if (use_mpi && component->mpiCommVar != NULL && multipleProcessesCheck) {
+    if (use_mpi && multipleProcessesCheck) {
+        if (component->mpiCommVar == NULL) {
+            throw Exception(true, Exception::ERR_MPI, "createDistributeMPISubGroupCommunicator: communicator handle undefined for component \"%s\".", component->name);
+        }
         ierr = MPI_Group_incl(mpiGroupWorld, component->numProcesses, component->processes, &mpiGroupComp);
         if (ierr != MPI_SUCCESS) {
             throw Exception(true, Exception::ERR_MPI, "createDistributeMPISubGroupCommunicator: cannot create a subgroup of %d processes for component \"%s\". Code: %d.", component->numProcesses, component->name, ierr);
@@ -351,7 +354,6 @@ void Dimr::createDistributeMPISubGroupCommunicator(dimr_component* component, bo
             *fComm = MPI_Comm_c2f(component->mpiComm);
         }
     }
-
 }
 
 
@@ -1580,7 +1582,7 @@ void Dimr::scanComponent(XmlTree* xmlComponent, dimr_component* newComp) {
         newComp->mpiCommVar = commElement->charData;
     }
     else {
-      newComp->mpiCommVar = nullptr;
+        newComp->mpiCommVar = nullptr;
     }
 
     // Element inputFile (optional?)


### PR DESCRIPTION
… was missing in the xml file.

# What was done 

Fixed bug where mpiCommVar was set to a random pointer if the setting was not present in the configuration file.
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9240