### PR TITLE
Replace zsf.dll with dsle.dll in signed binaries check.

### DIFF
--- a/ci/python/ci_tools/dimrset_delivery/all-testbench-binaries.json
+++ b/ci/python/ci_tools/dimrset_delivery/all-testbench-binaries.json
@@ -545,7 +545,7 @@
             "issuedTo": "Stichting Deltares"
         },
         {
-            "file": "lib\\zsf.dll",
+            "file": "lib\\dsle.dll",
             "issuedTo": "Stichting Deltares"
         },
         {

--- a/ci/python/ci_tools/dimrset_delivery/fm-suite-binaries.json
+++ b/ci/python/ci_tools/dimrset_delivery/fm-suite-binaries.json
@@ -5,7 +5,7 @@
             "issuedTo": "Stichting Deltares"
         },
         {
-            "file": "lib\\zsf.dll",
+            "file": "lib\\dsle.dll",
             "issuedTo": "Stichting Deltares"
         },
         {


### PR DESCRIPTION
After https://github.com/Deltares/Delft3D/pull/301 the check on signed binaries fails. This pull request updates the list.

Until this is merged, our all/* branches will fail.