### PR TITLE
UNST-9746 Accidentally used diffuser id for run unique ID

### DIFF
--- a/src/tools_gpl/pre_c_sumo/src/coupling_steps.cpp
+++ b/src/tools_gpl/pre_c_sumo/src/coupling_steps.cpp
@@ -69,7 +69,7 @@ namespace pre_c_sumo
                 .wait_for_file = nf2ff_wait_file,
                 .ff_run_directory = diffuser.ff_run_dir.string(),
                 .run_id = run_id,
-                .unique_id = diffuser.id.value_or(""),
+                .unique_id = "", // Do not use unique ID, run C-SUMO in different directories for now
                 .subgrid_model_nr = subgrid_model_nr,
                 .current_time_seconds = current_time_seconds,
                 .constituent_names = constituent_names,


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
