### PR TITLE
UNST-9051: Rename 'fxxx' functionality groups

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -1516,7 +1516,7 @@
     </testCase>
 
     <testCase name="e02_f045_c010_nudgerate" ref="dflowfm_default">
-      <path version="2025-30-09T09:41:00">e02_dflowfm/f045_nudging/c010_nudgerate</path>
+      <path version="2025-09-30T09:41:00">e02_dflowfm/f045_nudging/c010_nudgerate</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/test_map.nc" type="netCDF">


### PR DESCRIPTION
# What was done 

Copied the following directories in MinIO (dsc-testbench bucket)
- cases/e02_dflowfm/fxxx_nudging/ -> cases/e02_dflowfm/f045_nudging/
- cases/e02_dflowfm/fxxx_spherical_coordinates -> cases/e02_dflowfm/f046_spherical_coordinates/
- cases/e02_dflowfm/fxxx_surfbeat -> cases/e02_dflowfm/f047_surfbeat/
- references/win64/e02_dflowfm/fxxx_nudging/ -> references/win64/e02_dflowfm/f045_nudging/

Notes:
The only test case in these functionality groups that runs in our pre-merge pipelines is 'e02_fxxx_c010_nudgerate'. I have updated
the testbench config file to point to the new location. Both Linux and Windows use the same references in references/win64.

# Evidence of the work done 

- [x]	Functionality groups: https://s3-console.deltares.nl/browser/dsc-testbench/cases%2Fe02_dflowfm%2F
- [x]  References: https://s3-console.deltares.nl/browser/dsc-testbench/references%2Fwin64%2Fe02_dflowfm%2Ff045_nudging%2F

# Tests 
- [x] Update testcase e02_fxxx_nudgerate

# Documentation  
- [x]	Not applicable 

# Issue link
