### PR TITLE
DEVOPSDSC-953: Replace AWS config provider with static credentials using env vars.

### DIFF
--- a/ci/python/ci_tools/minio/synchronize/cli.py
+++ b/ci/python/ci_tools/minio/synchronize/cli.py
@@ -13,7 +13,7 @@ from urllib.parse import urlparse
 import certifi
 import minio
 import urllib3
-from minio.credentials.providers import AWSConfigProvider
+from minio.credentials.providers import StaticProvider
 from s3_path_wrangler.paths import S3Path
 
 from ci_tools import minio as const
@@ -108,6 +108,8 @@ class CommandLine:
                 endpoint_url=args.endpoint_url,
                 max_pool_size=args.jobs,
                 profile=args.profile,
+                aws_access_key_id=args.aws_access_key_id,
+                aws_secret_access_key=args.aws_secret_access_key,
             )
 
             cls._check_minio_connection(minio_client)
@@ -161,7 +163,8 @@ class CommandLine:
             description=cls.CLI_DESCRIPTION,
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-
+        parser.add_argument("-a", "--aws-access-key-id", type=str, help="MinIO access key ID")
+        parser.add_argument("-k", "--aws-secret-access-key", type=str, help="MinIO secret access key")
         parser.add_argument("-s", "--source", required=True, type=cls._location, help=cls.HELP["source"])
         parser.add_argument("-d", "--destination", required=True, type=cls._location, help=cls.HELP["destination"])
         parser.add_argument("-t", "--timestamp", type=cls._timestamp, help=cls.HELP["timestamp"])
@@ -228,9 +231,11 @@ class CommandLine:
         endpoint_url: str,
         profile: str | None = None,
         max_pool_size: int | None = None,
+        aws_access_key_id: str | None = None,
+        aws_secret_access_key: str | None = None,
     ) -> minio.Minio:
         parsed_url = urlparse(endpoint_url)
-        secure = False if parsed_url.scheme == "http" else True
+        secure = parsed_url.scheme != "http"
 
         max_pool_size = max_pool_size or cls.HTTP_DEFAULT_POOL_SIZE
         timeout = cls.HTTP_TIMEOUT_SECONDS
@@ -245,9 +250,20 @@ class CommandLine:
                 status_forcelist=[500, 502, 503, 504],
             ),
         )
+
+        access_key = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = aws_secret_access_key or os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+        if not access_key or not secret_key:
+            raise CommandLineError(
+                "Missing MinIO credentials. Provide --aws-access-key-id and "
+                "--aws-secret-access-key, or set AWS_ACCESS_KEY_ID and "
+                "AWS_SECRET_ACCESS_KEY."
+            )
+
         return minio.Minio(
             parsed_url.netloc,
-            credentials=AWSConfigProvider(profile=profile),
+            credentials=StaticProvider(access_key, secret_key),
             http_client=pool_manager,
             secure=secure,
         )

--- a/ci/python/ci_tools/minio/synchronize/cli.py
+++ b/ci/python/ci_tools/minio/synchronize/cli.py
@@ -106,8 +106,7 @@ class CommandLine:
             logger = cls._make_logger("minio-sync", args.log_level)
             minio_client = cls._make_minio_client(
                 endpoint_url=args.endpoint_url,
-                max_pool_size=args.jobs,
-                profile=args.profile
+                max_pool_size=args.jobs
             )
 
             cls._check_minio_connection(minio_client)
@@ -190,7 +189,6 @@ class CommandLine:
         parser.add_argument("-j", "--jobs", type=int, help=cls.HELP["jobs"])
         parser.add_argument("--queue-size", type=int, help=cls.HELP["queue-size"])
         parser.add_argument("--part-size", type=int, help=cls.HELP["part-size"])
-        parser.add_argument("--profile", help=cls.HELP["profile"])
         parser.add_argument("--endpoint-url", type=cls._endpoint_url, help=cls.HELP["endpoint-url"])
 
         parser.set_defaults(

--- a/ci/python/ci_tools/minio/synchronize/cli.py
+++ b/ci/python/ci_tools/minio/synchronize/cli.py
@@ -86,7 +86,6 @@ class CommandLine:
         "jobs": "The number of threads to use for synchronization.",
         "queue-size": "The maximum size of the queue for synchronization. This will limit memory usage.",
         "part-size": "The size of the parts to use for multipart uploads.",
-        "profile": "The AWS profile to use to authenticate with MinIO.",
         "endpoint-url": "The endpoint URL to use for MinIO.",
     }
 
@@ -204,8 +203,7 @@ class CommandLine:
             jobs=DEFAULT_WORKER_COUNT,
             queue_size=DEFAULT_QUEUE_SIZE,
             log_level=cls.DEFAULT_LOG_LEVEL,
-            endpoint_url=os.environ.get("ENDPOINT_URL", f"https://{const.DEFAULT_MINIO_HOSTNAME}"),
-            profile=os.environ.get("AWS_PROFILE"),
+            endpoint_url=os.environ.get("ENDPOINT_URL", f"https://{const.DEFAULT_MINIO_HOSTNAME}")
         )
 
         return parser

--- a/ci/python/ci_tools/minio/synchronize/cli.py
+++ b/ci/python/ci_tools/minio/synchronize/cli.py
@@ -103,10 +103,7 @@ class CommandLine:
             args = parser.parse_args()
 
             logger = cls._make_logger("minio-sync", args.log_level)
-            minio_client = cls._make_minio_client(
-                endpoint_url=args.endpoint_url,
-                max_pool_size=args.jobs
-            )
+            minio_client = cls._make_minio_client(endpoint_url=args.endpoint_url, max_pool_size=args.jobs)
 
             cls._check_minio_connection(minio_client)
         except CommandLineError as exc:
@@ -203,7 +200,7 @@ class CommandLine:
             jobs=DEFAULT_WORKER_COUNT,
             queue_size=DEFAULT_QUEUE_SIZE,
             log_level=cls.DEFAULT_LOG_LEVEL,
-            endpoint_url=os.environ.get("ENDPOINT_URL", f"https://{const.DEFAULT_MINIO_HOSTNAME}")
+            endpoint_url=os.environ.get("ENDPOINT_URL", f"https://{const.DEFAULT_MINIO_HOSTNAME}"),
         )
 
         return parser
@@ -244,9 +241,7 @@ class CommandLine:
         secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
         if not access_key or not secret_key:
-            raise CommandLineError(
-                "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
-            )
+            raise CommandLineError("Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.")
 
         return minio.Minio(
             parsed_url.netloc,

--- a/ci/python/ci_tools/minio/synchronize/cli.py
+++ b/ci/python/ci_tools/minio/synchronize/cli.py
@@ -107,9 +107,7 @@ class CommandLine:
             minio_client = cls._make_minio_client(
                 endpoint_url=args.endpoint_url,
                 max_pool_size=args.jobs,
-                profile=args.profile,
-                aws_access_key_id=args.aws_access_key_id,
-                aws_secret_access_key=args.aws_secret_access_key,
+                profile=args.profile
             )
 
             cls._check_minio_connection(minio_client)
@@ -163,8 +161,6 @@ class CommandLine:
             description=cls.CLI_DESCRIPTION,
             formatter_class=argparse.RawDescriptionHelpFormatter,
         )
-        parser.add_argument("-a", "--aws-access-key-id", type=str, help="MinIO access key ID")
-        parser.add_argument("-k", "--aws-secret-access-key", type=str, help="MinIO secret access key")
         parser.add_argument("-s", "--source", required=True, type=cls._location, help=cls.HELP["source"])
         parser.add_argument("-d", "--destination", required=True, type=cls._location, help=cls.HELP["destination"])
         parser.add_argument("-t", "--timestamp", type=cls._timestamp, help=cls.HELP["timestamp"])
@@ -229,10 +225,7 @@ class CommandLine:
     def _make_minio_client(
         cls,
         endpoint_url: str,
-        profile: str | None = None,
         max_pool_size: int | None = None,
-        aws_access_key_id: str | None = None,
-        aws_secret_access_key: str | None = None,
     ) -> minio.Minio:
         parsed_url = urlparse(endpoint_url)
         secure = parsed_url.scheme != "http"
@@ -251,14 +244,12 @@ class CommandLine:
             ),
         )
 
-        access_key = aws_access_key_id or os.environ.get("AWS_ACCESS_KEY_ID")
-        secret_key = aws_secret_access_key or os.environ.get("AWS_SECRET_ACCESS_KEY")
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
         if not access_key or not secret_key:
             raise CommandLineError(
-                "Missing MinIO credentials. Provide --aws-access-key-id and "
-                "--aws-secret-access-key, or set AWS_ACCESS_KEY_ID and "
-                "AWS_SECRET_ACCESS_KEY."
+                "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
             )
 
         return minio.Minio(

--- a/ci/python/ci_tools/minio/synchronize/sync_builder.py
+++ b/ci/python/ci_tools/minio/synchronize/sync_builder.py
@@ -199,9 +199,7 @@ class SyncBuilder:
         secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
         if not access_key or not secret_key:
-            raise ValueError(
-                "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
-            )
+            raise ValueError("Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.")
 
         return Minio(
             endpoint=DEFAULT_MINIO_HOSTNAME,

--- a/ci/python/ci_tools/minio/synchronize/sync_builder.py
+++ b/ci/python/ci_tools/minio/synchronize/sync_builder.py
@@ -1,10 +1,11 @@
+import os
 from datetime import datetime, timezone
 from logging import Logger
 from pathlib import Path
 from typing import Iterable
 
 from minio import Minio
-from minio.credentials.providers import AWSConfigProvider
+from minio.credentials.providers import StaticProvider
 from s3_path_wrangler.paths import S3Path
 
 from ci_tools.minio import DEFAULT_MINIO_HOSTNAME, DEFAULT_MULTIPART_UPLOAD_PART_SIZE
@@ -194,9 +195,17 @@ class SyncBuilder:
         if self._minio_client is not None:
             return self._minio_client
 
+        access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+        secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+        if not access_key or not secret_key:
+            raise ValueError(
+                "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+            )
+
         return Minio(
             endpoint=DEFAULT_MINIO_HOSTNAME,
-            credentials=AWSConfigProvider(),
+            credentials=StaticProvider(access_key, secret_key),
         )
 
     def _get_local_listing(self) -> Iterable[ListItem]:

--- a/ci/python/ci_tools/verschilanalyse/find_latest_weekly_output.py
+++ b/ci/python/ci_tools/verschilanalyse/find_latest_weekly_output.py
@@ -72,9 +72,7 @@ if __name__ == "__main__":
     secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
 
     if not access_key or not secret_key:
-        raise ValueError(
-            "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
-        )
+        raise ValueError("Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.")
 
     client = minio.Minio(endpoint=ENDPOINT, credentials=StaticProvider(access_key, secret_key))
     reporter = VerschilAnalyseReporter(minio=client, bucket_name=BUCKET_NAME, prefix=PREFIX)

--- a/ci/python/ci_tools/verschilanalyse/find_latest_weekly_output.py
+++ b/ci/python/ci_tools/verschilanalyse/find_latest_weekly_output.py
@@ -1,10 +1,11 @@
+import os
 import sys
 from collections import defaultdict
 from dataclasses import dataclass
 from datetime import datetime
 
 import minio
-from minio.credentials import AWSConfigProvider
+from minio.credentials.providers import StaticProvider
 
 ENDPOINT = "s3.deltares.nl"
 BUCKET_NAME = "devops-test-verschilanalyse"
@@ -67,7 +68,15 @@ if __name__ == "__main__":
 
     Used in TeamCity pipeline to set the `reference_prefix` parameter.
     """
-    client = minio.Minio(endpoint=ENDPOINT, credentials=AWSConfigProvider())
+    access_key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret_key = os.environ.get("AWS_SECRET_ACCESS_KEY")
+
+    if not access_key or not secret_key:
+        raise ValueError(
+            "Missing MinIO credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY."
+        )
+
+    client = minio.Minio(endpoint=ENDPOINT, credentials=StaticProvider(access_key, secret_key))
     reporter = VerschilAnalyseReporter(minio=client, bucket_name=BUCKET_NAME, prefix=PREFIX)
 
     report = reporter.get_latest_run()

--- a/ci/python/tests/minio_tests/synchronize/test_cli.py
+++ b/ci/python/tests/minio_tests/synchronize/test_cli.py
@@ -40,7 +40,6 @@ class TestCommandLineInterface:
         assert args.queue_size == DEFAULT_QUEUE_SIZE
         assert args.part_size == DEFAULT_MULTIPART_UPLOAD_PART_SIZE
         assert args.endpoint_url == f"https://{DEFAULT_MINIO_HOSTNAME}"
-        assert args.profile is None
         assert args.log_level == CommandLine.DEFAULT_LOG_LEVEL
 
     @pytest.mark.parametrize(
@@ -70,7 +69,6 @@ class TestCommandLineInterface:
             pytest.param("jobs", ["--jobs=4"], 4, int, id="jobs"),
             pytest.param("queue_size", ["--queue-size=100"], 100, int, id="queue-size"),
             pytest.param("part_size", ["--part-size=42"], 42, int, id="part-size"),
-            pytest.param("profile", ["--profile=foo"], "foo", str, id="profile"),
             pytest.param("endpoint_url", ["--endpoint-url=https://min.io"], "https://min.io", str, id="endpoint_url"),
         ],
     )

--- a/ci/teamcity/Delft3D/settings.kts
+++ b/ci/teamcity/Delft3D/settings.kts
@@ -180,17 +180,17 @@ project {
             userName = "%delft3d-user%"
             password = "%delft3d-secret%"
         }
-        awsConnection {
-            id = "doc_download_connection"
-            name = "Deltares MinIO connection"
-            credentialsType = static {
-                accessKeyId = DslContext.getParameter("s3_dsctestbench_accesskey")
-                secretAccessKey = "credentialsJSON:7e8a3aa7-76e9-4211-a72e-a3825ad1a160"
-                useSessionCredentials = false
-            }
-            allowInSubProjects = true
-            allowInBuilds = true
-        }
+        // awsConnection {
+        //     id = "doc_download_connection"
+        //     name = "Deltares MinIO connection"
+        //     credentialsType = static {
+        //         accessKeyId = DslContext.getParameter("s3_dsctestbench_accesskey")
+        //         secretAccessKey = "credentialsJSON:7e8a3aa7-76e9-4211-a72e-a3825ad1a160"
+        //         useSessionCredentials = false
+        //     }
+        //     allowInSubProjects = true
+        //     allowInBuilds = true
+        // }
         feature {
             type = "OAuthProvider"
             param("displayName", "Keeper Vault Delft3d")

--- a/ci/teamcity/Delft3D/settings.kts
+++ b/ci/teamcity/Delft3D/settings.kts
@@ -180,17 +180,6 @@ project {
             userName = "%delft3d-user%"
             password = "%delft3d-secret%"
         }
-        // awsConnection {
-        //     id = "doc_download_connection"
-        //     name = "Deltares MinIO connection"
-        //     credentialsType = static {
-        //         accessKeyId = DslContext.getParameter("s3_dsctestbench_accesskey")
-        //         secretAccessKey = "credentialsJSON:7e8a3aa7-76e9-4211-a72e-a3825ad1a160"
-        //         useSessionCredentials = false
-        //     }
-        //     allowInSubProjects = true
-        //     allowInBuilds = true
-        // }
         feature {
             type = "OAuthProvider"
             param("displayName", "Keeper Vault Delft3d")

--- a/ci/teamcity/Delft3D/template/downloadFromS3.kt
+++ b/ci/teamcity/Delft3D/template/downloadFromS3.kt
@@ -49,8 +49,6 @@ object TemplateDownloadFromS3 : Template({
             command = module {
                 module = "ci_tools.minio.synchronize.cli"
                 scriptArguments = """
-                    --aws-access-key-id=%env.AWS_ACCESS_KEY_ID%
-                    --aws-secret-access-key=%env.AWS_SECRET_ACCESS_KEY%
                     --source=s3://dsc-testbench/cases/%engine_dir%/
                     --destination=%engine_dir%
                     "--timestamp=%env.TIME_ISO_8601%"

--- a/ci/teamcity/Delft3D/template/downloadFromS3.kt
+++ b/ci/teamcity/Delft3D/template/downloadFromS3.kt
@@ -2,7 +2,6 @@ package Delft3D.template
 
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
-import jetbrains.buildServer.configs.kotlin.buildFeatures.*
 import jetbrains.buildServer.configs.kotlin.triggers.*
 
 
@@ -21,6 +20,8 @@ object TemplateDownloadFromS3 : Template({
             regex = """^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4}$""",
             validationMessage = "format: 2025-04-03 14:25:08 +0000"
         )
+        param("env.AWS_ACCESS_KEY_ID", "%s3_dsctestbench_accesskey%")
+        param("env.AWS_SECRET_ACCESS_KEY", "%s3_dsctestbench_secret%")
     }
 
     steps {
@@ -48,6 +49,8 @@ object TemplateDownloadFromS3 : Template({
             command = module {
                 module = "ci_tools.minio.synchronize.cli"
                 scriptArguments = """
+                    --aws-access-key-id=%env.AWS_ACCESS_KEY_ID%
+                    --aws-secret-access-key=%env.AWS_SECRET_ACCESS_KEY%
                     --source=s3://dsc-testbench/cases/%engine_dir%/
                     --destination=%engine_dir%
                     "--timestamp=%env.TIME_ISO_8601%"
@@ -55,12 +58,6 @@ object TemplateDownloadFromS3 : Template({
                     --no-progress
                 """.trimIndent()
             }
-        }
-    }
-
-    features {
-        provideAwsCredentials {
-            awsConnectionId = "doc_download_connection"
         }
     }
 })


### PR DESCRIPTION
# What was done 

Removed the AWS connection and replaced it with static AWS connection credentials set by the environmental variables AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.
 
# Tests
Validation documentation [build](https://dpcbuild.deltares.nl/buildConfiguration/Temporary_PersonalBuildsMdj_Delft3DNexus_ValidationDocumentMatrix/7156514?buildTab=log&logView=flowAware&focusLine=0).
Functionality documentation [build](https://dpcbuild.deltares.nl/buildConfiguration/Temporary_PersonalBuildsMdj_Delft3DNexus_FunctionalityDocumentMatrix/7156520?buildTab=log&focusLine=0&logView=flowAware). These tests also fails in Delft3D main. But you can see the files are downloaded.

# Issue link
DEVOPSDSC-953