### PR TITLE
Add harbor registry version check scripts and tests; update publish s…

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -122,10 +122,10 @@ object Publish : BuildType({
             }
         }
         dockerCommand {
-            name = "Tag specific image"
+            name = "Tag images"
             commandType = other {
                 subCommand = "tag"
-                commandArgs = "%source_image% %destination_image_specific%"
+                commandArgs = "%source_image% %destination_image_specific% && docker tag %source_image% %destination_image_generic%"
             }
         }
         dockerCommand {


### PR DESCRIPTION
Fixup commit in order to fix:https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_Publish_virtual_Batch_385034366_1/6516198?buildTab=log&linesState=227.367.401&logView=flowAware

It now also tags the image as development.

The robot credentials now also have the right to list and read artifacts. That was required for the python script. This is tested locally.