### PR TITLE
Fix Windows Debug build of fm-suite

### DIFF
--- a/src/tools_gpl/csumo_precice/test/CMakeLists.txt
+++ b/src/tools_gpl/csumo_precice/test/CMakeLists.txt
@@ -6,6 +6,10 @@ add_executable(test_csumo_precice_lib ${source_files})
 target_link_libraries(test_csumo_precice_lib PRIVATE compiler_warnings_settings csumo_precice_lib gtest)
 if(WIN32)
     # Copy runtime DLLs to test directory for test discovery
+    set(Boost_USE_STATIC_LIBS OFF)
+    find_package(LibXml2 REQUIRED PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../libxml2/libxml2-v2.15.1/lib/cmake/libxml2")
+    find_package(Boost REQUIRED COMPONENTS log log_setup program_options thread PATHS "${CMAKE_CURRENT_SOURCE_DIR}/../boost/boost_1_90_0/lib/cmake")
+    target_link_libraries(test_csumo_precice_lib PRIVATE Boost::log Boost::log_setup Boost::program_options Boost::thread LibXml2::LibXml2)
     add_custom_command(TARGET test_csumo_precice_lib POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy -t $<TARGET_FILE_DIR:test_csumo_precice_lib> $<TARGET_RUNTIME_DLLS:test_csumo_precice_lib>
         COMMAND_EXPAND_LISTS


### PR DESCRIPTION
# What was done 

Explicitly add boost and libxml2 to test_csumo_precice_lib target with target_link_libraries, so the dlls are copied to the TARGET_FILE_DIR of the test executable. This way, the test_csume_precise_lib target builds and runs without missing DLLs

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
