### PR TITLE
All/poc/unst 9341 add pre cice profiling to simple wave fm coupling

### DIFF
--- a/examples/dflowfm/08_dflowfm_sequential_dwaves/dflowfm/f34.mdu
+++ b/examples/dflowfm/08_dflowfm_sequential_dwaves/dflowfm/f34.mdu
@@ -94,7 +94,7 @@ DtMax                               = 30.0000000                         # Max t
 DtInit                              = 1.                                 # Initial timestep in seconds
 AutoTimestep                        = 1                                  # Use CFL timestep limit or not (1/0)
 TStart                              = 0.0000000e+00                      # Start time w.r.t. RefDate (in TUnit)
-TStop                               = 1.5000000e+03                      # Stop  time w.r.t. RefDate (in TUnit)
+TStop                               = 120                                # Stop  time w.r.t. RefDate (in TUnit)
 
 [restart]
 RestartFile                         =                                    # Restart file, only map, hence: *_map.nc

--- a/examples/dflowfm/08_dflowfm_sequential_dwaves/precice_config.xml
+++ b/examples/dflowfm/08_dflowfm_sequential_dwaves/precice_config.xml
@@ -39,7 +39,7 @@
 
   <coupling-scheme:serial-explicit>
     <time-window-size value="3600" method="fixed" />
-    <max-time value="90000" />
+    <max-time value="7200" />
     <participants first="wave" second="fm" />
     <exchange data="fm-data" mesh="wave-mesh" from="fm" to="wave" />
     <exchange data="wave-data" mesh="fm-mesh" from="wave" to="fm" />

--- a/examples/dflowfm/08_dflowfm_sequential_dwaves/run_precice.sh
+++ b/examples/dflowfm/08_dflowfm_sequential_dwaves/run_precice.sh
@@ -4,17 +4,41 @@ RUN_DATE=$(date "+%Y%m%d_%H%M%S")
 #REPO_ROOT=$(cd ../../..; pwd)
 #PATH=${REPO_ROOT}/install_all/bin/:$PATH
 
+pid_of() { ps aux | grep "$1" | grep -v grep | head -1 | tr -s ' ' | cut -f 2 -d ' '; }
+
+if [ "$1" == "-k" ]
+then
+    while [ "$(pid_of dflowfm)" != "" ]
+    do
+        kill -9 $(pid_of dflowfm)
+    done
+    while [ "$(pid_of wave)" != "" ]
+    do
+        kill -9 $(pid_of wave)
+    done
+    shift
+fi
+
+if [ "$1" == "-c" ]
+then
+    rm -rf precice-run
+    rm -rf dwaves/precice-profiling
+    rm -rf dflowfm/precice-profiling
+    shift
+fi
 
 cd dflowfm
 dflowfm f34.mdu > ../dflowfm_${RUN_DATE}_out.log 2>&1 &
+ps aux | grep dflowfm | head -1
 cd ..
-echo "[PROCESS] $(ps -a | grep dflowfm | head -1)"
+echo "[PROCESS] $(pid_of dflowfm)"
 cd dwaves
 wave f34.mdw 1 > ../wave_${RUN_DATE}_out.log 2>&1 &
+ps aux | grep wave | head -1
 cd ..
-echo "[PROCESS] $(ps -a | grep wave | head -1)"
+echo "[PROCESS] $(pid_of wave)"
 
-while [ "$(ps -a | grep wave | head -1)" != "" -a "$(ps -a | grep dflowfm | head -1)" != "" ]
+while [ "$(pid_of wave)" != "" -o "$(pid_of dflowfm)" != "" ]
 do
     echo -n "."
     sleep 1

--- a/src/engines_gpl/wave/packages/kernel/src/run_swan.f90
+++ b/src/engines_gpl/wave/packages/kernel/src/run_swan.f90
@@ -39,6 +39,7 @@ subroutine run_swan (casl)
     use swan_input
     use wave_mpi, only: numranks, wave_mpi_bcast, wave_mpi_barrier, engine_comm_world, MPI_SUCCESS, SWAN_GO
     use system_utils, only: SCRIPT_EXTENSION
+    use precice, only: precicef_start_profiling_section, precicef_stop_last_profiling_section
     !
     implicit none
 !
@@ -62,7 +63,7 @@ subroutine run_swan (casl)
     !
     ! SWAN execution
     !
-    call precicef_start_profiling_section("run_swan")
+    call precicef_start_profiling_section("run_swan", 8)
     if (swan_run%exemode == SWAN_MODE_LIB) then
        !
        ! As built-in function.

--- a/src/engines_gpl/wave/packages/manager/src/wave_main.F90
+++ b/src/engines_gpl/wave/packages/manager/src/wave_main.F90
@@ -470,6 +470,7 @@ end function wave_init
 !
 ! ====================================================================================
 function wave_main_step(stepsize) result(retval)
+   use precice, only: precicef_start_profiling_section, precicef_stop_last_profiling_section
    implicit none
 !
 ! return value
@@ -490,7 +491,9 @@ function wave_main_step(stepsize) result(retval)
       !
       ! master node does all the work ...
       !
+      call precicef_start_profiling_section("wave_master_step", 16)
       retval = wave_master_step(stepsize)
+      call precicef_stop_last_profiling_section()
    else
       !
       ! nothing to do for slave nodes except for waiting and calling swan as needed
@@ -507,6 +510,7 @@ end function wave_main_step
 !
 ! ====================================================================================
 function wave_master_step(stepsize) result(retval)
+   use precice, only: precicef_start_profiling_section, precicef_stop_last_profiling_section
    implicit none
 !
 ! return value
@@ -532,7 +536,7 @@ function wave_master_step(stepsize) result(retval)
 !
    retval = 0
    !
-   !call precicef_start_profiling_section("wave_main")
+   !call precicef_start_profiling_section("wave_master_step", 16)
 
    if (wavedata%mode /= stand_alone) then
       !


### PR DESCRIPTION
# What was done 

Added an example to add a profiling section. Nesting does (for some reason not work)

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9341
