### PR TITLE
Split Docker image tagging commands to separate specific and generic …

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -122,10 +122,17 @@ object Publish : BuildType({
             }
         }
         dockerCommand {
-            name = "Tag images"
+            name = "Tag image specific"
             commandType = other {
                 subCommand = "tag"
-                commandArgs = "%source_image% %destination_image_specific% && docker tag %source_image% %destination_image_generic%"
+                commandArgs = "%source_image% %destination_image_specific%"
+            }
+        }
+        dockerCommand {
+            name = "Tag image generic"
+            commandType = other {
+                subCommand = "tag"
+                commandArgs = "%source_image% %destination_image_generic%"
             }
         }
         dockerCommand {


### PR DESCRIPTION
This should fix:
https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_Publish_virtual_Batch_385034366_1/6519118?buildTab=log&linesState=162.183.194.197.216&logView=flowAware

Split tagging of docker images