### PR TITLE
Try removing DAP from netcdf on linux, see if curl dependency disappears

### DIFF
--- a/ci/dockerfiles/linux/third-party-libs.Dockerfile
+++ b/ci/dockerfiles/linux/third-party-libs.Dockerfile
@@ -358,6 +358,7 @@ cmake .. \
     -DCMAKE_INSTALL_PREFIX=/usr/local \
     -DCMAKE_INSTALL_LIBDIR=lib \
     -DENABLE_PARALLEL4=ON \
+    -DENABLE_DAP=OFF \
     -DZLIB_INCLUDE_DIR=/usr/local/include \
     -DZLIB_LIBRARY=/usr/local/lib/libz.so \
     -DSzip_INCLUDE_DIRS=/usr/local/include \


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
