### PR TITLE
Lincontin test

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/sethu.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/sethu.f90
@@ -87,7 +87,6 @@ contains
       integer, parameter :: Rajaratnam = 23
       integer, parameter :: Tabellenboek = 24
       integer, parameter :: Villemonte = 25
-      integer, parameter :: LINEAR_CONTINUITY = 1
       integer, parameter :: DRY_FLAG = 1
       integer, parameter :: CENTRAL_FROM_BED_TIL_SECOND_OR_FIRST_ABOVE_LOCAL_BOB = 1
       integer, parameter :: ALL_CENTRAL = 2
@@ -224,12 +223,6 @@ contains
       do link = 1, lnx ! why is it here?- it is not hu
          huvli(link) = 1.0_dp / max(epshs, acl(link) * hs(ln(1, link)) + (1.0_dp - acl(link)) * hs(ln(2, link)))
       end do
-
-      if (lincontin == LINEAR_CONTINUITY) then ! is this only for 2D? why not at the beginning?
-         do link = 1, lnx
-            hu(link) = -0.5_dp * (bob(1, link) + bob(2, link))
-         end do
-      end if
 
       if (nbnd1d2d > 0) then ! 1d2d boundary check for closed boundaries
          call sethu_1d2d()


### PR DESCRIPTION
UNST-9467: setting hu equal to minus the average bob ... would be positive for coastal/delta areas where bobs are negative, but negative for river areas where bobs are positive. Not clear why setting hu to this value would make sense. Trying removing these statements.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge peirs 
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
