### PR TITLE
Removed e100_f10_c05_wave2_lib and e02_f203_c05_Waal_trachytopes_2D_s…

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves_parallel.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves_parallel.xml
@@ -109,6 +109,8 @@
         </file>
       </checks>
     </testCase>
+
+<!-- flaky in Windows container
     <testCase name="e100_f10_c05_wave2_lib" ref="dimr">
       <path version="2025-07-01T13:58:52.012000">e100_dflowfm-dwaves/f10_parallel/c05_wave2_lib</path>
       <programs>
@@ -127,6 +129,7 @@
         </file>
       </checks>
     </testCase>
+-->
 
     <!--
     Testcaes "e100_f10_c06_wave4_lib" is disabled because it produces wrong results on Linux in a Docker container. See UNST-9023

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
@@ -494,6 +494,7 @@
             </file>
         </checks>
     </testCase>
+<!-- flaky in Windows container
     <testCase name="e02_f203_c05_Waal_trachytopes_2D_single" ref="dimr">
        <path version="2025-09-08T09:45:49.723000">e02_dflowfm/f203_3D_trachytopes/c05_Waal_trachytopes_2D_single</path>
        <programs>
@@ -525,6 +526,7 @@
             </file>
         </checks>
     </testCase>
+-->
     <!-- The testcase below is copied "as is" from "dimr_dflowfm_all_but_validation_cases.xml" .
          Here it is executed again, but now with "mpiexec -c 1" prepended.
          Motivation: Slurm related scripts always prepend mpiexec


### PR DESCRIPTION
These two cases randomly fail in Windows containers and are blocking merge-requests due to unknown reasons.