### PR TITLE
Don't read 'value' for initialvertical-quantities

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -655,7 +655,7 @@ contains
          end if
 
          ! read value
-         if ((filetype == inside_polygon) .and. .not. strcmpi(quantity, 'initialvertical', 15)) then
+         if (filetype == inside_polygon .and. method == METHOD_CONSTANT) then
             call prop_get(node_ptr, '', 'value', transformcoef(1), retVal)
             if (.not. retVal) then
                write (msgbuf, '(5a)') 'Wrong block in file ''', trim(inifilename), ''': [', trim(groupname), &


### PR DESCRIPTION
# What was done 
- Don't read 'value' for initialvertical-quantities
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [x]	Documentation updated: revision 80670
- [ ]	Not applicable 

# Issue link
