### PR TITLE
Add requirement for VS2022 in WindowsCollect build type

### DIFF
--- a/ci/teamcity/Delft3D/windows/collect.kt
+++ b/ci/teamcity/Delft3D/windows/collect.kt
@@ -104,5 +104,6 @@ object WindowsCollect : BuildType({
     requirements {
         exists("env.PYTHON_PATH")
         contains("teamcity.agent.jvm.os.name", "Windows")
+        exists("VS2022")
     }
 })


### PR DESCRIPTION
This pull request introduces a minor update to the TeamCity build configuration for Windows collection. The change ensures that the build only runs on agents where Visual Studio 2022 is available.