### PR TITLE
solve flaky test since recent code change

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -12709,8 +12709,8 @@ contains
          !       make sure to store vertical orientation of variable.
          ! TODO: handle _FillValue correctly, and make sure that the mesh writing
          !       stays consistent with the fill/dmiss value that we use here.
-      else
-         call realloc(bl, 0)
+      elseif (allocated(bl)) then
+         deallocate(bl)
       end if
    end subroutine read_mesh2d_face_z
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_drypoints_from_netgeom.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_drypoints_from_netgeom.f90
@@ -168,7 +168,7 @@ contains
                   ierror = 0
                end if
 
-               call remove_masked_netcells(update_bl=.true.)
+               call remove_masked_netcells()
 
             end if
          else

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_remove_masked_netcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_remove_masked_netcells.f90
@@ -46,10 +46,8 @@ module m_remove_masked_netcells
       !> note: we do not want to alter the netnodes and netlinks and will therefore not change kn and nod%lin
       !> during the removal process, the netcells are renumbered, so that the remaining cells are numbered 1..numpnew
       !> this renumbering should also be applied to all quantities defined on netcells, such as bl, ba, xz, yz
-      !> the bl array may not yet be loaded and therefore an optional argument is provided to specify whether bl should be updated
-      module subroutine remove_masked_netcells(update_bl)
+      module subroutine remove_masked_netcells()
          implicit none
-         logical, optional, intent(in) :: update_bl !< flag to specify whether bl should be updated
       end subroutine remove_masked_netcells
 
    end interface

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/remove_masked_netcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/remove_masked_netcells.f90
@@ -42,17 +42,14 @@ submodule(m_remove_masked_netcells) m_remove_masked_netcells_
    !> note: we do not want to alter the netnodes and netlinks and will therefore not change kn and nod%lin
    !> during the removal process, the netcells are renumbered, so that the remaining cells are numbered 1..numpnew
    !> this renumbering should also be applied to all quantities defined on netcells, such as bl, ba, xz, yz
-   !> the bl array may not yet be loaded and therefore an optional argument is provided to specify whether bl should be updated
-   module subroutine remove_masked_netcells(update_bl)
+   module subroutine remove_masked_netcells()
       use network_data
       use m_flowgeom, only: xz, yz, ba, bl
       use m_alloc
       use m_partitioninfo, only: idomain, iglobal_s
       
-      logical, optional, intent(in) :: update_bl !< flag to specify whether bl should be updated
-      
       integer, dimension(:), allocatable :: numnew ! permutation array
-      logical :: update_bl_ ! flag equal to update_bl if present, otherwise false
+      logical :: update_bl ! flag indicating whether bl should be updated
 
       integer :: i, ic, icL, icR, icnew, isL, isR, L, num, N, numpnew
 
@@ -60,10 +57,10 @@ submodule(m_remove_masked_netcells) m_remove_masked_netcells_
       integer :: jaiglobal_s
 
       num = 0
-      if (present(update_bl) .and. allocated(bl)) then
-         update_bl_ = update_bl
+      if (allocated(bl)) then
+         update_bl = .true.
       else
-         update_bl_ = .false.
+         update_bl = .false.
       end if
 
 !     check if cellmask array is allocated
@@ -192,7 +189,7 @@ submodule(m_remove_masked_netcells) m_remove_masked_netcells_
             xzw(icnew) = xzw(ic)
             yzw(icnew) = yzw(ic)
             ba(icnew) = ba(ic)
-            if (update_bl_) then
+            if (update_bl) then
                bl(icnew) = bl(ic)
             end if
          end if


### PR DESCRIPTION
remove the optional argument for remove_masked_netcells. Make sure that bl is not allocated when not yet read.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
