### PR TITLE
All/task/devopsdsc 000 override system deps

### DIFF
--- a/ci/teamcity/Delft3D/linux/docker/testContainer.Dockerfile
+++ b/ci/teamcity/Delft3D/linux/docker/testContainer.Dockerfile
@@ -23,8 +23,8 @@ RUN set -eo pipefail && \
 # Install pip
 RUN set -eo pipefail && \
     curl https://bootstrap.pypa.io/get-pip.py | python3 - && \
-    python3 -m pip install --upgrade pip && \
-    python3 -m pip install --requirement "/tmp/lnx-requirements.txt" && \
+    python3 -m pip install --upgrade pip --break-system-packages && \
+    python3 -m pip install --requirement "/tmp/lnx-requirements.txt" --break-system-packages --ignore-installed && \
     rm --verbose "/tmp/lnx-requirements.txt"
 
 ENV LD_LIBRARY_PATH=/opt/dimrset/lib

--- a/ci/teamcity/signing/sign.kt
+++ b/ci/teamcity/signing/sign.kt
@@ -38,14 +38,9 @@ object Sign : BuildType({
         }
         step {
             name = "Sign"
-            type = "AzureSigningTemplate"
+            type = "AzureSigningTemplate2"
             param("workingDir", "to_sign")
             param("binaryPatterns", "*.exe,*.dll")
-            param("timestampUrl", "http://timestamp.acs.microsoft.com")
-            param("digestAlgorithm", "SHA256")
-            param("timestampDigestAlgorithm", "SHA256")
-            param("dlibPath", """C:\\ProgramData\\Microsoft\\MicrosoftTrustedSigningClientTools\\Azure.CodeSigning.Dlib.dll""")
-            param("metadataPath", """C:\\ProgramData\\Microsoft\\MicrosoftTrustedSigningClientTools\\metadata.json""")
         }
         powerShell {
             name = "Move back signed binaries"


### PR DESCRIPTION
Use --break-system-packages and --ignore-install for pip install to override system-installed (RPM) dependencies.
This fixes:
https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_LinuxRuntimeContainers_virtual_Batch_1835993813_2/7055819?buildTab=log&linesState=288&logView=flowAware&focusLine=906