### PR TITLE
Allow Publish (containers) status to be viewed through the status widget

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -17,6 +17,7 @@ object Publish : BuildType({
     description = "Currently only used for publishing the container."
     buildNumberPattern = "%build.vcs.number%"
     maxRunningBuilds = 1
+    allowExternalStatus = true
 
     artifactRules = """
         #teamcity:symbolicLinks=as-is


### PR DESCRIPTION
The purpose is to inform the user if the latest weekly has been successfully published.