### PR TITLE
UNST-9465: operand '+' crash 2

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update_boundaries.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update_boundaries.f90
@@ -154,6 +154,7 @@ contains
       end if
 
       if (item_velocitybnd /= ec_undef_int) then
+         zbndu(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_velocitybnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888
@@ -161,6 +162,7 @@ contains
       end if
 
       if (item_dischargebnd /= ec_undef_int) then
+         zbndq(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_dischargebnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888
@@ -209,6 +211,7 @@ contains
       end if
 
       if (nbndt > 0) then
+         zbndt(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_tangentialvelocitybnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888
@@ -216,6 +219,7 @@ contains
       end if
 
       if (nbnduxy > 0) then
+         zbnduxy(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_uxuyadvectionvelocitybnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888
@@ -223,6 +227,7 @@ contains
       end if
 
       if (nbndn > 0) then
+         zbndn(:) = 0.0_dp
          success = ec_gettimespacevalue(ecInstancePtr, item_normalvelocitybnd, irefdate, tzone, tunit, time)
          if (.not. success) then
             goto 888


### PR DESCRIPTION
# What was done 

In `fm_external_update_boundaries.f90` the variables `zbndq`, `zbndu`, `zbndt`, `zbndn`, and `zbnduxy` are also set to zero for each timestep.
 

# Evidence of the work done 
 
- [x]	Clear from the issue description 

# Tests 

- [x]	Not applicable 

# Documentation  

- [x]	Not applicable 

# Issue link
