### PR TITLE
Add Submit option to reuse existing verschilanalyse output

### DIFF
--- a/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
@@ -44,6 +44,15 @@ object StartVerschilanalyse : BuildType({
         param("model_filter", "")
         param("json_configs_path", "config")
         checkbox(
+            "run_models",
+            "true",
+            display = ParameterDisplay.NORMAL,
+            label = "Run models on H7",
+            description = "Run models on Slurm before running Verschillentool. Disable to reuse existing output at current_prefix.",
+            checked = "true",
+            unchecked = "false",
+        )
+        checkbox(
             "send_email",
             "true",
             display = ParameterDisplay.NORMAL,
@@ -124,6 +133,7 @@ object StartVerschilanalyse : BuildType({
                 export BUILD_ID='%teamcity.build.id%'
                 export BRANCH_NAME='%teamcity.build.branch%'
                 export SEND_EMAIL='%send_email%'
+                export RUN_MODELS='%run_models%'
 
                 # Create the builds dir if it does not exist
                 builds_dir="/p/devops-dsc/verschilanalyse/builds"
@@ -152,6 +162,7 @@ object StartVerschilanalyse : BuildType({
                     --models-path='%models_path%' \
                     --model-filter='%model_filter%' \
                     --json-configs-path='%json_configs_path%' \
+                    --run-models='%run_models%' \
                     --va-home="${'$'}{va_home}"
                 popd
             """.trimIndent()

--- a/ci/teamcity/Delft3D/verschilanalyse/bundle/jobs/download_current_output.sh
+++ b/ci/teamcity/Delft3D/verschilanalyse/bundle/jobs/download_current_output.sh
@@ -1,0 +1,48 @@
+#! /bin/bash
+#SBATCH --job-name=va-download-current-output
+#SBATCH --time=04:00:00
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --partition=16vcpu_spot
+#SBATCH --account=verschilanalyse
+#SBATCH --qos=verschilanalyse
+
+set -eo pipefail
+
+if ! util.check_vars_are_set BUCKET CURRENT_PREFIX VAHOME MODELS_PATH; then
+    >&2 echo "Abort"
+    exit 1
+fi
+
+export CURRENT_OUTPUT_ARCHIVE_DIR="${VAHOME}/current_output_archive"
+
+function unzip_current_output {
+    # Unzip one archived model output into its model directory.
+    local zip_path="$1"
+    local model_name
+    model_name="$(basename -s .zip "$zip_path")"
+    local model_dir
+    model_dir="${VAHOME}/${MODELS_PATH}/${model_name}"
+
+    mkdir -p "$model_dir"
+    unzip -o "$zip_path" -d "$model_dir"
+}
+export -f unzip_current_output
+
+rm -rf "$CURRENT_OUTPUT_ARCHIVE_DIR"
+mkdir -p "$CURRENT_OUTPUT_ARCHIVE_DIR"
+
+# Download archived output from CURRENT_PREFIX.
+docker run --rm \
+    --volume="${HOME}/.aws:/root/.aws:ro" --volume="${CURRENT_OUTPUT_ARCHIVE_DIR}:/data" \
+    -e AWS_CA_BUNDLE="/etc/pki/tls/cert.pem" \
+    docker.io/amazon/aws-cli:2.32.14 \
+    --profile=verschilanalyse --endpoint-url=https://s3.deltares.nl \
+    s3 sync --delete --no-progress "${BUCKET}/${CURRENT_PREFIX}/output" /data
+
+# Unpack each model archive in the local model tree.
+find "$CURRENT_OUTPUT_ARCHIVE_DIR" -iname '*.zip' -print0 |
+    xargs -0 -I'{}' -P8 bash -c 'unzip_current_output "{}"'
+
+rm -rf "$CURRENT_OUTPUT_ARCHIVE_DIR"

--- a/ci/teamcity/Delft3D/verschilanalyse/bundle/start_verschilanalyse.sh
+++ b/ci/teamcity/Delft3D/verschilanalyse/bundle/start_verschilanalyse.sh
@@ -8,7 +8,7 @@ source util.sh
 
 function show_help {
     cat - <<EOF
-Usage: $0 -a <apptainer-image> -r <s3-path-prefix> -o <s3-path-prefix> [-m <models-path>] [-f <comma-separated list>]
+Usage: $0 -a <apptainer-image> -r <s3-path-prefix> -o <s3-path-prefix> [-m <models-path>] [-f <comma-separated list>] [-s true|false]
 -a|--apptainer oras://repo/image:tag
     Either a path to a '.sif' file or a link to a repository e.g. 'oras://<repo>/<image>:<tag>'.
 -c|--current-prefix path/to/output
@@ -19,12 +19,14 @@ Usage: $0 -a <apptainer-image> -r <s3-path-prefix> -o <s3-path-prefix> [-m <mode
     The S3 path and local directory name for model data
 -f|--model-filter grevelingen,volkerakzoommeer
     Comma-separated list of patterns. Only models with paths matching one of these patterns will be run.
+-s|--run-models true|false
+    If false, skip model execution and reuse already archived output from CURRENT_PREFIX.
 
 EOF
 }
 
 # Parse command line options
-PARSED_OPTIONS=$(getopt -o 'a:c:r:m:f:d:j:h' -l 'apptainer:,current-prefix:,reference-prefix:,models-path:,model-filter:,json-configs-path:,va-home:,help' -- "$@")
+PARSED_OPTIONS=$(getopt -o 'a:c:r:m:f:d:j:s:h' -l 'apptainer:,current-prefix:,reference-prefix:,models-path:,model-filter:,json-configs-path:,va-home:,run-models:,help' -- "$@")
 eval set -- "$PARSED_OPTIONS"
 
 APPTAINER=
@@ -34,6 +36,7 @@ MODELS_PATH=
 MODEL_FILTER=
 JSON_CONFIGS_PATH=
 VAHOME=
+RUN_MODELS='true'
 
 while true; do
     case "$1" in
@@ -65,6 +68,10 @@ while true; do
         VAHOME="$2"
         shift 2
         ;;
+    -s | --run-models)
+        RUN_MODELS="$2"
+        shift 2
+        ;;
     -h | --help)
         show_help
         exit 0
@@ -84,6 +91,14 @@ if ! util.check_vars_are_set APPTAINER REFERENCE_PREFIX CURRENT_PREFIX VAHOME MO
     show_help
     exit 1
 fi
+
+RUN_MODELS="${RUN_MODELS,,}"
+if [[ "$RUN_MODELS" != 'true' && "$RUN_MODELS" != 'false' ]]; then
+    >&2 echo "Error: --run-models must be 'true' or 'false', got: $RUN_MODELS"
+    show_help
+    exit 1
+fi
+echo "RUN_MODELS=${RUN_MODELS}"
 
 if [[ -z "$MODEL_FILTER" ]]; then
     # This regex matches all models.
@@ -130,51 +145,60 @@ DOWNLOAD_REFS_JOB_ID=$(
         ./jobs/download_references.sh
 )
 
-# Pull apptainer from Harbor and store it as a `.sif` in the home directory.
-apptainer remote login \
-    --username="robot\$delft3d+h7" \
-    --password-stdin oras://containers.deltares.nl <"${HOME}/.harbor/delft3d"
-mkdir -p "$(dirname "$DELFT3D_SIF")"
-apptainer pull --force "$DELFT3D_SIF" "$APPTAINER"
+if [[ "$RUN_MODELS" = 'true' ]]; then
+    # Pull apptainer from Harbor and store it as a `.sif` in the home directory.
+    apptainer remote login \
+        --username="robot\$delft3d+h7" \
+        --password-stdin oras://containers.deltares.nl <"${HOME}/.harbor/delft3d"
+    mkdir -p "$(dirname "$DELFT3D_SIF")"
+    apptainer pull --force "$DELFT3D_SIF" "$APPTAINER"
 
-# Find and submit all 'submit_apptainer_h7.sh' scripts.
-JOB_IDS=()
-SUBMIT_SCRIPTS=$(find "${VAHOME}/${MODELS_PATH}" -type f -name submit_apptainer_h7.sh -iregex "$MODEL_REGEX")
-for SCRIPT in $SUBMIT_SCRIPTS; do
-    MODEL_DIR=$(echo "$SCRIPT" | sed -n -e 's|^\([-/_0-9A-Za-z]*\)/computations/.*$|\1|p')
+    # Find and submit all 'submit_apptainer_h7.sh' scripts.
+    JOB_IDS=()
+    SUBMIT_SCRIPTS=$(find "${VAHOME}/${MODELS_PATH}" -type f -name submit_apptainer_h7.sh -iregex "$MODEL_REGEX")
+    for SCRIPT in $SUBMIT_SCRIPTS; do
+        MODEL_DIR=$(echo "$SCRIPT" | sed -n -e 's|^\([-/_0-9A-Za-z]*\)/computations/.*$|\1|p')
 
-    # To run the simulation, the working directory must be the directory containing the submit script.
-    # The model directory is bind-mounted inside the apptainer. It must contain all input files.
-    echo "Submitting script ${SCRIPT}"
-    echo "Model directory: ${MODEL_DIR}"
-    JOB_ID=$(
-        sbatch --parsable \
-            --chdir="$(dirname "$SCRIPT")" \
-            --output="${LOG_DIR}/models/$(basename "$MODEL_DIR").out" \
-            "$SCRIPT" --apptainer "$DELFT3D_SIF" --model-dir "$MODEL_DIR"
+        # To run the simulation, the working directory must be the directory containing the submit script.
+        # The model directory is bind-mounted inside the apptainer. It must contain all input files.
+        echo "Submitting script ${SCRIPT}"
+        echo "Model directory: ${MODEL_DIR}"
+        JOB_ID=$(
+            sbatch --parsable \
+                --chdir="$(dirname "$SCRIPT")" \
+                --output="${LOG_DIR}/models/$(basename "$MODEL_DIR").out" \
+                "$SCRIPT" --apptainer "$DELFT3D_SIF" --model-dir "$MODEL_DIR"
+        )
+        JOB_IDS+=("$JOB_ID")
+    done
+
+    # Make colon-separated list of JOB_IDS.
+    JOB_ID_LIST=$(
+        IFS=':'
+        echo "${JOB_IDS[*]}"
     )
-    JOB_IDS+=("$JOB_ID")
-done
 
-# Make colon-separated list of JOB_IDS.
-JOB_ID_LIST=$(
-    IFS=':'
-    echo "${JOB_IDS[*]}"
-)
-
-# Archive and upload new output.
-UPLOAD_OUTPUT_JOB_ID=$(
-    sbatch --parsable \
-        --output="${LOG_DIR}/va-upload-output-%j.out" \
-        --dependency="afterany:${JOB_ID_LIST}" \
-        ./jobs/upload_output.sh
-)
+    # Archive and upload new output.
+    OUTPUT_READY_JOB_ID=$(
+        sbatch --parsable \
+            --output="${LOG_DIR}/va-upload-output-%j.out" \
+            --dependency="afterany:${JOB_ID_LIST}" \
+            ./jobs/upload_output.sh
+    )
+else
+    # Reuse existing archived output from CURRENT_PREFIX.
+    OUTPUT_READY_JOB_ID=$(
+        sbatch --parsable \
+            --output="${LOG_DIR}/va-download-current-output-%j.out" \
+            ./jobs/download_current_output.sh
+    )
+fi
 
 # Generate report.
 RUN_VERSCHILLENTOOL_JOB_ID=$(
     sbatch --parsable \
         --output="${LOG_DIR}/va-run-verschillentool-%j.out" \
-        --dependency="afterany:${DOWNLOAD_REFS_JOB_ID}:${UPLOAD_OUTPUT_JOB_ID}" \
+        --dependency="afterany:${DOWNLOAD_REFS_JOB_ID}:${OUTPUT_READY_JOB_ID}" \
         ./jobs/run_verschillentool.sh
 )
 


### PR DESCRIPTION
This pull request introduces a new mechanism to optionally skip running model executions and instead reuse previously archived outputs in the Verschilanalyse pipeline. The changes add a `run_models` parameter throughout the TeamCity configuration and pipeline scripts, allowing users to control whether models are executed or existing outputs are used.

**Parameterization and Pipeline Control:**

* Added a `run_models` checkbox parameter to the TeamCity build configuration (`StartVerschilanalyse`) and propagated it through the environment and command-line arguments, enabling users to decide whether to run models or reuse existing output.

**Pipeline Logic Updates:**

* Updated `start_verschilanalyse.sh` to branch execution based on the `RUN_MODELS` flag: if true, models are executed and output is uploaded; if false, existing output is downloaded and reused. Job dependencies are adjusted accordingly.

**New Script for Output Reuse:**

* Added `download_current_output.sh`, a Slurm job script that downloads and unpacks archived model outputs from S3, supporting the reuse workflow.