### PR TITLE
Fix error message of DLL transport formula

### DIFF
--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/erosed.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/erosed.f90
@@ -889,9 +889,11 @@ subroutine erosed(nmmax     ,kmax      ,icx       ,icy       ,lundia    , &
        endif
        taks0 = max(aksfac*rc, 0.01_fp*h1)
        !
-       if (wave .and. tp(nm)>0.0_fp) then
-          delr  = 0.025_fp
-          taks0 = max(0.5_fp*delr, taks0)
+       if (wave) then
+          if (tp(nm)>0.0_fp) then
+             delr  = 0.025_fp
+             taks0 = max(0.5_fp*delr, taks0)
+          endif
        endif
        !
        ! Limit maximum aks to 20% of water depth

--- a/src/plugins_lgpl/plugin_delftflow_traform/src/partheniades_krone.f90
+++ b/src/plugins_lgpl/plugin_delftflow_traform/src/partheniades_krone.f90
@@ -98,7 +98,6 @@ real(hp)           :: ws
 real(hp)           :: zumod
 character(len=256) :: runid
 character(len=256) :: filenm
-character(len=256) :: error_message
 
 !
 ! Local variables

--- a/src/plugins_lgpl/plugin_delftflow_traform/src/vrijn84_riv_77.f90
+++ b/src/plugins_lgpl/plugin_delftflow_traform/src/vrijn84_riv_77.f90
@@ -83,7 +83,6 @@ real(hp)           :: ws
 real(hp)           :: zumod
 character(len=256) :: runid
 character(len=256) :: filenm
-character(len=256) :: error_message
 !
 ! Local variables: parameters
 !


### PR DESCRIPTION

# What was done 

- only use wave period `tp` if `wave==.true. `
- fix error messages in dll transport formula.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Test run locally. Applies only to Partheniades-Krone DLL and Van Rijn 84 (RIV 77)

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
closes Delft3D-37889 