### PR TITLE
Prevent false error for structure fileVersion = 1.00

### DIFF
--- a/src/utils_gpl/flow1d/packages/flow1d_io/src/Readstructures.f90
+++ b/src/utils_gpl/flow1d/packages/flow1d_io/src/Readstructures.f90
@@ -163,7 +163,7 @@ contains
       major = 1
       minor = 0
       call get_version_number(md_ptr, major=major, minor=minor, success=success1)
-      if (.not. success1) then
+      if (.not. success1 .OR. major == 1) then
          msgbuf = 'Early return, file '//trim(structurefile)//' is a 2D3D structure file (version 1.0).'
          call msg_flush()
          ! TODO: UNST-8867: re-enable the warning below after support for old structure files is dropped/differences have been explained.


### PR DESCRIPTION
# What was done 

As documented in UNST-9148, the structures.ini `fileVersion = 1.00` is the correct way of enforcing the old general structure calculation. This PR removes a false error message  when using such input.
It's only the error message, the runtime behavior was already correct (because `LEVEL_ERROR` was already made non-blocking in commits from a long time ago (see `unstruc_model::loadModel()`: `threshold_abort = LEVEL_FATAL`).
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
Closes UNST-2799.