### PR TITLE
UNST-9724 Warn if values enclosed in pound signs are parsed

### DIFF
--- a/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
+++ b/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
@@ -1222,7 +1222,6 @@ contains
    ! --------------------------------------------------------------------
    !
    integer function preprocINI(infilename, error, outfilename) result(outfilenumber)
-      use MessageHandling
       !
       ! Parameters
       !
@@ -1715,6 +1714,8 @@ contains
    !!    Use the delimiters "#". Example:
    !!    StringIn = # AFileName # Comments are allowed behind the second "#"
    subroutine prop_get_alloc_string(tree, chapterin, keyin, value, success)
+      use MessageHandling, only: mess, LEVEL_WARN
+
       type(tree_data), pointer, intent(in) :: tree !< The property tree
       character(*), intent(in) :: chapterin !< Name of the chapter (case-insensitive) or "*" to get any key
       character(*), intent(in) :: keyin !< Name of the key (case-insensitive)
@@ -1788,6 +1789,8 @@ contains
                   k = index(localvalue, '#')
                   if (k > 0) then
                      localvalue = localvalue(1:k - 1)
+                     call mess(LEVEL_WARN, "Encountered value '#" // localvalue // "#'. Parsing values enclosed with # characters is " &
+                        //"deprecated functionality and will be removed in the future. Remove the # characters.")
                   end if
                   localvalue = adjustl(localvalue)
                end if

--- a/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
+++ b/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
@@ -1789,8 +1789,8 @@ contains
                   k = index(localvalue, '#')
                   if (k > 0) then
                      localvalue = localvalue(1:k - 1)
-                     call mess(LEVEL_WARN, "Encountered value '#" // localvalue // "#'. Parsing values enclosed with # characters is " &
-                        //"deprecated functionality and will be removed in the future. Remove the # characters.")
+                     call mess(LEVEL_WARN, "Encountered value '#" // localvalue // "#'. Parsing values enclosed in '#' is " &
+                        //"deprecated and will be removed in a future release. Please remove the '#' characters to ensure compatibility.")
                   end if
                   localvalue = adjustl(localvalue)
                end if


### PR DESCRIPTION
# What was done 

The ini-file-reading-logic supports `#values between pound signs#` which is something we want to remove in the future. This PR adds a deprecation warning when such a value is encountered.
 
# Evidence of the work done 
<img width="768" height="325" alt="image" src="https://github.com/user-attachments/assets/823a16e9-c743-44e9-96ef-ab0493a1a4d1" />

I would have liked to include the filename in the message but I don't have access to it at the place where the warning is written.

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link https://issuetracker.deltares.nl/browse/UNST-9724
