### PR TITLE
All/feature/esiwace-10 mpi barrier replaced by ibarrier

### DIFF
--- a/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
@@ -871,7 +871,15 @@ void Dimr::runParallelUpdate(dimr_control_block* cb, double tStep) {
             // Sync all partitions to execute the same component
             // This ensures that all flow calculations are finished before a wave calculation is started
             if (use_mpi) {
-                int ierr = MPI_Barrier(MPI_COMM_WORLD);
+              MPI_Request req = MPI_REQUEST_NULL;
+              // Dont use default MPI_Barrier spinlock, instead allow other processes to use cpu by periodically polling for barrier completion
+              int ierr = MPI_Ibarrier(MPI_COMM_WORLD, &req);
+              while (true) {
+                int complete;
+                MPI_Test(&req,&complete,MPI_STATUS_IGNORE);
+                if (complete) { break; } 
+                sleep(0.5);
+              }
             }
 
             if (i == cb->masterSubBlockId) {


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- DIMR: MPI_barrier replaced by Ibarrier
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
[ESIWACE3-10](https://issuetracker.deltares.nl/browse/ESIWACE3-10)