### PR TITLE
DEVOPSDSC-954: Set fetch depth in checkout step of TeamCity Kill switch workflow to 0

### DIFF
--- a/.github/workflows/cancel_teamcity_builds.yml
+++ b/.github/workflows/cancel_teamcity_builds.yml
@@ -22,6 +22,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Configure
         id: configure


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSDSC-954