### PR TITLE
Prevent _work directory mixing in testbench and HPC pipelines

### DIFF
--- a/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/common_utilities.sh
+++ b/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/common_utilities.sh
@@ -4,7 +4,15 @@
 # This file contains shared functions used by prepare_all_models.sh and run_all_models.sh
 
 find_dimr_directories() {
-    find . -type f \( -name "dimr.xml" -o -name "dimr_config.xml" \) -exec dirname {} \; | sort -u
+    find . -type f \( -name "dimr.xml" -o -name "dimr_config.xml" \) -exec dirname {} \; | sort -u | while read dir; do
+        dir_name=$(basename "$dir")
+        parent_dir=$(dirname "$dir")
+        # Skip non-_work directory when a _work sibling exists (prefer _work for execution)
+        if [[ "$dir_name" != *_work ]] && [ -d "$parent_dir/${dir_name}_work" ]; then
+            continue
+        fi
+        echo "$dir"
+    done
 }
 
 is_supported_platform() {

--- a/test/deltares_testbench/src/suite/test_set_runner.py
+++ b/test/deltares_testbench/src/suite/test_set_runner.py
@@ -609,7 +609,11 @@ class TestSetRunner(ABC):
             local_path = self.__build_local_path(config, location)
             self.__download_location_with_retries(config, location, remote_path, local_path, logger)
             if location.type == PathType.INPUT:
-                self.__copy_to_work_folder(Path(local_path), logger)
+                work_path = Path(local_path).with_name(f"{Path(local_path).name}_work")
+                if work_path.exists() and self.settings.command_line_settings.skip_run:
+                    logger.debug(f"Preserving existing work directory: {work_path}")
+                else:
+                    self.__copy_to_work_folder(Path(local_path), logger)
 
             self.__set_absolute_paths(config, location.type, local_path)
 


### PR DESCRIPTION
In test_set_runner.py, preserve existing _work directory when --skip-run is set, so the receive pipeline does not overwrite remote execution results with pristine input. If _work does not exist yet, create it normally regardless of skip-run.

In common_utilities.sh, filter find_dimr_directories to skip non-_work directories when a _work sibling exists, preventing duplicate model execution on H7.