### PR TITLE
Fm/bugfix/unst 2799 structure type 1.00 fixes

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flgsfm.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flgsfm.f90
@@ -193,7 +193,7 @@ contains
          ausav(1, n) = 0.0_dp
       end if
 
-      if (gatedoorheight > 0.0_dp) then ! now add water overflowing top of gate
+      if (gatedoorheight > 0.0_dp .and. gatedoorheight < huge(1.0_dp) .and. gateloweredgelevel < huge(1.0_dp)) then ! now add water overflowing top of gate
          zs = gateloweredgelevel + gatedoorheight
          zbi(2) = zs
          if (husb > zs) then ! husb = upwind waterlevel instead of height

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
@@ -249,7 +249,7 @@ contains
       use m_readstructures, only: readpump
       use unstruc_model, only: md_structurefile_dir
       use unstruc_files, only: resolvePath
-      use string_module, only: str_lower, strcmpi
+      use string_module, only: str_tolower, strcmpi
       use m_longculverts, only: nlongculverts
       use m_partitioninfo, only: jampi
       use m_qnerror, only: qnerror
@@ -924,8 +924,7 @@ contains
                   write (msgbuf, '(a,a,a)') 'Optional field ''GateOpeningHorizontalDirection'' not available for gate ''', trim(strid), '''. Use default value.'
                   call msg_flush()
                end if
-               call str_lower(rec)
-               select case (trim(rec))
+               select case (str_tolower(trim(rec)))
                case ('from_left', 'fromleft')
                   istrtmp = IOPENDIR_FROMLEFT
                case ('from_right', 'fromright')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
@@ -416,7 +416,7 @@ contains
          call prop_get(str_ptr, '', 'branchid', branchid, success)
          if (.not. success) call prop_get(str_ptr, '', 'numCoordinates', branchid, success)
          if (success) then
-            if (trim(strtype) /= 'pump' .and. trim(strtype) /= 'dambreak') then
+            if (.not. strcmpi(strtype, 'pump') .and. .not. strcmpi(strtype, 'dambreak')) then
                cycle
             end if
          end if
@@ -460,7 +460,7 @@ contains
 
          end if
 
-         select case (strtype)
+         select case (str_tolower(strtype))
          case ('gateloweredgelevel') ! Old-style controllable gateloweredgelevel
             !else if (qid == 'gateloweredgelevel' ) then
 
@@ -562,7 +562,7 @@ contains
 
             ncgen = ncgen + numgen
             ! For later usage split up the set of all generalstructures into weirs, gates or true general structures (in user input)
-            select case (strtype)
+            select case (str_tolower(strtype))
             case ('weir')
                nweirgen = nweirgen + 1
             case ('gate')
@@ -709,7 +709,7 @@ contains
             call resolvePath(plifile, md_structurefile_dir)
 
             ! Start with some general structure default params, and thereafter, make changes depending on actual strtype
-            if (strtype /= 'generalstructure') then
+            if (.not. strcmpi(strtype, 'generalstructure')) then
                hulp(idx_upstream1width, n) = huge(1.0_dp) ! Upstream1Width
                hulp(idx_upstream1level, n) = -huge(1.0_dp) ! Upstream1Level
                hulp(idx_upstream2width, n) = huge(1.0_dp) ! Upstream2Width
@@ -738,7 +738,7 @@ contains
                hulp(idx_gateopeningwidth, n) = 0.0_dp ! GateOpeningWidth
             end if
 
-            select case (strtype)
+            select case (str_tolower(strtype))
       !! WEIR !!
             case ('weir')
                rec = ' '


### PR DESCRIPTION
# What was done 
Fixed a few non-blocking issues while working on release testcases with frontend team.
- Make old (1.00) structure reader case insensitive for structure types.
- Prevent Debug crashes because of overflows when weir/gate have default values that are huge.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
Originates from UNST-2799.