### PR TITLE
feat: add dvc garbage colleciton pipeline

### DIFF
--- a/ci/teamcity/Delft3D/dvc/GarbageCollection.kt
+++ b/ci/teamcity/Delft3D/dvc/GarbageCollection.kt
@@ -1,0 +1,78 @@
+package Delft3D.dvc
+
+import jetbrains.buildServer.configs.kotlin.*
+import jetbrains.buildServer.configs.kotlin.buildFeatures.*
+import jetbrains.buildServer.configs.kotlin.buildSteps.*
+import jetbrains.buildServer.configs.kotlin.failureConditions.*
+import jetbrains.buildServer.configs.kotlin.triggers.*
+import Delft3D.template.*
+import Delft3D.step.*
+
+object DvcGarbageCollection : BuildType({
+
+    description = "Routinely run garbage collection for DVC files"
+
+    templates(
+        TemplatePublishStatus,
+        TemplateMonitorPerformance
+    )
+
+    name = "Garbage Collection"
+
+    allowExternalStatus = false
+
+    params {
+        param("s3_delft3d_testbench_accesskey", DslContext.getParameter("s3_delft3d_testbench_accesskey"))
+        password("s3_delft3d_testbench_secret", DslContext.getParameter("s3_delft3d_testbench_secret"))
+
+    }
+
+    vcs {
+	root(DslContext.settingsRoot)
+	cleanCheckout = true
+    }
+
+    steps {
+	script {
+            name = "Run garbage collector"
+	    id = "DvcGcExecute"
+	    scriptContent = """
+                set -e 
+                git fetch --unshallow 
+        		uv venv --python=3.12 .venv
+                uv pip sync test/deltares_testbench/pip/lnx-dev-requirements.txt
+                source .venv/bin/activate
+                export AWS_ACCESS_KEY_ID='%s3_delft3d_testbench_accesskey%'
+                export AWS_SECRET_ACCESS_KEY='%s3_delft3d_testbench_secret%'
+                dvc config -l
+                dvc fetch -aT -R 
+                dvc gc -aT --cloud -f -v -r storage
+                """
+        }
+    }
+
+
+    triggers {
+        schedule {
+            schedulingPolicy = weekly {
+                dayOfWeek = ScheduleTrigger.DAY.Sunday
+                hour = 20
+                minute = 0
+            }
+            branchFilter = "+:<default>"
+            triggerBuild = always()
+            withPendingChangesOnly = false
+            param("trigger.type", "schedule")
+        }
+    }
+
+
+    failureConditions {
+        executionTimeoutMin = 180
+        errorMessage = true
+    }
+
+    requirements {
+        equals("teamcity.agent.jvm.os.name", "Linux")
+    }
+})

--- a/ci/teamcity/Delft3D/settings.kts
+++ b/ci/teamcity/Delft3D/settings.kts
@@ -9,6 +9,7 @@ import Delft3D.windows.*
 import Delft3D.template.*
 
 import Delft3D.ciUtilities.*
+import Delft3D.dvc.*
 import Delft3D.verschilanalyse.*
 
 version = "2026.1"
@@ -155,9 +156,10 @@ project {
         buildType(LifecycleScanMain)
         buildType(LifecycleScanTestBench)
         buildType(LifecycleScanCiTools)
+	buildType(DvcGarbageCollection)
 
         buildTypesOrder = arrayListOf(
-            TestPythonCiTools, TestBenchValidation, TestFortranStyler, CopyExamples, SigCi, RunBashBatonUtilities, DvcDiffComment, LifecycleScanMain, LifecycleScanTestBench, LifecycleScanCiTools
+            TestPythonCiTools, TestBenchValidation, TestFortranStyler, CopyExamples, SigCi, RunBashBatonUtilities
         )
     }
 


### PR DESCRIPTION
# What was done 

- Add a pipeline job to routinely remove unreferenced file from the DVC store
- Files that are referneced in commits in any branch or tag are kept
- it is not possible to keep files for up to 30 days expect to run the job once per 30 days. There is an option to keep all files older than 30 days ironically, but given that it will only be cleaned if it is no longer referenced in a commit, I thought this was okay. 
 

# Issue link
