### PR TITLE
Set proper working directory of test_deltares_common_gtest from cmake

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/CMakeLists.txt
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/CMakeLists.txt
@@ -48,3 +48,6 @@ f90twtest(${test_target}
 add_subdirectory(helpers)
 
 copy_test_resources("${test_target}" "${CMAKE_CURRENT_SOURCE_DIR}/resources/MDUversion" "$<TARGET_FILE_DIR:${test_target}>/MDUversion")
+set_target_properties(${test_target} PROPERTIES
+    VS_DEBUGGER_WORKING_DIRECTORY "$<TARGET_FILE_DIR:${test_target}>"
+)


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
