### PR TITLE
UNST-9768: Renamed and restructured Secchi variables

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_heatfluxes.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_heatfluxes.f90
@@ -56,7 +56,6 @@ module m_heatfluxes
 
    integer :: jamapheatflux !< write heatfluxes to map
    integer :: jarichardsononoutput !< write Richardson nr to his
-   integer :: jasecchisp !< Spatial Secchi 0,1
    integer :: rho_water_in_wind_stress !< Use rhomean or local (surface) density of model in windstress: 0,1
    integer, parameter :: RHO_MEAN = 0 !< Use rhomean in windstress
 
@@ -68,7 +67,9 @@ module m_heatfluxes
    real(kind=dp), dimension(:), allocatable :: qfrconmap
    real(kind=dp), dimension(:), allocatable :: qtotmap
 
-   real(kind=dp), dimension(:), allocatable, target :: secchisp !< [m] Space-varying secchi depth {"location": "face", "shape": ["ndx"]}
+   ! Secchi depth variables
+   integer :: enable_spatial_secchi_depth !< Enable spatially varying Secchi depth (0: no, 1: yes) {former:jasecchisp}
+   real(kind=dp), dimension(:), allocatable, target :: spatial_secchi_depth !< [m] Space-varying Secchi depth {"location": "face", "shape": ["ndx"]} {former:secchisp}
 
 contains
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_physcoef.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_physcoef.f90
@@ -94,10 +94,11 @@ module m_physcoef
    real(kind=dp), parameter :: BACKGROUND_AIR_TEMPERATURE = 20.0_dp !< background air temperature (degrees Celsius)
    real(kind=dp), parameter :: BACKGROUND_CLOUDINESS = 50.0_dp !< (%) cloudiness for non-specified points
    real(kind=dp), parameter :: BACKGROUND_HUMIDITY = 50.0_dp !< (%) relative humidity for non-specified points
-   real(kind=dp) :: secchidepth !< (m) secchidepth
-   real(kind=dp) :: secchidepth2 !< (m) secchidepth2
-   real(kind=dp) :: secchidepth2fraction !< (m) fraction of total absorbed by profile 2
-   real(kind=dp) :: zab(2), sfr(2) !< help variables
+
+   ! Secchi depth variables
+   real(kind=dp), dimension(2) :: secchi_depth !< [m] Constant Secchi depth; 1 = visible light and UV radiation, 2 = infrared radiation
+   real(kind=dp), dimension(2) :: secchi_radiation_fraction !< [-] Radiation fraction in (1) visible light and UV radiation, (2) infrared radiation used in Secchi computation
+   real(kind=dp), dimension(2) :: secchi_extinction_depth !< [m] Extinction depth scale for Secchi radiation, extinction_depth = secchi_depth / 1.7
 
    integer :: limiterhordif !< 0=No, 1=Horizontal gradient densitylimiter, 2=Finite volume
 
@@ -148,9 +149,12 @@ contains
       rhomean = 1000.0_dp
       backgroundwatertemperature = 20.0_dp
       backgroundsalinity = 30.0_dp
-      secchidepth = 1.0_dp
-      secchidepth2 = 0.0_dp
-      secchidepth2fraction = 0.0_dp
+      secchi_depth(1) = 1.0_dp
+      secchi_depth(2) = 0.0_dp
+      secchi_radiation_fraction(1) = 1.0_dp
+      secchi_radiation_fraction(2) = 0.0_dp
+      secchi_extinction_depth(1) = secchi_depth(1) / 1.7_dp
+      secchi_extinction_depth(2) = secchi_depth(2) / 1.7_dp
       vicwminb = 0.0_dp
       xlozmidov = 0.0_dp
       idensform = 2

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -1583,7 +1583,7 @@ contains
       use m_lateral_helper_fuctions, only: prepare_lateral_mask
       use fm_external_forcings_data, only: success
       use fm_external_forcings_utils, only: split_qid
-      use m_heatfluxes, only: secchisp
+      use m_heatfluxes, only: spatial_secchi_depth
       use m_wind, only: wind_drag_type, CD_TYPE_CONST
       use m_fm_icecover, only: ja_ice_area_fraction_read, ja_ice_thickness_read, fm_ice_activate_by_ext_forces
       use m_meteo, only: ec_addtimespacerelation
@@ -1733,9 +1733,9 @@ contains
          target_location_type = UNC_LOC_S
          time_dependent_array = .true.
       case ('secchidepth')
-         call realloc(secchisp, ndx, keepExisting=.true., fill=dmiss, stat=ierr)
+         call realloc(spatial_secchi_depth, ndx, keepExisting=.true., fill=dmiss, stat=ierr)
          target_location_type = UNC_LOC_S
-         target_array => secchisp
+         target_array => spatial_secchi_depth
       case ('backgroundverticaleddydiffusivitycoefficient')
          target_location_type = UNC_LOC_S
          call realloc(dicoww, ndx, constant_dicoww)
@@ -2008,8 +2008,8 @@ contains
       use m_grw, only: jaintercept2D
       use m_fm_icecover, only: ja_ice_area_fraction_read, ja_ice_thickness_read
 
-      use m_heatfluxes, only: jasecchisp, secchisp
-      use m_physcoef, only: secchidepth
+      use m_heatfluxes, only: enable_spatial_secchi_depth, spatial_secchi_depth
+      use m_physcoef, only: secchi_depth
       use m_meteo, only: ec_addtimespacerelation
       use m_vegetation, only: stemheight, stemheightstd
       use fm_location_types, only: UNC_LOC_S, UNC_LOC_U
@@ -2066,10 +2066,10 @@ contains
       case ('sea_ice_thickness')
          ja_ice_thickness_read = 1
       case ('secchidepth')
-         jaSecchisp = 1
+         enable_spatial_secchi_depth = 1
          do n = 1, ndx
-            if (secchisp(n) == dmiss) then
-               secchisp(n) = secchidepth
+            if (spatial_secchi_depth(n) == dmiss) then
+               spatial_secchi_depth(n) = secchi_depth(1)
             end if
          end do
       case ('stemheight')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1421,15 +1421,17 @@ contains
 
       call prop_get(md_ptr, 'physics', 'Temperature', temperature_model)
       call prop_get(md_ptr, 'physics', 'InitialTemperature', temini)
-      call prop_get(md_ptr, 'physics', 'Secchidepth', Secchidepth)
-      call prop_get(md_ptr, 'physics', 'Secchidepth2', Secchidepth2)
-      call prop_get(md_ptr, 'physics', 'Secchidepth2fraction', Secchidepth2fraction)
-      zab(1) = Secchidepth / 1.7_dp
-      sfr(1) = 1.0_dp
-      if (Secchidepth2 > 0) then
-         zab(2) = Secchidepth2 / 1.7_dp
-         sfr(2) = Secchidepth2fraction
-         sfr(1) = 1.0_dp - sfr(2)
+
+      ! Secchi parameter readout
+      call prop_get(md_ptr, 'physics', 'SecchiDepth', secchi_depth(1))
+      call prop_get(md_ptr, 'physics', 'SecchiDepth2', secchi_depth(2))
+      call prop_get(md_ptr, 'physics', 'SecchiDepth2Fraction', secchi_radiation_fraction(2))
+
+      secchi_extinction_depth(1) = secchi_depth(1) / 1.7_dp
+      
+      if (secchi_depth(2) > 0) then
+         secchi_extinction_depth(2) = secchi_depth(2) / 1.7_dp
+         secchi_radiation_fraction(1) = 1.0_dp - secchi_radiation_fraction(2)
       end if
 
       call prop_get(md_ptr, 'physics', 'Stanton', Stanton)
@@ -3444,10 +3446,10 @@ contains
       call prop_set(prop_ptr, 'physics', 'Temperature', temperature_model, 'Include temperature (0: no, 1: only transport, 3: excess model of D3D, 5: composite (ocean) model)')
       if (writeall .or. (temperature_model /= TEMPERATURE_MODEL_NONE)) then
          call prop_set(prop_ptr, 'physics', 'InitialTemperature', temini, 'Uniform initial water temperature (degC)')
-         call prop_set(prop_ptr, 'physics', 'Secchidepth', Secchidepth, 'Water clarity parameter (m)')
-         if (Secchidepth2 > 0) then
-            call prop_set(prop_ptr, 'physics', 'Secchidepth2', Secchidepth2, 'Water clarity parameter 2 (m), only used if > 0')
-            call prop_set(prop_ptr, 'physics', 'Secchidepth2fraction', Secchidepth2fraction, 'Fraction of total absorbed by profile 2')
+         call prop_set(prop_ptr, 'physics', 'SecchiDepth', secchi_depth(1), 'Water clarity parameter (m)')
+         if (secchi_depth(2) > 0) then
+            call prop_set(prop_ptr, 'physics', 'SecchiDepth2', secchi_depth(2), 'Water clarity parameter 2 (m), only used if > 0')
+            call prop_set(prop_ptr, 'physics', 'SecchiDepth2Fraction', secchi_radiation_fraction(2), 'Fraction of total absorbed by profile 2')
          end if
 
          call prop_set(prop_ptr, 'physics', 'Stanton', Stanton, 'Coefficient for convective heat flux, if negative, Ccon = abs(Stanton)*Cdwind')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
@@ -39,10 +39,10 @@ contains
    subroutine heatun(n, time_in_hours, nominal_solar_radiation)
       use precision, only: dp, comparereal, fp
       use physicalconsts, only: stf, celsius_to_kelvin, kelvin_to_celsius
-      use m_physcoef, only: ag, rhomean, backgroundsalinity, backgroundwatertemperature, dalton, epshstem, stanton, sfr, &
-                            soiltempthick, BACKGROUND_AIR_PRESSURE, BACKGROUND_HUMIDITY, BACKGROUND_CLOUDINESS, secchidepth2, surftempsmofac, &
-                            jadelvappos, zab, free_convection_coefficient
-      use m_heatfluxes, only: em, albedo, cpa, jaSecchisp, Secchisp, jamapheatflux, rcpi, fwind, qtotmap, qsunmap, qevamap, &
+      use m_physcoef, only: ag, rhomean, backgroundsalinity, backgroundwatertemperature, dalton, epshstem, stanton, secchi_depth, &
+                            soiltempthick, BACKGROUND_AIR_PRESSURE, BACKGROUND_HUMIDITY, BACKGROUND_CLOUDINESS, surftempsmofac, &
+                            jadelvappos, free_convection_coefficient, secchi_radiation_fraction, secchi_extinction_depth
+      use m_heatfluxes, only: em, albedo, cpa, enable_spatial_secchi_depth, spatial_secchi_depth, jamapheatflux, rcpi, fwind, qtotmap, qsunmap, qevamap, &
                               qconmap, qlongmap, qfrevamap, qfrconmap, qsunav, qlongav, qconav, qevaav, qfrconav, qfrevaav
       use m_flow, only: kmx, hs, solar_radiation_factor, zws, ucx, ucy, ktop
       use m_flowparameters, only: jahisheatflux, temperature_model, TEMPERATURE_MODEL_EXCESS, TEMPERATURE_MODEL_COMPOSITE, &
@@ -85,6 +85,7 @@ contains
       real(kind=dp) :: surface_temperature !< surface temperature ... temperature of water, ice or snow depending on their presence (degC)
       real(kind=dp) :: surface_albedo !< local surface albedo (may differ from albedo when ice/snow is present)
       real(kind=dp) :: salinity !< water salinity (ppt)
+      real(kind=dp), dimension(2) :: local_secchi_extinction_depth !< Local Secchi extinction depth used in computations
 
       real(kind=dp), parameter :: MIN_THICK = 0.001_fp !< threshold thickness for ice/snow to overrule the underlying layer (m)
 
@@ -204,7 +205,10 @@ contains
          if (solar_radiation_flux > 0.0_dp) then
 
             if (kmx > 0) then ! distribute incoming radiation over water column
-               if (secchidepth2 > 0.0_dp) then
+               local_secchi_extinction_depth(1) = secchi_extinction_depth(1)
+               local_secchi_extinction_depth(2) = secchi_extinction_depth(2)
+
+               if (secchi_depth(2) > 0.0_dp) then
                   j2 = 2
                else
                   j2 = 1
@@ -212,8 +216,8 @@ contains
 
                do j = j2, 1, -1
 
-                  if (j == 1 .and. jasecchisp > 0) then
-                     zab(1) = secchisp(n) / 1.7_dp
+                  if (j == 1 .and. enable_spatial_secchi_depth == 1) then
+                     local_secchi_extinction_depth(1) = spatial_secchi_depth(n) / 1.7_dp
                   end if
 
                   zlo = 0.0_dp
@@ -223,7 +227,7 @@ contains
                      zup = zlo
                      expup = explo
                      zlo = zws(k_top) - zws(cell_index_3D - 1)
-                     ratio = zlo / zab(j)
+                     ratio = zlo / local_secchi_extinction_depth(j)
                      if (ratio > 4.0_dp) then !  .or. cell_index_3D.eq.k_bot) then
                         explo = 0.0_dp
                      else
@@ -231,7 +235,7 @@ contains
                      end if
                      dexp = expup - explo
                      if (dexp > 0.0_dp) then
-                        heatsrc0(cell_index_3D) = heatsrc0(cell_index_3D) + sfr(j) * solar_radiation_flux * dexp * ice_free_area_fraction
+                        heatsrc0(cell_index_3D) = heatsrc0(cell_index_3D) + secchi_radiation_fraction(j) * solar_radiation_flux * dexp * ice_free_area_fraction
                      else
                         exit
                      end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2669,10 +2669,10 @@ contains
          end do
       end if
 
-      if (jaSecchisp > 0) then
+      if (enable_spatial_secchi_depth == 1) then
          do n = 1, ndx
-            if (Secchisp(n) == dmiss) then
-               Secchisp(n) = Secchidepth
+            if (spatial_secchi_depth(n) == dmiss) then
+               spatial_secchi_depth(n) = secchi_depth(1)
             end if
          end do
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -263,17 +263,17 @@ contains
 
             else if (qid == 'secchidepth') then
 
-               if (jaSecchisp == 0) then
-                  if (allocated(Secchisp)) then
-                     deallocate (Secchisp)
+               if (enable_spatial_secchi_depth == 0) then
+                  if (allocated(spatial_secchi_depth)) then
+                     deallocate (spatial_secchi_depth)
                   end if
-                  allocate (Secchisp(ndx), stat=ierr)
-                  call aerr('Secchisp(ndx)', ierr, lnx)
-                  Secchisp = dmiss
-                  jaSecchisp = 1
+                  allocate (spatial_secchi_depth(ndx), stat=ierr)
+                  call aerr('spatial_secchi_depth(ndx)', ierr, lnx)
+                  spatial_secchi_depth = dmiss
+                  enable_spatial_secchi_depth = 1
                end if
 
-               success = timespaceinitialfield(xz, yz, Secchisp, ndx, filename, filetype, method, operand, transformcoef, UNC_LOC_U)
+               success = timespaceinitialfield(xz, yz, spatial_secchi_depth, ndx, filename, filetype, method, operand, transformcoef, UNC_LOC_U)
 
             else if (qid == 'advectiontype') then
 


### PR DESCRIPTION
# What was done 

Renamed Secchi variables to be more descriptive and simplified the variable structure

Important to note:
The old `secchidepth` is for visible light & uv radiation
The old `secchidepth2` is for infrared radiation
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
