### PR TITLE
Fm/bugfix/devopsdsc 000 limit swan threads in example

### DIFF
--- a/examples/dflowfm/09_dflowfm_parallel_dwaves/run_example.sh
+++ b/examples/dflowfm/09_dflowfm_parallel_dwaves/run_example.sh
@@ -31,6 +31,5 @@ else
         run_dflowfm.sh --partition:ndomains=${nPart}:icgsolver=6 ${mduFile}
     popd
     echo "Starting computation..."
-    export OMP_NUM_THREADS=1
     run_dimr.sh -c ${nProc} -m ${dimrFile}
 fi


### PR DESCRIPTION
Changed FM+D-Waves /example case to 4 (instead of 8) partitions due to segfaults.