### PR TITLE
UNST-9835: Add testcase for spherical friction coefficient

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -3142,7 +3142,7 @@ contains
       if (writeall .or. jaLogprofatubndin /= 1) then
          call prop_set(prop_ptr, 'numerics', 'Logprofatubndin', jaLogprofatubndin, 'ubnds inflow: 0=uniform U1, 1 = log U1, 2 = user3D')
       end if
-      if (writeall .or. jaLogprofkepsbndin /= 1) then
+      if (writeall .or. jaLogprofkepsbndin /= 0) then
          call prop_set(prop_ptr, 'numerics', 'Logprofkepsbndin', jaLogprofkepsbndin, 'inflow: 0=0 keps, 1 = log keps inflow, 2 = log keps in and outflow')
       end if
 
@@ -3928,7 +3928,7 @@ contains
                        'Write the total number of times a cell was Courant limiting to <run_id>_numlimdt.xyz file (1: yes, 0: no).')
       end if
       if (writeall .or. len_trim(unc_metadatafile) > 0) then
-         call prop_set(prop_ptr, 'output', 'MetaDataFile', unc_metadatafile, 'Metadata NetCDF file with user-defined global dataset attributes (*_meta.nc).')
+         call prop_set(prop_ptr, 'output', 'MetaDataFile', trim(unc_metadatafile), 'Metadata NetCDF file with user-defined global dataset attributes (*_meta.nc).')
       end if
       if (writeall .or. unc_uuidgen /= 0) then
          call prop_set(prop_ptr, 'output', 'GenerateUUID', unc_uuidgen, 'Generate UUID as unique dataset identifier and include in output NetCDF files.')

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -4625,7 +4625,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f015_c045_friccoef_xyz_spherical" ref="dflowfm_default">
-      <path version="2026-04-20T15:50:00">e02_dflowfm/f015_spatial_interpolation/c045_friccoef_xyz_spherical</path>
+      <path version="2026-04-22T16:16:00">e02_dflowfm/f015_spatial_interpolation/c045_friccoef_xyz_spherical</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_model/model_map.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -4633,7 +4633,7 @@
       <path version="2026-04-20T15:50:00">e02_dflowfm/f015_spatial_interpolation/c045_friccoef_xyz_spherical</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
-        <file name="DFM_OUTPUT_model/friccoeff_map.nc" type="netCDF">
+        <file name="DFM_OUTPUT_model/model_map.nc" type="netCDF">
           <parameters>
             <parameter name="mesh2d_cfu" toleranceAbsolute="0.0001" />
           </parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -4629,6 +4629,17 @@
         </file>
       </checks>
     </testCase>
+    <testCase name="e02_f015_c045_friccoef_xyz_spherical" ref="dflowfm_default">
+      <path version="2026-04-20T15:50:00">e02_dflowfm/f015_spatial_interpolation/c045_friccoef_xyz_spherical</path>
+      <maxRunTime>15000.0000000</maxRunTime>
+      <checks>
+        <file name="dflowfmoutput/friccoeff_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_cfu" toleranceAbsolute="0.0001" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
     <testCase name="e02_f015_c073_iniwatdep_pol" ref="dflowfm_default">
       <path version="2025-10-15T15:17:39.177000">e02_dflowfm/f015_spatial_interpolation/c073_iniwatdep_pol</path>
       <maxRunTime>15000.0000000</maxRunTime>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -4633,7 +4633,7 @@
       <path version="2026-04-20T15:50:00">e02_dflowfm/f015_spatial_interpolation/c045_friccoef_xyz_spherical</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
-        <file name="dflowfmoutput/friccoeff_map.nc" type="netCDF">
+        <file name="DFM_OUTPUT_model/friccoeff_map.nc" type="netCDF">
           <parameters>
             <parameter name="mesh2d_cfu" toleranceAbsolute="0.0001" />
           </parameters>


### PR DESCRIPTION
# What was done 
- Add testcase for spherical friction coefficient: e02_f015_c045_friccoef_xyz_spherical
- And two small fixes: default of jalogprofkepsbndin is 0 (and not 1). apply trim() to MetaDataFile to get a proper .dia file
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated: e02_f015_c045_friccoef_xyz_spherical

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9835