### PR TITLE
UNST-9465: operand '+' results in crash in Wadden Sea model

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update_boundaries.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update_boundaries.f90
@@ -74,6 +74,7 @@ contains
       call setsigmabnds() ! our side of preparation for 3D ec module
 
       if (nzbnd > nqhbnd) then
+         zbndz(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_waterlevelbnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888


### PR DESCRIPTION
# What was done 

Every time the waterlevel boundary is updated, the reference array `zbndz` is now set to zero.
 

# Evidence of the work done 

- [x]	Clear from the issue description 

# Tests 

- [x]	Not applicable 

# Documentation  

- [x]	Not applicable 

# Issue link
