### PR TITLE
correct remove masked netcells algorithm to prevent out of bounds cra…

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/partition_from_commandline.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/partition_from_commandline.f90
@@ -103,6 +103,7 @@ contains
          call generate_partitioning_from_pol()
       end if
 
+      netstat = NETSTAT_OK !> reset netstat before writing partitions
       if (ndomains > 1) then
          call partition_write_domains(trim(fnam), md_icgsolver, jacells, japolygon, md_partugrid)
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/remove_masked_netcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/remove_masked_netcells.f90
@@ -194,7 +194,7 @@ contains
             yzw(icnew) = yzw(ic)
             ba(icnew) = ba(ic)
 
-            if (update_blcell_and_non_empty) then
+            if (update_blcell_and_non_empty .and. ic <= nump) then
                blcell(icnew) = blcell(ic)
             end if
          end if


### PR DESCRIPTION
…sh. Always set netstat to clean before writing partitioned netfile to prevent re-finding of global cells

# What was done 

<a short description with bullets> 

- correct out of bounds crash in remove masked netcells
- always set netstat to clean before writing partitioned netfile to preserve partitioning

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ x]	Not applicable 

# Issue link

Branch name is wrong:
https://issuetracker.deltares.nl/browse/UNST-9431