### PR TITLE
UNST-9842 set the stack size of OpenMP helper threads to 20MB, just l…

### DIFF
--- a/src/cmake/CMakeLists.txt
+++ b/src/cmake/CMakeLists.txt
@@ -47,6 +47,9 @@ set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 # Set compiler flags
 enable_language(Fortran C CXX)
 
+# DFlowFM stack size in bytes, used for OpenMP thread stack and Windows linker /STACK flag
+set(DFLOWFM_STACK_SIZE_BYTES 20000000 CACHE STRING "DFlowFM stack size in bytes")
+
 if(${CMAKE_Fortran_COMPILER_ID} MATCHES "GNU")
     include(compiler_options/gnu.cmake)
 elseif(${CMAKE_Fortran_COMPILER_ID} MATCHES "Intel")

--- a/src/cmake/compiler_options/intel.cmake
+++ b/src/cmake/compiler_options/intel.cmake
@@ -8,7 +8,7 @@ if (WIN32)
     message(STATUS "Setting global Intel Fortran compiler flags in Windows")
     set(CMAKE_Fortran_FLAGS "/W1 /nologo /libs:dll /threads /MP /Qdiag-disable:10448 /assume:recursion")
     # Set global linker flags for Fortran
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE /STACK:20000000")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /LARGEADDRESSAWARE /STACK:${DFLOWFM_STACK_SIZE_BYTES}")
     # Set global C/C++ compiler flags that apply for each C/C++ project
     string(APPEND CMAKE_C_FLAGS " /MP")
     string(APPEND CMAKE_CXX_FLAGS " /MP")

--- a/src/engines_gpl/dflowfm/packages/dflowfm-cli_exe/src/net_main.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm-cli_exe/src/net_main.F90
@@ -204,9 +204,7 @@ program unstruc
 
    call iset_jaopengl(md_jaopengl)
 
-#ifdef _OPENMP
-      ierr = init_openmp(md_numthreads, jampi)
-#endif
+   ierr = init_openmp(md_numthreads, jampi)
 
    call START_PROGRAM()
    call resetFullFlowModel()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/CMakeLists.txt
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/CMakeLists.txt
@@ -257,6 +257,7 @@ set_source_files_properties(${fortran_version_files}
 
 # Define preprocessor definitions
 set_target_properties(${library_name} PROPERTIES COMPILE_FLAGS ${openmp_flag})
+target_compile_definitions(${library_name} PRIVATE DFLOWFM_STACK_SIZE_BYTES=${DFLOWFM_STACK_SIZE_BYTES})
 if (WIN32)
     if(WITH_INTERACTER)
         # Add HAVE_DISPLAY=1

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
@@ -66,6 +66,12 @@ contains
 #endif
 
 #ifdef _OPENMP
+      ! Set OpenMP worker thread stack size to 20 MB.
+      ! Must be called before the first parallel region.
+      ! On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
+      ! subroutines with large automatic arrays, causing random stack overflows.
+      call kmp_set_stacksize_s(20 * 1024 * 1024)
+
       if (mpion == 1 .and. maxnumthreads == 0) then
          ! If MPI is on for this model, *and* no user-define numthreads was set, then disable OpenMP.
          openmp_threads = 1

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
@@ -66,12 +66,6 @@ contains
 #endif
 
 #ifdef _OPENMP
-      ! Set OpenMP worker thread stack size to the same as the windows main thread (typically 20 MB).
-      ! Must be called before the first parallel region.
-      ! On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
-      ! subroutines with large automatic arrays, causing random stack overflows.
-      call kmp_set_stacksize_s(DFLOWFM_STACK_SIZE_BYTES)
-
       if (mpion == 1 .and. maxnumthreads == 0) then
          ! If MPI is on for this model, *and* no user-define numthreads was set, then disable OpenMP.
          openmp_threads = 1
@@ -95,6 +89,19 @@ contains
          call mess(LEVEL_INFO, 'OpenMP disabled.')
          call omp_set_num_threads(1)
       end if
+
+      ! Set OpenMP worker thread stack size to the same as the windows main thread (typically 20 MB)
+      ! if not set by the user explicitly.
+      ! Must be called before the first parallel region.
+      ! On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
+      ! subroutines with large automatic arrays, causing random stack overflows.
+#ifdef __INTEL_COMPILER
+      call get_environment_variable("OMP_STACKSIZE", status=status)
+      if (status /= 0) then
+         call kmp_set_stacksize_s(DFLOWFM_STACK_SIZE_BYTES)
+         call mess(LEVEL_INFO, 'OpenMP worker thread stack size (in bytes) set to ', DFLOWFM_STACK_SIZE_BYTES)
+      end if
+#endif
 #endif
 
    end function init_openmp

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/init_openmp.F90
@@ -66,11 +66,11 @@ contains
 #endif
 
 #ifdef _OPENMP
-      ! Set OpenMP worker thread stack size to 20 MB.
+      ! Set OpenMP worker thread stack size to the same as the windows main thread (typically 20 MB).
       ! Must be called before the first parallel region.
       ! On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
       ! subroutines with large automatic arrays, causing random stack overflows.
-      call kmp_set_stacksize_s(20 * 1024 * 1024)
+      call kmp_set_stacksize_s(DFLOWFM_STACK_SIZE_BYTES)
 
       if (mpion == 1 .and. maxnumthreads == 0) then
          ! If MPI is on for this model, *and* no user-define numthreads was set, then disable OpenMP.

--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -249,6 +249,7 @@ contains
 
       ! Extra local variables
       integer :: inerr ! number of the initialisation error
+      integer :: ierr
       logical :: mpi_initd
 
       c_iresult = 0 ! TODO: is this return value BMI-compliant?
@@ -290,13 +291,12 @@ contains
          jampi = 0
       end if
 
-#ifdef _OPENMP
-      ierr = init_openmp(md_numthreads, jampi)
-#endif
       !   make domain number string as soon as possible
       write (sdmn, '(I4.4)') my_rank
 
 #endif
+
+      ierr = init_openmp(md_numthreads, jampi)
 
       ! do this until default has changed
       jaGUI = 0

--- a/src/engines_gpl/dimr/packages/dimr/src/dimr_exe.cpp
+++ b/src/engines_gpl/dimr/packages/dimr/src/dimr_exe.cpp
@@ -58,7 +58,6 @@
 #include <sstream>
 #include <math.h>
 #include <mpi.h>
-#include <omp.h>
 
 #if defined(WIN32)
     #include "getopt.h"
@@ -99,12 +98,6 @@ int main(int argc, char* argv[], char* envp[])
 #endif
     // Do not delete the next line; it ensures that the version string is added to the binary
     const char* dimrexeversion = getversionidstring_dimr_exe();
-
-    // Set OpenMP worker thread stack size to 20 MB.
-    // Must be called before the first parallel region.
-    // On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
-    // subroutines with large automatic arrays, causing random stack overflows.
-    kmp_set_stacksize_s(20 * 1024 * 1024);
 
     int ireturn = -1;
     DimrExe* DHE;

--- a/src/engines_gpl/dimr/packages/dimr/src/dimr_exe.cpp
+++ b/src/engines_gpl/dimr/packages/dimr/src/dimr_exe.cpp
@@ -58,6 +58,7 @@
 #include <sstream>
 #include <math.h>
 #include <mpi.h>
+#include <omp.h>
 
 #if defined(WIN32)
     #include "getopt.h"
@@ -98,6 +99,12 @@ int main(int argc, char* argv[], char* envp[])
 #endif
     // Do not delete the next line; it ensures that the version string is added to the binary
     const char* dimrexeversion = getversionidstring_dimr_exe();
+
+    // Set OpenMP worker thread stack size to 20 MB.
+    // Must be called before the first parallel region.
+    // On Windows, the default (4 MB for Intel OpenMP) is too small for Fortran
+    // subroutines with large automatic arrays, causing random stack overflows.
+    kmp_set_stacksize_s(20 * 1024 * 1024);
 
     int ireturn = -1;
     DimrExe* DHE;


### PR DESCRIPTION
…ike the main thread on windows

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link UNST-9842
