### PR TITLE
Update contributing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,13 @@ If you are interested in using these products, and do not (yet) want to compile 
 - **Delft3D 4 Suite website:** https://www.deltares.nl/en/software-and-data/products/delft3d-4-suite
 - **Delft3D FM Suite:** https://www.deltares.nl/en/software-and-data/products/delft3d-flexible-mesh-suite
 
-and contact our **sales team:** https://www.deltares.nl/en/software-and-data/software-sales-and-support-teams
+and contact our **sales services team:** https://www.deltares.nl/en/software-and-data/software-sales-and-support-teams
 
-## Bug reports
+## Community support
 
-To limit the number of parallel communication channels and issue trackers, the issues tab has been removed on the Delft3D GitHub site.
-In case you encounter bugs, please report them to our **support team:** https://www.deltares.nl/en/software-and-data/software-sales-and-support-teams
+Clients with Service Packages have access to the support team.
+For the wider open source community, we recommend the use of the [GitHub Discussions](https://github.com/Deltares/Delft3D/discussions) tab.
+Please post questions and suggestions there in the Q&A sections.
 
 ## Open Source Community
 

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -10,6 +10,7 @@ If you are entirely new to contributing to open source, [this generic guide](htt
  - Reach out to Deltares as early as possible if you intend to contribute changes back to the main Delft3D version.
    This helps us with keeping track of what developments are ongoing.
    This helps avoid starting work on something that other people are already implementing, and we can give guidance on how best to implement the intended changes.
+   Reach out to us via the **sales services team:** https://www.deltares.nl/en/software-and-data/software-sales-and-support-teams with a brief description of the scope of the code change; they will forward your request internally to the appropriate development team.
  - Checkout/Clone the repository locally.
  - Create a branch, ideally using the naming convention below.
    The frequency of updating your fork/branch from the Deltares main is up to personal taste.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -7,9 +7,9 @@ If you are entirely new to contributing to open source, [this generic guide](htt
 ## Workflow
 ### External contributors
  - Create a fork of the Delft3D repository.
- - Reach out to Deltares in as early as possible if you intend to contribute changes back to the main Delft3D version.
+ - Reach out to Deltares as early as possible if you intend to contribute changes back to the main Delft3D version.
    This helps us with keeping track of what developments are ongoing.
-   This avoids that you start implementing something that other people are also working on, and we can give guidance as to how to best implement the intended changes.
+   This helps avoid starting work on something that other people are already implementing, and we can give guidance on how best to implement the intended changes.
  - Checkout/Clone the repository locally.
  - Create a branch, ideally using the naming convention below.
    The frequency of updating your fork/branch from the Deltares main is up to personal taste.
@@ -34,13 +34,13 @@ If you are entirely new to contributing to open source, [this generic guide](htt
  - Implement, test and document the modifications.
    In case of changes by external contributors, this step will include pulling the changes from the external repository into the local branch and at least a security scan of the changes made by the external contributor.
  - Create a pull request:
-   - Our Continuous Integration pipelines will be triggered automatically by pull request created by Deltares employees.
+   - Our Continuous Integration pipelines will be triggered automatically by a pull request created by Deltares employees.
      These pipelines consist of (Deltares-internal) TeamCity projects to build the source code (Windows and Linux) and subsequently a set of model simulation testbenches.
      A merge is only possible when all checks succeed.
      The projects will take at least 30 minutes to complete.
-   - You have to assign the Pull request to a core developer for review.
+   - You have to assign the pull request to a core developer for review.
      If review and all tests pass, the tester/reviewer is allowed to merge into main (signed Fiduciary License Agreement required in case of external contributor).
- - Official binary deliveries are only allowed using Deltares TeamCity server
+ - Official binary deliveries are only allowed using the Deltares TeamCity server.
 
 ## Branch naming
 For each issue or feature, a separate branch should be created from the main.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -21,8 +21,9 @@ If you are entirely new to contributing to open source, [this generic guide](htt
      Obviously, with some iterations if one of the steps identifies issues to be resolved before the merge.
  - To keep legal representation of the Delft3D software indisputable, we ask you to sign a Fiduciary License Agreement (FLA) before the final merge into main.
    For an explanation why, see [this page](https://fsfe.org/activities/fla/fla.en.html) by the Free Software Foundation Europe.
-   The FLA makes sense for code contributions of significant size.
-   For small bug fixes, it's better to send an email with a test case and the recommended code changes than following the formal procedure described above.
+   The FLA can be obtained via the Deltares contact person who handles the merging process.
+   Signing the FLA makes sense for code contributions of significant size.
+   For small bug fixes, it's better to send an email with a test case and a description of the recommended code changes than following the formal procedure described above.
 
 ### Deltares employees
  - Checkout/Clone the repository locally.

--- a/doc/contributing.md
+++ b/doc/contributing.md
@@ -5,22 +5,41 @@ Below are the specifics about our contributing process.
 If you are entirely new to contributing to open source, [this generic guide](https://opensource.guide/how-to-contribute/) also helps explain why, what, and how to successfully get involved in open source projects.
 
 ## Workflow
- - Create a fork of the Delft3D repository, or request write-access to our Delft3D repository via Delft3D support.
- - Create a JIRA issue ticket at https://issuetracker.deltares.nl describing the bug to be fixed or functionality to be developed.
-   The issue number is relevant for naming the development branch (see below).
-   Third party developers don't have access to the issue tracker; we recommend to communicate with a Deltares contact person.
+### External contributors
+ - Create a fork of the Delft3D repository.
+ - Reach out to Deltares in as early as possible if you intend to contribute changes back to the main Delft3D version.
+   This helps us with keeping track of what developments are ongoing.
+   This avoids that you start implementing something that other people are also working on, and we can give guidance as to how to best implement the intended changes.
  - Checkout/Clone the repository locally.
+ - Create a branch, ideally using the naming convention below.
+   The frequency of updating your fork/branch from the Deltares main is up to personal taste.
+   Yet, merge from our main as often as possible, and contribute back to us as early as possible.
+ - Implement, test and document the modifications.
+ - Provide a patch-file, or reach out to Deltares to create a pull request:
+   - Although anyone can create a pull request on our repository, our pipelines will only be triggered if the pull request is created by a Deltares employee.
+   - Merging back to our main will typically include the following steps: transfer code changes to a branch in our Delft3D repository, security scan of the changes made, creation of a pull request, review of code, documentation and test cases, and automated code testing.
+     Obviously, with some iterations if one of the steps identifies issues to be resolved before the merge.
+ - To keep legal representation of the Delft3D software indisputable, we ask you to sign a Fiduciary License Agreement (FLA) before the final merge into main.
+   For an explanation why, see [this page](https://fsfe.org/activities/fla/fla.en.html) by the Free Software Foundation Europe.
+   The FLA makes sense for code contributions of significant size.
+   For small bug fixes, it's better to send an email with a test case and the recommended code changes than following the formal procedure described above.
+
+### Deltares employees
+ - Checkout/Clone the repository locally.
+ - Create a JIRA issue ticket at https://issuetracker.deltares.nl describing the bug to be fixed or functionality to be developed.
+   The issue number is required for naming the development branch (see below).
  - Create a branch using the naming convention below.
-   If no issue number is available, create a research branch starting with `research/`.
    The frequency of updating your branch from main is up to personal taste.
    Yet, merge from main as often as possible, and merge back to main as early as possible.
- - Make and test the modifications.
- - Provide a patch-file, or create a pull request:
-   - Our Continuous Integration pipelines will only be triggered if the pull request is created by a Deltares contact person.
+ - Implement, test and document the modifications.
+   In case of changes by external contributors, this step will include pulling the changes from the external repository into the local branch and at least a security scan of the changes made by the external contributor.
+ - Create a pull request:
+   - Our Continuous Integration pipelines will be triggered automatically by pull request created by Deltares employees.
      These pipelines consist of (Deltares-internal) TeamCity projects to build the source code (Windows and Linux) and subsequently a set of model simulation testbenches.
      A merge is only possible when all checks succeed.
      The projects will take at least 30 minutes to complete.
-   - You have to assign the Pull request to a core developer for reviewing and testing. When succeeded, the tester/reviewer is allowed to merge into main.
+   - You have to assign the Pull request to a core developer for review.
+     If review and all tests pass, the tester/reviewer is allowed to merge into main (signed Fiduciary License Agreement required in case of external contributor).
  - Official binary deliveries are only allowed using Deltares TeamCity server
 
 ## Branch naming


### PR DESCRIPTION
# What was done 

- Split the “Workflow” section into “External contributors” and “Deltares employees”.
- Added guidance on early coordination with Deltares and described the typical merge steps for external contributions.
- Added mention of signing a Fiduciary License Agreement (FLA) prior to final merge (for external contributions).

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [x]	Documentation updated \
See commit.
- [ ]	Not applicable 

# Issue link
Closes UNST-9851