### PR TITLE
UNST-9862: Clean linked source/sinks for bubblescreens implementation

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1293,8 +1293,6 @@ contains
 
       real(kind=dp), dimension(:), allocatable :: x_flowcell !< x-coordinate of flow cell
       real(kind=dp), dimension(:), allocatable :: y_flowcell !< y-coordinate of flow cell
-      real(kind=dp), dimension(2) :: x_flowcell_2element !< x-coordinate of flow cell source, 2-elements long for addsorsin input
-      real(kind=dp), dimension(2) :: y_flowcell_2element !< y-coordinate of flow cell source, 2-elements long for addsorsin input
       real(kind=dp), dimension(2) :: z_flowcell_source !< z-coordinate of flow cell source
       real(kind=dp), dimension(2) :: z_flowcell_sink !< z-coordinate of flow cell sink
       real(kind=dp) :: z_dummy !< Dummy readout variable for z_level
@@ -1353,9 +1351,7 @@ contains
                write (srcid, '(A,I0)') trim(id), bubblescreen_source_sink_count
 
                ! Create a linked source/sink in the flow cell
-               x_flowcell_2element = [x_flowcell(cidx), x_flowcell(cidx)]
-               y_flowcell_2element = [y_flowcell(cidx), y_flowcell(cidx)]
-               call addsorsin(srcid, x_flowcell_2element, y_flowcell_2element, z_flowcell_source, z_flowcell_sink, 0.0_dp, ierr)
+               call addsorsin(srcid, [x_flowcell(cidx), x_flowcell(cidx)], [y_flowcell(cidx), y_flowcell(cidx)], z_flowcell_source, z_flowcell_sink, 0.0_dp, ierr)
                if (bubblescreen_cells(cidx) /= -1) then
                   local_count = local_count + 1
                   bubblescreen%source_sink_indices(local_count) = num_source_sink !> global counter which has just been incremented by addsorsin

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1271,7 +1271,7 @@ contains
       use m_addsorsin, only: addsorsin, addsorsin_from_polyline_file
       use m_setsorsin
       use m_missing, only: dmiss
-      use m_partitioninfo, only: jampi, reduce_cells, reduce_double_array_max, idomain, my_rank
+      use m_partitioninfo, only: jampi, reduce_cells, reduce_double_array_max
       use m_alloc, only: realloc
       use m_flowgeom, only: ndx
 
@@ -1293,6 +1293,8 @@ contains
 
       real(kind=dp), dimension(:), allocatable :: x_flowcell !< x-coordinate of flow cell
       real(kind=dp), dimension(:), allocatable :: y_flowcell !< y-coordinate of flow cell
+      real(kind=dp), dimension(2) :: x_flowcell_2element !< x-coordinate of flow cell source, 2-elements long for addsorsin input
+      real(kind=dp), dimension(2) :: y_flowcell_2element !< y-coordinate of flow cell source, 2-elements long for addsorsin input
       real(kind=dp), dimension(2) :: z_flowcell_source !< z-coordinate of flow cell source
       real(kind=dp), dimension(2) :: z_flowcell_sink !< z-coordinate of flow cell sink
       real(kind=dp) :: z_dummy !< Dummy readout variable for z_level
@@ -1351,19 +1353,12 @@ contains
                write (srcid, '(A,I0)') trim(id), bubblescreen_source_sink_count
 
                ! Create a linked source/sink in the flow cell
-               call addsorsin(srcid, x_flowcell(cidx:cidx), y_flowcell(cidx:cidx), z_flowcell_source, z_flowcell_sink, 0.0_dp, ierr)
+               x_flowcell_2element = [x_flowcell(cidx), x_flowcell(cidx)]
+               y_flowcell_2element = [y_flowcell(cidx), y_flowcell(cidx)]
+               call addsorsin(srcid, x_flowcell_2element, y_flowcell_2element, z_flowcell_source, z_flowcell_sink, 0.0_dp, ierr)
                if (bubblescreen_cells(cidx) /= -1) then
                   local_count = local_count + 1
                   bubblescreen%source_sink_indices(local_count) = num_source_sink !> global counter which has just been incremented by addsorsin
-                  source_sink_indices(1, num_source_sink) = bubblescreen_cells(cidx)
-                  source_sink_indices(4, num_source_sink) = bubblescreen_cells(cidx)
-                  if (jampi == 1) then
-                     if (idomain(bubblescreen_cells(cidx)) /= my_rank) then
-                        ! Ghost cell: owned by another partition, zero out indices so setsorsin
-                        ! skips the coupled branch and avoids double-counting source_sink_reduction
-                        source_sink_indices(1, num_source_sink) = 0
-                     end if
-                  end if
                end if
             end do
          end associate


### PR DESCRIPTION
# What was done 

By creating linked source/sinks the correct way we don't need to check if bubblescreen linked source/sinks are in ghost cells
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
