### PR TITLE
UNST-9427: Removed warning coinciding point sources

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
@@ -253,17 +253,6 @@ contains
          if (num_points > 1) then
             call normalin(source_sink_x(num_source_sink, num_points - 1), source_sink_y(num_source_sink, num_points - 1), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), source_sink_discharge_cosine(2, num_source_sink), source_sink_discharge_sine(2, num_source_sink), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), jsferic, jasfer3D, dxymis)
          end if
-
-         do i = 1, num_source_sink - 1
-            if (source_sink_indices(1, i) /= 0 .and. kk2 == source_sink_indices(1, i)) then
-               write (msgbuf, '(4a)') 'TO point of ', trim(source_sink_name(num_source_sink)), ' coincides with FROM point of ', trim(source_sink_name(i))
-               call warn_flush()
-            else if (source_sink_indices(4, i) /= 0 .and. kk2 == source_sink_indices(4, i)) then
-               write (msgbuf, '(4a)') 'TO point of ', trim(source_sink_name(num_source_sink)), ' coincides with TO   point of ', trim(source_sink_name(i))
-               call warn_flush()
-            end if
-         end do
-
       end if
 
       ierr = DFM_NOERR

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
@@ -249,7 +249,7 @@ contains
          if (z_source(2) /= dmiss) then
             source_sink_z_top(2, num_source_sink) = z_source(2)
          end if
-         ! Determine angle (sin/cos) of 'to' link (=first segment of polyline)
+         ! Determine angle (sin/cos) of 'to' link (= first segment of polyline)
          if (num_points > 1) then
             call normalin(source_sink_x(num_source_sink, num_points - 1), source_sink_y(num_source_sink, num_points - 1), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), source_sink_discharge_cosine(2, num_source_sink), source_sink_discharge_sine(2, num_source_sink), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), jsferic, jasfer3D, dxymis)
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
@@ -249,6 +249,7 @@ contains
          if (z_source(2) /= dmiss) then
             source_sink_z_top(2, num_source_sink) = z_source(2)
          end if
+         
          ! Determine angle (sin/cos) of 'to' link (= first segment of polyline)
          if (num_points > 1) then
             call normalin(source_sink_x(num_source_sink, num_points - 1), source_sink_y(num_source_sink, num_points - 1), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), source_sink_discharge_cosine(2, num_source_sink), source_sink_discharge_sine(2, num_source_sink), source_sink_x(num_source_sink, num_points), source_sink_y(num_source_sink, num_points), jsferic, jasfer3D, dxymis)


### PR DESCRIPTION
# What was done 

Removed the warning for coinciding point sources
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
