### PR TITLE
Prevent false error for structure fileVersion = 1.00 (#224)

### DIFF
--- a/src/utils_gpl/flow1d/packages/flow1d_io/src/Readstructures.f90
+++ b/src/utils_gpl/flow1d/packages/flow1d_io/src/Readstructures.f90
@@ -163,7 +163,7 @@ contains
       major = 1
       minor = 0
       call get_version_number(md_ptr, major=major, minor=minor, success=success1)
-      if (.not. success1) then
+      if (.not. success1 .OR. major == 1) then
          msgbuf = 'Early return, file '//trim(structurefile)//' is a 2D3D structure file (version 1.0).'
          call msg_flush()
          ! TODO: UNST-8867: re-enable the warning below after support for old structure files is dropped/differences have been explained.


### PR DESCRIPTION
Same as  #224 but now applied to all/release/2026.01 (cherry picked from commit 4232eeb03e71eef31265e30e5af0ce8ff17f0e6e)

# What was done 

See #224
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
Solves UNST-2799