### PR TITLE
don't write timing info for invalid handle numbers

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_modelinit.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_modelinit.F90
@@ -183,10 +183,6 @@ contains
 
       call timstop(handle_extra(1)) ! End basic steps
 
-      if (jagui == 1) then
-         call timini() ! this seems to work, initimer and timini pretty near to each other
-      end if
-
 ! JRE
       if (jawave == WAVE_SURFBEAT) then
          call timstrt('Surfbeat input init', handle_extra(2)) ! Wave input


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- don't reset timers (causing crashes) for interacter runs. timini() should only be called once, inside reset_timers().
calling timini() a second time orphans all existing handles, causing crashes when writing timing info.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
