### PR TITLE
Filter testbench results for releases on e00_ prefix format.

### DIFF
--- a/ci/python/ci_tools/dimrset_delivery/step_3_teamcity_test_results.py
+++ b/ci/python/ci_tools/dimrset_delivery/step_3_teamcity_test_results.py
@@ -1,4 +1,5 @@
 import os
+import re
 import sys
 from datetime import datetime, timezone
 from enum import Enum
@@ -173,9 +174,10 @@ class TeamCityTestResultWriter(StepExecutorInterface):
 
         # 2. Loop over the builds and retrieve the test results and write to file
         result_list = []
+        regex = re.compile(r"^e[0-9]+_")
         for dep_build_id in dependency_chain:
             test_result = self.__services.teamcity.get_build_test_results_from_teamcity(dep_build_id)
-            if test_result:
+            if test_result and regex.match(test_result.name):
                 result_list.append(test_result)
 
         # 3. Write test results to file


### PR DESCRIPTION
Sometimes the (Delft3D/Windows/Build) unit tests results were part of the tally for the DIMR release mail.

---

This pull request introduces a small change to the test results filtering logic in the `step_3_teamcity_test_results.py` script. The update ensures that only test results with names matching a specific pattern are included in the result list.

Filtering logic improvement:

* Added a regular expression filter (`^e[0-9]+_`) to only include test results whose names start with an 'e', followed by one or more digits, and an underscore. This helps focus the results on a specific subset of tests. [[1]](diffhunk://#diff-86f621db71d5d77bdde2b267091469edc09817a8bb3c9398aed1fc0fff95a797R2) [[2]](diffhunk://#diff-86f621db71d5d77bdde2b267091469edc09817a8bb3c9398aed1fc0fff95a797R177-R180)