### PR TITLE
All/task/unst 9131 remove double circumcenter computation

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_dry_points_and_areas.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_dry_points_and_areas.f90
@@ -41,6 +41,7 @@ contains
       use m_delete_drypoints_from_netgeom, only: delete_drypoints_from_netgeom
       use unstruc_model, only: md_dryptsfile, md_encfile
       use gridoperations, only: update_cell_circumcenters
+      use m_circumcenter_method, only: ALL_NETLINKS_LOOP, circumcenter_method
       use unstruc_caching
       use network_data, only: nump, nump1d2d, lne, lnn, xzw, yzw, netcell
       use m_flowgeom, only: xz, yz, ba
@@ -58,9 +59,9 @@ contains
          call delete_drypoints_from_netgeom(md_dryptsfile, 0, 0, update_blcell)
          call delete_drypoints_from_netgeom(md_encfile, 0, -1, update_blcell)
 
-         ! for issue UNST-3381, compute circumcenter after deleting dry areas
-         ! TODO: UNST-3436 must be done as a better solution
-         if (len_trim(md_dryptsfile) > 0 .or. len_trim(md_encfile) > 0) then
+         ! Note: code below should stay as long as the old circumcenter method is still available (INTERNAL_NETLINKS_EDGE).
+         ! For the new methods, it is no longer needed (implemented in UNST-8546).
+         if (circumcenter_method /= ALL_NETLINKS_LOOP .and. (len_trim(md_dryptsfile) > 0 .or. len_trim(md_encfile) > 0)) then
             call update_cell_circumcenters()
          end if
 


### PR DESCRIPTION
# What was done 
The call to `update_cell_circumcenters()` no longer needs to be done a second time for dry points/areas if the new circumcenter method has been set.

Note: this branch was deliberately branched off from "all/task/UNST-8857-update-circumcenter-defaults", but can be merged to main directly after that one is first in main AND no new tests fail.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
Solves UNST-9131.