### PR TITLE
UNST-7049: Fix ugrid export of data on edges and support flag values & meanings

### DIFF
--- a/src/tools_lgpl/matlab/quickplot/progsrc/private/qp_export.m
+++ b/src/tools_lgpl/matlab/quickplot/progsrc/private/qp_export.m
@@ -1433,15 +1433,7 @@ try
                         Val = [prefix 'FaceVal'];
                         dimVal = dim_nFaces;
                 end
-                var_Val = netcdf.defVar(ncid,Val,'double',dimVal);
-                netcdf.putAtt(ncid,var_Val,'long_name',DATA.Name);
-                if isfield(DATA,'Units') && ~isempty(DATA.Units)
-                    netcdf.putAtt(ncid,var_Val,'units',DATA.Units);
-                end
-                if isfield(DATA,'Classes') && isfield(DATA,'ClassVal')
-                    netcdf.putAtt(ncid,var_Val,'flag_meanings',strjoin(DATA.Classes));
-                    netcdf.putAtt(ncid,var_Val,'flag_values',DATA.ClassVal);
-                end
+                var_Val = add_Val_field(ncid, Val, dimVal, DATA);
             end
             %
             globalId = netcdf.getConstant('GLOBAL');
@@ -1491,11 +1483,7 @@ try
                 end
                 %
                 Val = [prefix 'Val'];
-                var_Val = netcdf.defVar(ncid,Val,'double',dim_nPoints);
-                netcdf.putAtt(ncid,var_Val,'long_name',DATA.Name);
-                if isfield(DATA,'Units') && ~isempty(DATA.Units)
-                    netcdf.putAtt(ncid,var_Val,'units',DATA.Units);
-                end
+                var_Val = add_Val_field(ncid, Val, dim_nPoints, DATA);
                 %
                 %globalId = netcdf.getConstant('GLOBAL');
                 %netcdf.putAtt(ncid,globalId,'Conventions','CF?');
@@ -1520,4 +1508,15 @@ catch Exception1
         % ignore or append
     end
     rethrow(Exception1)
+end
+
+function varid = add_Val_field(ncid, Val, dimVal, DATA)
+varid = netcdf.defVar(ncid,Val,'double',dimVal);
+netcdf.putAtt(ncid, varid, 'long_name', DATA.Name);
+if isfield(DATA, 'Units') && ~isempty(DATA.Units)
+    netcdf.putAtt(ncid, varid, 'units', DATA.Units);
+end
+if isfield(DATA, 'Classes') && isfield(DATA, 'ClassVal')
+    netcdf.putAtt(ncid, varid, 'flag_meanings', strjoin(DATA.Classes));
+    netcdf.putAtt(ncid, varid, 'flag_values', DATA.ClassVal);
 end


### PR DESCRIPTION
# What was done 

- Improved export of data on edges to netCDF file (by merge of old none/feature/UNST-7049_QUICKPLOT_netCDF_export branch or commit 2faab34f5b77e04508232e6b94b4a333a43f226c)
- Add support for exporting flag values and meanings
- Test case added

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
"netCDF - D-Flow FM - map - ugrid edge without face"
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-7049
