### PR TITLE
UNST-9861 Create minimal memory leak fix for xmltree. Fix small bugs …

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/cutcell_list.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/cutcell_list.f90
@@ -85,7 +85,7 @@ contains
 
       jastored = 0
 
-      inquire (FILE=md_cutcelllist, EXIST=JAWEL)
+      inquire (FILE=trim(md_cutcelllist), EXIST=JAWEL)
       NUMFIL = 0
       if (JAWEL) then
          call OLDFIL(MLIST, md_cutcelllist)

--- a/src/engines_gpl/dimr/packages/dimr_lib/include/dimr_component.h
+++ b/src/engines_gpl/dimr/packages/dimr_lib/include/dimr_component.h
@@ -39,20 +39,20 @@ typedef void(CDECLOPT* BMI_GETVARSHAPE)(const char*, int*);
 typedef struct dimr_component dimr_component;
 struct dimr_component
 {
-    const char* name; // Component name: must be unique in the config.xml file (e.g. myNameFlow)
-    char* library;    // Component library name, without extension/prefix
-    int type;         // COMP_TYPE_FM, COMP_TYPE_RTC or COMP_TYPE_WAVE
+    const char* name;    // Component name: must be unique in the config.xml file (e.g. myNameFlow)
+    const char* library; // Component library name, without extension/prefix
+    int type;            // COMP_TYPE_FM, COMP_TYPE_RTC or COMP_TYPE_WAVE
 #ifdef _WIN32
     HINSTANCE libHandle; // (Windows) Handle to the loaded library for this component.
 #else
     void* libHandle; // (Linux) Handle to the loaded library for this component.
 #endif
-    char* inputFile;  // Component inputFile name
-    char* workingDir; // Component working directory
-    int* processes;   // (Optional) list of processes ranks that this component needs to run in.
-    int numProcesses; // Count of processes array.
-    bool onThisRank;  // Whether this component needs to run on current process rank.
-    char* mpiCommVar; // (Optional) Variable name for component's MPI communicator (must be accesible via BMI).
+    const char* inputFile;  // Component inputFile name
+    const char* workingDir; // Component working directory (owned, heap-allocated)
+    int* processes;         // (Optional) list of processes ranks that this component needs to run in.
+    int numProcesses;       // Count of processes array.
+    bool onThisRank;        // Whether this component needs to run on current process rank.
+    const char* mpiCommVar; // (Optional) Variable name for component's MPI communicator (must be accesible via BMI).
     MPI_Comm mpiComm; // An MPI communicator specific for this component (may run on less processes than master dimr).
     BMI_INITIALIZE dllInitialize;         // entry point in dll
     BMI_UPDATE dllUpdate;                 // entry point in dll

--- a/src/engines_gpl/dimr/packages/dimr_lib/include/dimr_coupler.h
+++ b/src/engines_gpl/dimr/packages/dimr_lib/include/dimr_coupler.h
@@ -7,8 +7,8 @@ typedef struct dimr_coupler dimr_coupler;
 struct dimr_coupler
 {
     const char* name;                // Coupler name: must be unique in the config.xml file (e.g. rtc2flow)
-    char* sourceComponentName;       // Name of the component providing data to be communicated by the coupler
-    char* targetComponentName;       // Name of the component receiving data to be communicated by the coupler
+    const char* sourceComponentName; // Name of the component providing data to be communicated by the coupler
+    const char* targetComponentName; // Name of the component receiving data to be communicated by the coupler
     dimr_component* sourceComponent; // Pointer to the related component
     dimr_component* targetComponent; // idem
     unsigned int numItems;

--- a/src/engines_gpl/dimr/packages/dimr_lib/include/xmltree.h
+++ b/src/engines_gpl/dimr/packages/dimr_lib/include/xmltree.h
@@ -98,6 +98,11 @@ public:
 
     void Print(void);
 
+    std::string charData;
+    XmlTree* parent;
+    std::vector<XmlTree*> children;
+    std::string name;
+
 private:
     void init(void);
 
@@ -107,21 +112,7 @@ private:
 
     static std::string EnvSubst(std::string instr);
 
-public:
-    static const int maxCharData = 1000000; // maximum size of an XML character data block
-    static const int maxPathname = 2560;    // maximum length of a full path name
-
-    XmlTree* parent;
-    char* name;
-    char* pathname;
-
-    std::vector<char*> attribNames;
-    std::vector<char*> attribValues;
-
-    std::vector<XmlTree*> children;
-
-    char* charData;
-    int charDataLen;
-
-private:
+    std::string pathname;
+    std::vector<std::string> attribNames;
+    std::vector<std::string> attribValues;
 };

--- a/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
@@ -1386,8 +1386,8 @@ void Dimr::receive_ptr(const char* name, const char* sourceName, int compType, B
     strcat(nameShape, "_shape");
     if (compType != COMP_TYPE_DSLE)
     {
-       //Setting nameshape in DSLE registers it as a constituent, which we do not want.
-       (dllSetVar)(nameShape, shape);
+        // Setting nameshape in DSLE registers it as a constituent, which we do not want.
+        (dllSetVar)(nameShape, shape);
     }
     // Finally: call setvar(name, pointer)
     (dllSetVar)(name, (void*)sourceVarPtr);
@@ -1594,7 +1594,7 @@ void Dimr::scanConfigFile(void)
                         configfile);
 
     // Check version number
-    const char* versionnr = fileversion->charData;
+    const char* versionnr = fileversion->charData.c_str();
     float versionnumber;
     int intRead = sscanf(versionnr, "%f", &versionnumber);
     if (intRead != 1)
@@ -1634,7 +1634,7 @@ void Dimr::scanGlobalSettings(XmlTree* rootXml)
     XmlTree* loggerNcFormat = globalSettings->Lookup("logger_ncFormat");
     if (loggerNcFormat != NULL)
     {
-        int intRead = sscanf(loggerNcFormat->charData, "%d", &(nc_mode));
+        int intRead = sscanf(loggerNcFormat->charData.c_str(), "%d", &(nc_mode));
         if (intRead != 1)
             throw Exception(Exception::ERR_INVALID_INPUT, "logger_ncFormat must contain the value 3 or 4");
         if (nc_mode == 3)
@@ -1663,7 +1663,7 @@ void Dimr::scanUnits(XmlTree* rootXml)
     // Scan
     for (int i = 0; i < rootXml->children.size(); i++)
     {
-        if (strcmp(rootXml->children[i]->name, "component") == 0)
+        if (rootXml->children[i]->name == "component")
         {
             componentsList.numComponents++;
             if (componentsList.components == NULL)
@@ -1682,7 +1682,7 @@ void Dimr::scanUnits(XmlTree* rootXml)
             }
             scanComponent(rootXml->children[i], &(componentsList.components[componentsList.numComponents - 1]));
         }
-        if (strcmp(rootXml->children[i]->name, "coupler") == 0)
+        if (rootXml->children[i]->name == "coupler")
         {
             couplersList.numCouplers++;
             if (couplersList.couplers == NULL)
@@ -1709,16 +1709,17 @@ void Dimr::scanComponent(XmlTree* xmlComponent, dimr_component* newComp)
     // Needed for path handling
     char* curPath = new char[MAXSTRING];
     if (!getcwd(curPath, MAXSTRING))
+    {
         throw Exception(Exception::ERR_OS, "ERROR obtaining the current working directory (scan)");
-    //
-    //
+    }
+
     newComp->name = xmlComponent->GetAttrib("name");
     // Element library
     XmlTree* libraryElement = xmlComponent->Lookup("library");
     if (libraryElement == NULL)
         throw Exception(Exception::ERR_INVALID_INPUT, "Component \"%s\" does not contain a library element",
                         newComp->name);
-    newComp->library = libraryElement->charData;
+    newComp->library = libraryElement->charData.c_str();
     int libLen = strlen(newComp->library);
     char* libNameLowercase = new char[libLen + 1];
     strncpy(libNameLowercase, newComp->library, libLen);
@@ -1788,7 +1789,7 @@ void Dimr::scanComponent(XmlTree* xmlComponent, dimr_component* newComp)
     if (processElement != NULL)
     {
         // Store process rank numbers in component's processes array.
-        char_to_ints(processElement->charData, &(newComp->processes), &(newComp->numProcesses));
+        char_to_ints(processElement->charData.c_str(), &(newComp->processes), &(newComp->numProcesses));
 
         // Check whether this process' rank is also in components configured processes array.
         newComp->onThisRank = false; // Not found (yet): only active on other ranks.
@@ -1830,7 +1831,7 @@ void Dimr::scanComponent(XmlTree* xmlComponent, dimr_component* newComp)
     if (commElement != NULL)
     {
         // Store communicator var name in component.
-        newComp->mpiCommVar = commElement->charData;
+        newComp->mpiCommVar = commElement->charData.c_str();
     }
     else
     {
@@ -1845,19 +1846,19 @@ void Dimr::scanComponent(XmlTree* xmlComponent, dimr_component* newComp)
     }
     else
     {
-        newComp->inputFile = inputFileElement->charData;
+        newComp->inputFile = inputFileElement->charData.c_str();
     }
     // Element workingDir
     XmlTree* workingDirElement = xmlComponent->Lookup("workingDir");
     if (workingDirElement == NULL)
     {
-        newComp->workingDir = (char*)&curPath;
+        newComp->workingDir = curPath;
         log->Write(INFO, my_rank, "WARNING: No workingDir specified for component %s.", newComp->name);
         log->Write(INFO, my_rank, "         workingDir is set to %s", newComp->workingDir);
     }
     else
     {
-        newComp->workingDir = workingDirElement->charData;
+        newComp->workingDir = workingDirElement->charData.c_str();
     }
     // Is workingDir a valid relative path?
     char* combinedPath = new char[MAXSTRING];
@@ -1899,7 +1900,7 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
     if (sourceComponent == NULL)
         throw Exception(Exception::ERR_INVALID_INPUT, "The coupler \"%s\" does not contain a sourceComponent element",
                         newCoup->name);
-    newCoup->sourceComponentName = sourceComponent->charData;
+    newCoup->sourceComponentName = sourceComponent->charData.c_str();
     // Add reference to the actual component acting as source
     newCoup->sourceComponent = getComponent(newCoup->sourceComponentName);
     // Element targetComponent
@@ -1907,7 +1908,7 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
     if (targetComponent == NULL)
         throw Exception(Exception::ERR_INVALID_INPUT, "The coupler \"%s\" does not contain a targetComponent element",
                         newCoup->name);
-    newCoup->targetComponentName = targetComponent->charData;
+    newCoup->targetComponentName = targetComponent->charData.c_str();
     // Add reference to the actual component acting as target
     newCoup->targetComponent = getComponent(newCoup->targetComponentName);
     // Items
@@ -1915,7 +1916,7 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
     newCoup->items = NULL;
     for (int j = 0; j < xmlCoupler->children.size(); j++)
     {
-        if (strcmp(xmlCoupler->children[j]->name, "item") == 0)
+        if (xmlCoupler->children[j]->name == "item")
         {
             // Create the item
             newCoup->numItems++;
@@ -1953,8 +1954,8 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
                 throw Exception(Exception::ERR_INVALID_INPUT,
                                 "The coupler \"%s\", item %d, does not contain a sourceName element", newCoup->name,
                                 newCoup->numItems);
-            newItem->sourceName = xmlSource->charData;
-            if (newItem->sourceName == NULL)
+            newItem->sourceName = xmlSource->charData.c_str();
+            if (xmlSource->charData.empty())
                 throw Exception(Exception::ERR_INVALID_INPUT,
                                 "Item %d of coupler \"%s\" does not contain a source::name element", newCoup->numItems,
                                 newCoup->name);
@@ -1965,8 +1966,8 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
                 throw Exception(Exception::ERR_INVALID_INPUT,
                                 "The coupler \"%s\", item %d, does not contain a targetName element", newCoup->name,
                                 newCoup->numItems);
-            newItem->targetName = xmlTarget->charData;
-            if (newItem->targetName == NULL)
+            newItem->targetName = xmlTarget->charData.c_str();
+            if (xmlTarget->charData.empty())
                 throw Exception(Exception::ERR_INVALID_INPUT,
                                 "Item %d of coupler \"%s\" does not contain a target::name element", newCoup->numItems,
                                 newCoup->name);
@@ -2005,59 +2006,62 @@ void Dimr::scanCoupler(XmlTree* xmlCoupler, dimr_coupler* newCoup)
 //------------------------------------------------------------------------------
 void Dimr::scanControl(XmlTree* controlBlockXml, dimr_control_block* controlBlock)
 {
-    if (strcmp(controlBlockXml->name, "control") == 0)
+    if (controlBlockXml->name == "control")
     {
         controlBlock->type = CT_SEQUENTIAL;
+        controlBlock->computeTimes = nullptr;
     }
-    else if (strcmp(controlBlockXml->name, "parallel") == 0)
+    else if (controlBlockXml->name == "parallel")
     {
         controlBlock->type = CT_PARALLEL;
+        controlBlock->computeTimes = nullptr;
     }
-    else if (strcmp(controlBlockXml->name, "start") == 0)
+    else if (controlBlockXml->name == "start")
     {
         controlBlock->type = CT_START;
         controlBlock->unit.component = getComponent(controlBlockXml->GetAttrib("name"));
         controlBlock->unit.coupler = NULL;
+        controlBlock->computeTimes = nullptr;
     }
-    else if (strcmp(controlBlockXml->name, "startGroup") == 0)
+    else if (controlBlockXml->name == "startGroup")
     {
         controlBlock->type = CT_STARTGROUP;
         XmlTree* timeElt = controlBlockXml->Lookup("time");
         if (timeElt == NULL)
             throw Exception(Exception::ERR_INVALID_INPUT,
-                            "The startGroup component \"%s\" does not contain a time element", controlBlockXml->name);
+                            "The startGroup component \"%s\" does not contain a time element",
+                            controlBlockXml->name.c_str());
         // The time field either contains:
         // - tStart, tStep, tStop                             , e.g. <time>0.0 3.6e3 9.99e4</time>
         // - name of a file containing computation time points, e.g. <time>wave_computations.tim</time>
         // First check whether it's the name of a file:
-        if (!readComputeTimesFile(timeElt->charData, controlBlock))
+        if (!readComputeTimesFile(timeElt->charData.c_str(), controlBlock))
         {
             // No, it's not the name of a file. Assume that it contains tStart, tStep, tStop
-            int intRead = sscanf(timeElt->charData, "%lf %lf %lf", &(controlBlock->tStart), &(controlBlock->tStep),
-                                 &(controlBlock->tEnd));
+            int intRead = sscanf(timeElt->charData.c_str(), "%lf %lf %lf", &(controlBlock->tStart),
+                                 &(controlBlock->tStep), &(controlBlock->tEnd));
             if (intRead != 3)
                 throw Exception(Exception::ERR_INVALID_INPUT,
                                 "'%s' must either contain 'tStart, tStep, tEnd' or the name of a time series file",
-                                timeElt->charData);
+                                timeElt->charData.c_str());
             // computeTimesCurrent>0 indicates a time series read from file
             controlBlock->computeTimesCurrent = -1;
         }
     }
-    else if (strcmp(controlBlockXml->name, "coupler") == 0)
+    else if (controlBlockXml->name == "coupler")
     {
         controlBlock->type = CT_COUPLER;
         controlBlock->unit.component = NULL;
         controlBlock->unit.coupler = getCoupler(controlBlockXml->GetAttrib("name"));
+        controlBlock->computeTimes = nullptr;
     }
     controlBlock->numSubBlocks = 0;
     controlBlock->subBlocks = NULL;
     controlBlock->masterSubBlockId = -1;
     for (int i = 0; i < controlBlockXml->children.size(); i++)
     {
-        if (strcmp(controlBlockXml->children[i]->name, "parallel") == 0 ||
-            strcmp(controlBlockXml->children[i]->name, "start") == 0 ||
-            strcmp(controlBlockXml->children[i]->name, "startGroup") == 0 ||
-            strcmp(controlBlockXml->children[i]->name, "coupler") == 0)
+        if (controlBlockXml->children[i]->name == "parallel" || controlBlockXml->children[i]->name == "start" ||
+            controlBlockXml->children[i]->name == "startGroup" || controlBlockXml->children[i]->name == "coupler")
         {
             controlBlock->numSubBlocks++;
             if (controlBlock->subBlocks == NULL)
@@ -2432,8 +2436,9 @@ void Dimr::freeLibs(void)
         DWORD ierr;
         SetLastError(0); /* clear error code */
         bool success = FreeLibrary(componentsList.components[i].libHandle);
-        if ((ierr = GetLastError()) != 0)
+        if (!success)
         {
+            ierr = GetLastError();
             throw Exception(Exception::ERR_OS, "Cannot free component library \"%s\". Return code: %d.",
                             componentsList.components[i].library, ierr);
         }

--- a/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/dimr.cpp
@@ -2433,12 +2433,11 @@ void Dimr::freeLibs(void)
                             componentsList.components[i].library, err);
         }
 #else
-        DWORD ierr;
         SetLastError(0); /* clear error code */
         bool success = FreeLibrary(componentsList.components[i].libHandle);
         if (!success)
         {
-            ierr = GetLastError();
+            DWORD ierr = GetLastError();
             throw Exception(Exception::ERR_OS, "Cannot free component library \"%s\". Return code: %d.",
                             componentsList.components[i].library, ierr);
         }

--- a/src/engines_gpl/dimr/packages/dimr_lib/src/xmltree.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/xmltree.cpp
@@ -109,7 +109,10 @@ namespace
         (*curnode)->AddChild(node);
         *curnode = node;
 
-        for (int i = 0; attr[i] != NULL && attr[i + 1] != NULL; i += 2) node->AddAttrib(attr[i], attr[i + 1]);
+        for (int i = 0; attr[i] != NULL && attr[i + 1] != NULL; i += 2)
+        {
+            node->AddAttrib(attr[i], attr[i + 1]);
+        }
     }
 
     void endtag(void* userdata, const XML_Char* name)
@@ -119,11 +122,7 @@ namespace
 
         if (!state->charData.empty())
         {
-            std::string trimmed = trim(state->charData);
-            if (!trimmed.empty())
-            {
-                (*curnode)->charData = std::move(trimmed);
-            }
+            (*curnode)->charData = trim(state->charData);
             state->charData.clear();
         }
 

--- a/src/engines_gpl/dimr/packages/dimr_lib/src/xmltree.cpp
+++ b/src/engines_gpl/dimr/packages/dimr_lib/src/xmltree.cpp
@@ -84,12 +84,62 @@
     #define strdup _strdup
 #endif
 
-static void starttag(void*, const XML_Char*, const XML_Char**);
-static void endtag(void*, const XML_Char*);
-static void chardata(void*, const XML_Char*, int);
+namespace
+{
+    std::string trim(const std::string& text, const char* whiteSpace = " \t\n\r")
+    {
+        const auto first = text.find_first_not_of(whiteSpace);
+        if (first == std::string::npos)
+        {
+            return {};
+        }
+        return text.substr(first, text.find_last_not_of(whiteSpace) - first + 1);
+    }
 
-static char CharDataBuffer[XmlTree::maxCharData];
-static int CharDataLen = 0;
+    struct ParseState
+    {
+        XmlTree** curnode;
+        std::string charData;
+    };
+
+    void starttag(void* userdata, const XML_Char* name, const XML_Char* attr[])
+    {
+        XmlTree** curnode = static_cast<ParseState*>(userdata)->curnode;
+        XmlTree* node = new XmlTree(*curnode, name);
+        (*curnode)->AddChild(node);
+        *curnode = node;
+
+        for (int i = 0; attr[i] != NULL && attr[i + 1] != NULL; i += 2) node->AddAttrib(attr[i], attr[i + 1]);
+    }
+
+    void endtag(void* userdata, const XML_Char* name)
+    {
+        ParseState* state = static_cast<ParseState*>(userdata);
+        XmlTree** curnode = state->curnode;
+
+        if (!state->charData.empty())
+        {
+            std::string trimmed = trim(state->charData);
+            if (!trimmed.empty())
+            {
+                (*curnode)->charData = std::move(trimmed);
+            }
+            state->charData.clear();
+        }
+
+        *curnode = (*curnode)->parent;
+    }
+
+    void chardata(void* userdata, const XML_Char* data, int len)
+    {
+        // Chardata is stuff between tags, including "comments".
+        // Add it to the end of the buffer. When the end tag is reached
+        // the data will be added to the node.
+
+        static_cast<ParseState*>(userdata)->charData.append(data, len);
+    }
+
+} // namespace
 
 //------------------------------------------------------------------------------
 
@@ -97,9 +147,10 @@ XmlTree::XmlTree(FILE* input)
 {
     this->init();
     XmlTree* currentNode = this;
+    ParseState state{&currentNode, {}};
 
     XML_Parser parser = XML_ParserCreate(NULL);
-    XML_SetUserData(parser, (void*)&currentNode);
+    XML_SetUserData(parser, (void*)&state);
 
     XML_SetElementHandler(parser, &starttag, &endtag);
     XML_SetCharacterDataHandler(parser, &chardata);
@@ -115,112 +166,34 @@ XmlTree::XmlTree(FILE* input)
     delete[] buffer;
 }
 
-static void starttag(void* userdata, const XML_Char* name, const XML_Char* attr[])
-{
-    XmlTree** curnode = (XmlTree**)userdata;
-    XmlTree* node = new XmlTree(*curnode, name);
-    (*curnode)->AddChild(node);
-    *curnode = node;
-
-    for (int i = 0; attr[i] != NULL && attr[i + 1] != NULL; i += 2) node->AddAttrib(attr[i], attr[i + 1]);
-}
-
-#define IS_WHITESPACE(X) ((X) == ' ' || (X) == '\t' || (X) == '\n' || (X) == '\r')
-
-static void endtag(void* userdata, const XML_Char* name)
-{
-    XmlTree** curnode = (XmlTree**)userdata;
-
-    if (CharDataLen > 0)
-    {
-        char* begin = CharDataBuffer;
-        while (IS_WHITESPACE(*begin)) begin++;
-
-        char* end = CharDataBuffer + CharDataLen - 1;
-        while (IS_WHITESPACE(*end)) end--;
-        *++end = '\0';
-
-        int len = strlen(begin);
-        (*curnode)->charData = new char[len + 1];
-        memcpy((*curnode)->charData, begin, len);
-        (*curnode)->charData[len] = '\0';
-        (*curnode)->charDataLen = len + 1;
-        CharDataLen = 0;
-    }
-
-    *curnode = (*curnode)->parent;
-}
-
-static void chardata(void* userdata, const XML_Char* data, int len)
-{
-    // Chardata is stuff between tags, including "comments".
-    // Add it to the end of a static buffer.  When the end tag is reached
-    // the data will be added to the node.
-
-    XmlTree** curnode = (XmlTree**)userdata;
-
-    if (len + CharDataLen >= sizeof CharDataBuffer)
-        throw Exception(Exception::ERR_XML_PARSING, "XML charcter data block exceeds buffer size (%d bytes)",
-                        sizeof CharDataBuffer);
-
-    memcpy(CharDataBuffer + CharDataLen, data, len);
-    CharDataLen += len;
-}
-
-//------------------------------------------------------------------------------
-
 XmlTree::XmlTree(XmlTree* parent, const char* name)
 {
     this->init();
 
-    const char* ppn;
-    if (parent == NULL)
-        ppn = "";
-    else
-        ppn = parent->pathname;
+    const std::string parentPathName = (parent == NULL) ? std::string() : parent->pathname;
 
-    int pathlen = strlen(ppn) + strlen(name) + 2;
-    if (pathlen > this->maxPathname)
-        throw Exception(Exception::ERR_XML_PARSING, " XML pathname for node \"%s\" is too long", name);
-
-    this->name = new char[strlen(name) + 1];
-    strcpy(this->name, name);
-
-    this->pathname = new char[pathlen];
-    sprintf(this->pathname, "%s/%s", ppn, name);
+    this->name = name;
+    this->pathname = parentPathName + "/" + name;
 
     this->parent = parent;
 }
 
-void XmlTree::init(void)
-{
-    this->name = (char*)"";
-    this->pathname = (char*)"";
-    this->parent = NULL;
-    this->charData = NULL;
-    this->charDataLen = 0;
-}
+void XmlTree::init(void) { this->parent = NULL; }
 
 XmlTree::~XmlTree(void)
 {
-    if (this->parent != NULL && this->name != NULL)
+    for (XmlTree* child : children)
     {
-        delete[] this->name;
-        delete[] this->pathname;
+        delete child;
     }
-
-    if (this->charData != NULL) delete[] this->charData;
 }
 
 //------------------------------------------------------------------------------
 
 void XmlTree::AddAttrib(const char* name, const char* value)
 {
-    this->attribNames.push_back(new char[strlen(name) + 1]);
-    this->attribValues.push_back(new char[strlen(value) + 1]);
-
-    strcpy(this->attribNames.back(), name);
-    strcpy(this->attribValues.back(), value);
+    this->attribNames.push_back(std::string(name));
+    this->attribValues.push_back(std::string(value));
 }
 
 void XmlTree::AddChild(XmlTree* child) { this->children.push_back(child); }
@@ -235,7 +208,7 @@ XmlTree* XmlTree::Lookup(const char* pathname, int instance)
 
     if (pathname[0] == '/')
     {
-        if (this->name[0] != '\0') return NULL;
+        if (!this->name.empty()) return NULL;
 
         pathname++; // skip leading slash
     }
@@ -243,31 +216,31 @@ XmlTree* XmlTree::Lookup(const char* pathname, int instance)
     //  Copy pathname and split first component and the remainder
     //  (think of a backwards dirname/basename)
 
-    char* path = new char[strlen(pathname) + 1];
-    strcpy(path, pathname);
-    char* remainder = strchr(path, '/');
-    if (remainder == NULL)
-        remainder = (char*)"";
-    else
-        *remainder++ = '\0';
+    std::string path = pathname;
+    std::string remainder;
+    auto slash = path.find('/');
+    if (slash != std::string::npos)
+    {
+        remainder = path.substr(slash + 1);
+        path.resize(slash);
+    }
 
     XmlTree* node = NULL;
     for (int i = 0; i < children.size(); i++)
     {
-        if (strcmp(path, this->children[i]->name) == 0)
+        if (this->children[i]->name == path)
         {
-            if (remainder[0] == '\0')
+            if (remainder.empty())
             {
                 if (instance-- > 0) continue;
                 node = this->children[i];
             }
             else
-                node = this->children[i]->Lookup(remainder, instance);
+                node = this->children[i]->Lookup(remainder.c_str(), instance);
             break;
         }
     }
 
-    delete[] path;
     return node;
 }
 
@@ -282,7 +255,7 @@ int XmlTree::Lookup(const char* pathname, int instance,
 {
     if (pathname[0] == '/')
     {
-        if (this->name[0] != '\0') return (NULL);
+        if (!this->name.empty()) return (NULL);
 
         pathname++; // skip leading slash
     }
@@ -290,22 +263,23 @@ int XmlTree::Lookup(const char* pathname, int instance,
     //  Copy pathname and split first component and the remainder
     //  (think of a backwards dirname/basename)
 
-    char* path = new char[strlen(pathname) + 1];
-    strcpy(path, pathname);
-    char* remainder = strchr(path, '/');
-    if (remainder == NULL)
-        remainder = (char*)"";
-    else
-        *remainder++ = '\0';
+    std::string path = pathname;
+    std::string remainder;
+    auto slash = path.find('/');
+    if (slash != std::string::npos)
+    {
+        remainder = path.substr(slash + 1);
+        path.resize(slash);
+    }
 
     XmlTree* node = NULL;
     int ncount = 0;
     kvlist = NULL;
     for (int i = 0; i < children.size(); i++)
     {
-        if (strcmp(path, children[i]->name) == 0)
+        if (children[i]->name == path)
         {
-            if (remainder[0] == '\0')
+            if (remainder.empty())
             {
                 if (instance-- > 0) continue;
                 node = this->children[i]; // found a node
@@ -324,11 +298,10 @@ int XmlTree::Lookup(const char* pathname, int instance,
                 ncount++;
             }
             else
-                this->children[i]->Lookup(remainder, instance); // found a path to descend
+                this->children[i]->Lookup(remainder.c_str(), instance); // found a path to descend
         }
     }
 
-    delete[] path;
     return (ncount);
 }
 
@@ -350,7 +323,7 @@ const char* XmlTree::GetAttrib(const char* name)
     }
 
     for (int i = 0; i < attribNames.size(); i++)
-        if (strcmp(name, this->attribNames[i]) == 0) return this->attribValues[i];
+        if (this->attribNames[i] == name) return this->attribValues[i].c_str();
 
     return NULL;
 }
@@ -393,7 +366,7 @@ const char* XmlTree::GetElement(const char* name)
     if (node == NULL)
         return NULL;
     else
-        return node->charData;
+        return node->charData.empty() ? nullptr : node->charData.c_str();
 }
 
 bool XmlTree::GetBoolElement(const char* name, bool defaultValue)
@@ -426,9 +399,10 @@ void XmlTree::print(int level)
     if (this->parent == NULL)
         printf("/ [ ");
     else
-        printf("%s [ ", this->pathname);
+        printf("%s [ ", this->pathname.c_str());
 
-    for (int i = 0; i < attribNames.size(); i++) printf("%s=%s ", this->attribNames[i], this->attribValues[i]);
+    for (int i = 0; i < attribNames.size(); i++)
+        printf("%s=%s ", this->attribNames[i].c_str(), this->attribValues[i].c_str());
 
     printf("]\n");
 
@@ -451,9 +425,7 @@ std::string XmlTree::SubstEnvVar(std::string instr)
             pos1 = instr.length();
         }
         env_key = instr.substr(pos0 + 2, pos1 - pos0 - 2);
-        size_t first = env_key.find_first_not_of(' '); // trim spaces from name
-        size_t last = env_key.find_last_not_of(' ');
-        std::string env_key_trunc = env_key.substr(first, last - first + 1);
+        const std::string env_key_trunc = trim(env_key, " ");
         const char* env_name = env_key_trunc.c_str();
         env_value = getenv(env_name);
         std::string rest_in = instr.substr(pos1 + 1);
@@ -472,26 +444,13 @@ void XmlTree::ExpandEnvironmentVariables() { return this->ExpandEnvironmentVaria
 
 void XmlTree::ExpandEnvironmentVariables(int instance)
 {
-    XmlTree* node = NULL;
-    char* orgstr;
-    std::string instr, outstr;
     for (int iattrib = 0; iattrib < attribValues.size(); iattrib++)
     {
-        orgstr = this->attribValues[iattrib];
-        instr = orgstr;
-        outstr = SubstEnvVar(instr) + '\0';
-        delete[] this->attribValues[iattrib];
-        this->attribValues[iattrib] = new char[outstr.length()];
-        outstr.copy(this->attribValues[iattrib], outstr.length());
+        this->attribValues[iattrib] = SubstEnvVar(this->attribValues[iattrib]);
     }
-    if (this->charData != NULL)
+    if (!this->charData.empty())
     {
-        orgstr = this->charData;
-        instr = orgstr;
-        outstr = SubstEnvVar(instr) + '\0';
-        delete[] this->charData;
-        this->charData = new char[outstr.length()];
-        outstr.copy(this->charData, outstr.length());
+        this->charData = SubstEnvVar(this->charData);
     }
 
     for (int i = 0; i < children.size(); i++)


### PR DESCRIPTION
…in error logging.

# What was done 

<a short description with bullets> 

This is a safe subset of pull request https://github.com/Deltares/Delft3D/pull/815. Solving all memory leaks using a singleton pattern appears to cause a static destruction order fiasco, so I only focused on keeping some bug fixes and keeping the memory leak fixes in xmltree

- Fix small issue where inquire accesses trailing whitespace in Fortran code
- Inside xmltree, use std::string over allocated char*. Make the fields private that can be private.
- Fix bug where workingDir was assigned to a pointer to pointer cast to a char * (garbage): newComp->workingDir = (char*)&curPath;
- Store the charDataStr (xmltree) in a state variable of the library, instead of in global data, so that there is no global std::string with constructors/destructors that can cause issues
- Properly delete all children of the XML nodes

 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
