### PR TITLE
Add id="run_testsbench" to Windows and Linux testbench build step.

### DIFF
--- a/ci/teamcity/Delft3D/linux/test.kt
+++ b/ci/teamcity/Delft3D/linux/test.kt
@@ -84,10 +84,10 @@ object LinuxTest : BuildType({
     }
 
     steps {
-        id = "run_tests"
         mergeTargetBranch {}
         python {
             name = "Run TestBench.py"
+            id = "run_testbench"
             workingDir = "test/deltares_testbench/"
             pythonVersion = customPython {
                 executable = "python3"

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -74,10 +74,10 @@ object WindowsTest : BuildType({
     }
 
     steps {
-        id = "run_tests"
         mergeTargetBranch {}
         python {
             name = "Run TestBench.py"
+            id = "run_testbench"
             workingDir = "test/deltares_testbench/"
             command = file {
                 filename = "TestBench.py"


### PR DESCRIPTION
With this merge, the build step that actually runs the tests can be referenced from the API.

```
<build>
<buildType>
<steps>
<step id="RUNNER_1" name="Merge target into branch" type="simpleRunner"/>
<step id="run_testbench" name="Run TestBench.py" type="python-runner"/>
<step id="RUNNER_2" name="Remove container" type="DockerCommand"/>
<step id="RUNNER_3" name="Prune" type="DockerCommand"/>
<step id="RUNNER_4" name="Copy cases" type="simpleRunner"/>
</steps>
</buildType>
</build>
```