### PR TITLE
Prevent simultaneous file generation and build of f90twi_gtest

### DIFF
--- a/src/third_party_open/f90tw/f90tw-main/f90tw/CMakeLists.txt
+++ b/src/third_party_open/f90tw/f90tw-main/f90tw/CMakeLists.txt
@@ -182,16 +182,21 @@ set(FPP_SWITCH ${FPP_SWITCH} CACHE STRING "preprocessor switch")
 
 set(file2fpp "${CMAKE_CURRENT_SOURCE_DIR}/assertions_gtest.fpp")
 set(file2 "${CMAKE_CURRENT_BINARY_DIR}/assertions_gtest.f90")
-add_library(f90twi_gtest OBJECT "${file2}")
-
-set_property(TARGET f90twi_gtest
-        APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${file2}"
-)
 
 F90TWFPP("${file2fpp}" "${file2}"
     EXE ${FPP_EXE}
     OPTIONS ${FPP_OPTIONS}
     SWITCH ${FPP_SWITCH}
+)
+
+# Create a custom target to ensure the file generation completes before library compilation
+add_custom_target(generate_assertions_gtest_f90 DEPENDS "${file2}")
+
+add_library(f90twi_gtest OBJECT "${file2}")
+add_dependencies(f90twi_gtest generate_assertions_gtest_f90)
+
+set_property(TARGET f90twi_gtest
+        APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${file2}"
 )
 
 add_library(f90tw_gtest STATIC gtest_assertions.cpp)


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
