### PR TITLE
Only recognize pull requests from collaborators.

### DIFF
--- a/ci/teamcity/Delft3D/template/mergeRequest.kt
+++ b/ci/teamcity/Delft3D/template/mergeRequest.kt
@@ -14,6 +14,7 @@ object TemplateMergeRequest : Template({
                 authType = token {
                     token = "%github_deltares-service-account_access_token%"
                 }
+                filterAuthorRole = PullRequests.GitHubRoleFilter.MEMBER
                 filterSourceBranch = "+:*"
                 ignoreDrafts = true
             }


### PR DESCRIPTION
This prevents 'anybody' to trigger a pipeline from a fork.