### PR TITLE
DEVOPSDSC-935: Update container run scripts for 2026.02 release

### DIFF
--- a/src/scripts_lgpl/singularity/submit_singularity_h7.sh
+++ b/src/scripts_lgpl/singularity/submit_singularity_h7.sh
@@ -26,8 +26,7 @@
  
 #--- Load modules (for use within Deltares) ------------------------------------------------------------------
 module purge
-module load apptainer/1.2.5     # Load the Apptainer container system software.
-module load intelmpi/2021.11.0   # Load the  message-passing library for parallel simulations.
+module load intelmpi/2021.17.2   # Load the  message-passing library for parallel simulations.
  
  
 #--- Setup the container ------------------------------------------------------------------------------------

--- a/src/scripts_lgpl/singularity/submit_singularity_snellius.sh
+++ b/src/scripts_lgpl/singularity/submit_singularity_snellius.sh
@@ -34,8 +34,8 @@
 
 echo "---Load modules..."
 module purge
-module load 2023
-module load intel/2023a
+module load 2025
+module load intel/2025b
 
 
 #---You will need to modify the input below this line---


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- Intel MPI module updated to 2021.17.2 in submit_singularity_h7.sh script
- Apptainer module removed from submit_singularity_h7.sh script. We'll use the default installation on h7 instead.
- Updated to 2025 software stack in submit_singularity_snellius.sh script, which includes Intel MPI 2021.16. 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/DEVOPSDSC-935