### PR TITLE
Test effect of fp-speculation = safe

### DIFF
--- a/src/cmake/compiler_options/intel.cmake
+++ b/src/cmake/compiler_options/intel.cmake
@@ -48,8 +48,9 @@ if (WIN32)
     set(debug_information_flag                /Z7)
 
     # Set debug flags:
+    string(APPEND CMAKE_Fortran_FLAGS_RELEASE " ${floating_point_speculation_safe_flag}")
     string(APPEND CMAKE_Fortran_FLAGS_DEBUG " ${check_stack_flag} ${check_bounds_flag} ${traceback_flag} ${debug_information_flag} ${check_pointers_flag} ${floating_point_exception_flag}")
-    string(APPEND CMAKE_Fortran_FLAGS_RELWITHDEBINFO " ${debug_information_flag}")
+    string(APPEND CMAKE_Fortran_FLAGS_RELWITHDEBINFO " ${debug_information_flag} ${floating_point_speculation_safe_flag}")
 
     # To prevent Visual Studio compilation failures when trying to write the manifest file
     # to a blocked .exe
@@ -96,12 +97,14 @@ if (UNIX)
     set(avx2_flag                                "-arch CORE-AVX2")
     set(generate_reentrancy_threaded_flag        "-reentrancy threaded")
     set(floating_point_exception_flag            "-fpe0")
+    set(floating_point_speculation_safe_flag     "-fp-speculation=safe")
     set(flush_to_zero_flag                       "-ftz")
     set(traceback_flag                           "-traceback")
     set(heap_arrays_100_flag                     "-heap-arrays 100")
     set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
     # Set debug flags:
+    string(APPEND CMAKE_Fortran_FLAGS_RELEASE " ${floating_point_speculation_safe_flag}")
     string(APPEND CMAKE_Fortran_FLAGS_DEBUG " ${check_stack_flag} ${check_bounds_flag} ${traceback_flag} ${check_pointers_flag} ${floating_point_exception_flag}")
 endif(UNIX)
 


### PR DESCRIPTION
This flag is already used in Debug mode (implied by other flag set).

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
