### PR TITLE
Specify Python version 3.11 for the harbor version checker script

### DIFF
--- a/ci/teamcity/Delft3D/publish.kt
+++ b/ci/teamcity/Delft3D/publish.kt
@@ -163,6 +163,7 @@ object Publish : BuildType({
         }
         python {
             name = "Set latest development tag parameter"
+            pythonVersion = customPython { executable = "python3.11" }
             command = module {
                 module = "ci_tools.harbor.harbor_version_checker"
                 scriptArguments = """


### PR DESCRIPTION
The `pythonVersion` for the "Set latest development tag parameter" build step is now set to use `python3.11` via the `customPython` executable.