### PR TITLE
All/poc/unst 9343 precice with fm parallel and wave

### DIFF
--- a/examples/dflowfm/08_dflowfm_sequential_dwaves/precice_config.xml
+++ b/examples/dflowfm/08_dflowfm_sequential_dwaves/precice_config.xml
@@ -24,7 +24,6 @@
 
   <participant name="fm">
     <provide-mesh name="fm_flow_nodes" />
-    <receive-mesh name="wave_nodes" from="wave" />
     <write-data name="water_levels" mesh="fm_flow_nodes" />
     <provide-mesh name="fm_com_mesh" />
     <write-data name="com_data_fm_to_wave" mesh="fm_com_mesh" />

--- a/examples/dflowfm/09_dflowfm_parallel_dwaves/precice_config.xml
+++ b/examples/dflowfm/09_dflowfm_parallel_dwaves/precice_config.xml
@@ -2,37 +2,44 @@
 <precice-configuration>
   <log>
     <sink type="file" output="precice_output.txt" filter= "(%Severity% > debug) or (%Severity% >= debug and %Module% contains ParticipantImpl) or (%Severity% >= debug and %Module% contains partition) or (%Severity% >= debug and %Module% contains PointToPointCommunication)" enabled="true" />
+    <sink type="stream" output="stdout" filter= "(%Severity% > debug) or (%Severity% >= debug and %Module% contains ParticipantImpl) or (%Severity% >= debug and %Module% contains partition) or (%Severity% >= debug and %Module% contains PointToPointCommunication)" enabled="true" />
   </log>
 
   <profiling mode="fundamental" flush-every="50" directory="." synchronize="false"/>
 
-  <data:scalar name="fm-data" />
-  <data:scalar name="wave-data" />
+  <data:scalar name="com_data_fm_to_wave" />
+  <data:scalar name="com_data_wave_to_fm" />
+  <data:scalar name="water_levels" />
 
-  <mesh name="fm-mesh" dimensions="2">
-    <use-data name="fm-data" />
-    <use-data name="wave-data" />
+  <mesh name="fm_com_mesh" dimensions="2">
+    <use-data name="com_data_fm_to_wave" />
+    <use-data name="com_data_wave_to_fm" />
   </mesh>
 
-  <mesh name="wave-mesh" dimensions="2">
-    <use-data name="wave-data" />
-    <use-data name="fm-data" />
+  <mesh name="fm_flow_nodes" dimensions="2">
+    <use-data name="water_levels" />
+  </mesh>
+
+  <mesh name="wave_nodes" dimensions="2">
+    <use-data name="water_levels" />
   </mesh>
 
   <participant name="fm">
-    <provide-mesh name="fm-mesh" />
-    <receive-mesh name="wave-mesh" from="wave"/>
-    <write-data name="fm-data" mesh="fm-mesh"/>
-    <read-data name="wave-data" mesh="fm-mesh"/>
-    <mapping:nearest-neighbor direction="write" from="fm-mesh" to="wave-mesh" constraint="conservative"/>
+    <provide-mesh name="fm_com_mesh" />
+    <write-data name="com_data_fm_to_wave" mesh="fm_com_mesh" />
+    <read-data name="com_data_wave_to_fm" mesh="fm_com_mesh" />
+    <provide-mesh name="fm_flow_nodes" />
+    <write-data name="water_levels" mesh="fm_flow_nodes" />
   </participant>
 
   <participant name="wave">
-    <provide-mesh name="wave-mesh" />
-    <receive-mesh name="fm-mesh" from="fm"/>
-    <write-data name="wave-data" mesh="wave-mesh"/>
-    <read-data name="fm-data" mesh="wave-mesh"/>
-    <mapping:nearest-neighbor direction="write" from="wave-mesh" to="fm-mesh" constraint="conservative"/>
+    <receive-mesh name="fm_com_mesh" from="fm" />
+    <read-data name="com_data_fm_to_wave" mesh="fm_com_mesh" />
+    <write-data name="com_data_wave_to_fm" mesh="fm_com_mesh" />
+    <provide-mesh name="wave_nodes" />
+    <receive-mesh name="fm_flow_nodes" from="fm" />
+    <read-data name="water_levels" mesh="wave_nodes" />
+    <mapping:linear-cell-interpolation direction="read" from="fm_flow_nodes" to="wave_nodes" constraint="consistent" />
   </participant>
 
   <m2n:sockets acceptor="fm" connector="wave" exchange-directory=".." />
@@ -41,7 +48,8 @@
     <time-window-size value="3600" method="fixed" />
     <max-time value="90000" />
     <participants first="wave" second="fm" />
-    <exchange data="fm-data" mesh="wave-mesh" from="fm" to="wave" />
-    <exchange data="wave-data" mesh="fm-mesh" from="wave" to="fm" />
+    <exchange data="com_data_fm_to_wave" mesh="fm_com_mesh" from="fm" to="wave" />
+    <exchange data="com_data_wave_to_fm" mesh="fm_com_mesh" from="wave" to="fm" />
+    <exchange data="water_levels" mesh="fm_flow_nodes" from="fm" to="wave" />
   </coupling-scheme:serial-explicit>
 </precice-configuration>

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/unstruc_api.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/unstruc_api.F90
@@ -77,17 +77,16 @@ contains
 
 #if defined(HAS_PRECICE_FM_WAVE_COUPLING)
    subroutine initialize_wave_coupling()
-      use precice, only: precicef_create,precicef_create_with_communicator, precicef_get_mesh_dimensions, precicef_set_vertices, &
-                  precicef_initialize, precicef_write_data, precicef_advance, precicef_get_max_time_step_size
-      use m_partitioninfo, only: jampi, numranks, my_rank,  DFM_COMM_DFMWORLD
+      use precice, only: precicef_create, precicef_create_with_communicator, precicef_get_mesh_dimensions, precicef_set_vertices, &
+                         precicef_initialize, precicef_write_data, precicef_advance, precicef_get_max_time_step_size
+      use m_partitioninfo, only: jampi, numranks, my_rank, DFM_COMM_DFMWORLD
       use m_flowtimes, only: dt_user
       use, intrinsic :: iso_c_binding, only: c_int, c_char, c_double
-      implicit none (type, external)
+      implicit none(type, external)
 
       character(kind=c_char, len=*), parameter :: precice_component_name = "fm"
       character(kind=c_char, len=*), parameter :: precice_config_name = "../precice_config.xml"
 
-      ! First create preCICE to be able to query max time step
       if (jampi == 0) then
          print *, '[FM] Initializing preCICE for serial execution'
          call precicef_create(precice_component_name, precice_config_name, my_rank, numranks, len(precice_component_name), len(precice_config_name))
@@ -195,8 +194,8 @@ contains
    end function is_wave_coupling_ongoing
 
    subroutine advance_time_window(dt_user)
-      use precice, only: precicef_advance      
-      use, intrinsic :: iso_c_binding, only:  c_double
+      use precice, only: precicef_advance
+      use, intrinsic :: iso_c_binding, only: c_double
       real(kind=c_double), intent(in) :: dt_user
       if (is_wave_coupling_ongoing()) then
          call precicef_advance(real(dt_user, kind=c_double))
@@ -508,7 +507,7 @@ contains
       use m_drawthis
       use m_draw_nu
       use m_flowtimes, only: dt_user
-      implicit none (type, external)
+      implicit none(type, external)
 
       integer, intent(out) :: jastop !< Communicate back to caller: whether to stop computations (1) or not (0)
       integer, intent(out) :: iresult !< Error status, DFM_NOERR==0 if successful.


### PR DESCRIPTION
# What was done 
- For running example 09 with FM running in MPI, precicef create with commincator was added
- Checking for coupling ongoing when doing advance in FM



# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9343