### PR TITLE
added parsing of csv file (output from teamcity case list) as input f…

### DIFF
--- a/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
+++ b/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
@@ -3,6 +3,7 @@
 Copyright (C)  Stichting Deltares, 2026
 """
 
+import csv
 import getpass
 import os
 from argparse import ArgumentParser, Namespace
@@ -63,7 +64,7 @@ class TestBenchParameterParser:
         # Additionally, extra TeamCity messages will be produced.
         settings.teamcity = cls.__get_argument_value("teamcity", args) or False
 
-        settings.filter = args.filter
+        settings.filter = cls.__resolve_filter(args.filter)
         # Determine type of run
         settings.run_mode = cls.__get_argument_value("run_mode", args) or ModeType.LIST
         settings.config_file = cls.__get_argument_value("config", args) or "config.xml"
@@ -72,6 +73,70 @@ class TestBenchParameterParser:
         settings.skip_post_processing = cls.__get_argument_value("skip_post_processing", args) or False
 
         return settings
+
+    @classmethod
+    def __resolve_filter(cls, filter_arg: str) -> str:
+        """Resolve the filter argument.
+
+        If the filter argument points to an existing CSV file, extract all
+        test names from the 'Test Name' column where 'Status' equals 'Failure'
+        and convert them into a ``testcase=name1,name2,...`` filter string.
+        Otherwise the original value is returned unchanged.
+
+        Parameters
+        ----------
+        filter_arg : str
+            The raw value passed to ``--filter``.
+
+        Returns
+        -------
+        str
+            The resolved filter string.
+        """
+        if not filter_arg or not os.path.isfile(filter_arg):
+            return filter_arg
+
+        failed_names = cls.__read_failed_tests_from_csv(filter_arg)
+        if not failed_names:
+            return filter_arg
+
+        return f"testcase={','.join(failed_names)}"
+
+    @classmethod
+    def __read_failed_tests_from_csv(cls, csv_path: str) -> List[str]:
+        """Read test names with a 'Failure' status from a CSV file.
+
+        Parameters
+        ----------
+        csv_path : str
+            Path to the CSV file with columns including 'Test Name' and 'Status'.
+
+        Returns
+        -------
+        List[str]
+            Names of all tests whose status is 'Failure'.
+
+        Raises
+        ------
+        ValueError
+            If the CSV file is missing the required 'Test Name' or 'Status' columns.
+        """
+        failed: List[str] = []
+        with open(csv_path, newline="", encoding="utf-8") as csv_file:
+            reader = csv.DictReader(csv_file)
+            required_columns = {"Test Name", "Status"}
+            if not required_columns.issubset(reader.fieldnames or []):
+                missing = required_columns - set(reader.fieldnames or [])
+                raise ValueError(
+                    f"CSV file '{csv_path}' is missing required columns: {missing}. "
+                    f"Found: {reader.fieldnames}"
+                )
+            for row in reader:
+                if row.get("Status", "").strip() == "Failure":
+                    name = row.get("Test Name", "").strip()
+                    if name:
+                        failed.append(name)
+        return failed
 
     @classmethod
     def __get_argument_value(
@@ -175,7 +240,11 @@ class TestBenchParameterParser:
         parser.add_argument(
             "--filter",
             default="",
-            help="Specify what tests to run based on filter (--list for options)",
+            help=(
+                "Specify what tests to run based on filter (--list for options). "
+                "Alternatively, provide a path to a CSV file with 'Test Name' and 'Status' columns "
+                "to automatically filter on all tests with status 'Failure'."
+            ),
             dest="filter",
         )
         parser.add_argument(

--- a/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
+++ b/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
@@ -7,7 +7,8 @@ import csv
 import getpass
 import os
 from argparse import ArgumentParser, Namespace
-from typing import Any, List, Optional
+from typing import Any, List, Optional, TextIO
+from pathlib import Path
 
 from src.config.credentials import Credentials
 from src.config.types.mode_type import ModeType
@@ -64,7 +65,17 @@ class TestBenchParameterParser:
         # Additionally, extra TeamCity messages will be produced.
         settings.teamcity = cls.__get_argument_value("teamcity", args) or False
 
-        settings.filter = cls.__resolve_filter(args.filter)
+        settings.filter = args.filter
+        filter_csv = cls.__get_argument_value("filter_csv", args)
+        if filter_csv:
+            filter_csv_path = Path(filter_csv)
+            if not filter_csv_path.is_file():
+                parser.error(f"--filter-csv: file not found: '{filter_csv_path}'")
+            with filter_csv_path.open(newline="", encoding="utf-8") as csv_file:
+                failed_names = cls.read_failed_tests_from_csv(csv_file)
+            if failed_names:
+                settings.filter = f"testcase={','.join(failed_names)}"
+
         # Determine type of run
         settings.run_mode = cls.__get_argument_value("run_mode", args) or ModeType.LIST
         settings.config_file = cls.__get_argument_value("config", args) or "config.xml"
@@ -74,42 +85,14 @@ class TestBenchParameterParser:
 
         return settings
 
-    @classmethod
-    def __resolve_filter(cls, filter_arg: str) -> str:
-        """Resolve the filter argument.
-
-        If the filter argument points to an existing CSV file, extract all
-        test names from the 'Test Name' column where 'Status' equals 'Failure'
-        and convert them into a ``testcase=name1,name2,...`` filter string.
-        Otherwise the original value is returned unchanged.
-
-        Parameters
-        ----------
-        filter_arg : str
-            The raw value passed to ``--filter``.
-
-        Returns
-        -------
-        str
-            The resolved filter string.
-        """
-        if not filter_arg or not os.path.isfile(filter_arg):
-            return filter_arg
-
-        failed_names = cls.__read_failed_tests_from_csv(filter_arg)
-        if not failed_names:
-            return filter_arg
-
-        return f"testcase={','.join(failed_names)}"
-
-    @classmethod
-    def __read_failed_tests_from_csv(cls, csv_path: str) -> List[str]:
+    @staticmethod
+    def read_failed_tests_from_csv(csv_file: TextIO) -> List[str]:
         """Read test names with a 'Failure' status from a CSV file.
 
         Parameters
         ----------
-        csv_path : str
-            Path to the CSV file with columns including 'Test Name' and 'Status'.
+        csv_file : TextIO
+            Opened CSV file with columns including 'Test Name' and 'Status'.
 
         Returns
         -------
@@ -121,22 +104,16 @@ class TestBenchParameterParser:
         ValueError
             If the CSV file is missing the required 'Test Name' or 'Status' columns.
         """
-        failed: List[str] = []
-        with open(csv_path, newline="", encoding="utf-8") as csv_file:
-            reader = csv.DictReader(csv_file)
-            required_columns = {"Test Name", "Status"}
-            if not required_columns.issubset(reader.fieldnames or []):
-                missing = required_columns - set(reader.fieldnames or [])
-                raise ValueError(
-                    f"CSV file '{csv_path}' is missing required columns: {missing}. "
-                    f"Found: {reader.fieldnames}"
-                )
-            for row in reader:
-                if row.get("Status", "").strip() == "Failure":
-                    name = row.get("Test Name", "").strip()
-                    if name:
-                        failed.append(name)
-        return failed
+        reader = csv.DictReader(csv_file)
+        required_columns = {"Test Name", "Status"}
+        if not required_columns.issubset(reader.fieldnames or []):
+            missing = required_columns - set(reader.fieldnames or [])
+            raise ValueError(f"CSV file is missing required columns: {missing}. " f"Found: {reader.fieldnames}")
+        return [
+            row["Test Name"].strip()
+            for row in reader
+            if row.get("Status", "").strip() == "Failure" and row.get("Test Name", "").strip()
+        ]
 
     @classmethod
     def __get_argument_value(
@@ -237,15 +214,21 @@ class TestBenchParameterParser:
             help="Path to config file, if empty default config file is used",
             dest="config",
         )
-        parser.add_argument(
+        filter_group = parser.add_mutually_exclusive_group()
+        filter_group.add_argument(
             "--filter",
             default="",
-            help=(
-                "Specify what tests to run based on filter (--list for options). "
-                "Alternatively, provide a path to a CSV file with 'Test Name' and 'Status' columns "
-                "to automatically filter on all tests with status 'Failure'."
-            ),
+            help="Specify what tests to run based on filter (--list for options)",
             dest="filter",
+        )
+        filter_group.add_argument(
+            "--filter-csv",
+            default=None,
+            help=(
+                "Path to a CSV file with 'Test Name' and 'Status' columns. "
+                "All tests with status 'Failure' will be used as the testcase filter."
+            ),
+            dest="filter_csv",
         )
         parser.add_argument(
             "--log-level",
@@ -297,14 +280,12 @@ class TestBenchParameterParser:
             "--username",
             help="Server username (e.g. git, SVN, MinIO).",
             default=None,
-            # required=True,
             dest="username",
         )
         parser.add_argument(
             "--password",
             help="Server password (e.g. git, SVN, MinIO).",
             default=None,
-            # required=True,
             dest="password",
         )
         parser.add_argument(

--- a/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
+++ b/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
@@ -7,8 +7,8 @@ import csv
 import getpass
 import os
 from argparse import ArgumentParser, Namespace
-from typing import Any, List, Optional, TextIO
 from pathlib import Path
+from typing import Any, List, Optional, TextIO
 
 from src.config.credentials import Credentials
 from src.config.types.mode_type import ModeType

--- a/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
+++ b/test/deltares_testbench/src/utils/test_bench_parameter_parser.py
@@ -70,7 +70,7 @@ class TestBenchParameterParser:
         if filter_csv:
             filter_csv_path = Path(filter_csv)
             if not filter_csv_path.is_file():
-                parser.error(f"--filter-csv: file not found: '{filter_csv_path}'")
+                parser.error(f"--filter-tc-csv: file not found: '{filter_csv_path}'")
             with filter_csv_path.open(newline="", encoding="utf-8") as csv_file:
                 failed_names = cls.read_failed_tests_from_csv(csv_file)
             if failed_names:
@@ -222,7 +222,7 @@ class TestBenchParameterParser:
             dest="filter",
         )
         filter_group.add_argument(
-            "--filter-csv",
+            "--filter-tc-csv",
             default=None,
             help=(
                 "Path to a CSV file with 'Test Name' and 'Status' columns. "

--- a/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
+++ b/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
@@ -79,7 +79,7 @@ class TestTestBenchParameterParser:
 
     @staticmethod
     def test_filter_csv_nonexistent_file_aborts(override_command_line_args) -> None:
-        override_command_line_args.extend(["--filter-csv", "/nonexistent/path/tests.csv"])
+        override_command_line_args.extend(["--filter-tc-csv", "/nonexistent/path/tests.csv"])
 
         with pytest.raises(SystemExit) as exc_info:
             TestBenchParameterParser().parse_arguments_to_settings()
@@ -90,7 +90,7 @@ class TestTestBenchParameterParser:
     def test_filter_and_filter_csv_are_mutually_exclusive(override_command_line_args, tmp_path: Path) -> None:
         csv_file = tmp_path / "tests.csv"
         csv_file.write_text("Order#,Test Name,Status\n1,test_a,Failure\n", encoding="utf-8")
-        override_command_line_args.extend(["--filter", "testcase=something", "--filter-csv", str(csv_file)])
+        override_command_line_args.extend(["--filter", "testcase=something", "--filter-tc-csv", str(csv_file)])
 
         with pytest.raises(SystemExit) as exc_info:
             TestBenchParameterParser().parse_arguments_to_settings()

--- a/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
+++ b/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
@@ -1,4 +1,5 @@
 import sys
+from pathlib import Path
 
 import pytest
 
@@ -20,6 +21,14 @@ class TestTestBenchParameterParser:
     def override_command_line_args_with_server_base_url(self, override_command_line_args):
         override_command_line_args.extend(["--server-base-url", "https://abcdef.ij"])
         return sys.argv
+
+    @pytest.fixture()
+    def override_command_line_args_with_filter(self, override_command_line_args):
+        def _set_filter(value: str):
+            override_command_line_args.extend(["--filter", value])
+            return sys.argv
+
+        return _set_filter
 
     @staticmethod
     def test_parse_arguments_default_server_base_url(override_command_line_args) -> None:
@@ -44,3 +53,89 @@ class TestTestBenchParameterParser:
 
         # Assert
         assert settings.server_base_url == "https://abcdef.ij"
+
+    @staticmethod
+    def test_filter_csv_extracts_failed_tests(
+        override_command_line_args_with_filter, tmp_path: Path
+    ) -> None:
+        # Arrange
+        csv_file = tmp_path / "tests.csv"
+        csv_file.write_text(
+            "Order#,Test Name,Status,Duration(ms)\n"
+            "1,test_passing,OK,100\n"
+            "2,test_failing_a,Failure,200\n"
+            "3,test_failing_b,Failure,300\n",
+            encoding="utf-8",
+        )
+        override_command_line_args_with_filter(str(csv_file))
+        parser = TestBenchParameterParser()
+
+        # Act
+        settings = parser.parse_arguments_to_settings()
+
+        # Assert
+        assert settings.filter == "testcase=test_failing_a,test_failing_b"
+
+    @staticmethod
+    def test_filter_csv_with_no_failures_returns_path_unchanged(
+        override_command_line_args_with_filter, tmp_path: Path
+    ) -> None:
+        # Arrange
+        csv_file = tmp_path / "tests.csv"
+        csv_file.write_text(
+            "Order#,Test Name,Status,Duration(ms)\n"
+            "1,test_passing_a,OK,100\n"
+            "2,test_passing_b,OK,200\n",
+            encoding="utf-8",
+        )
+        override_command_line_args_with_filter(str(csv_file))
+        parser = TestBenchParameterParser()
+
+        # Act
+        settings = parser.parse_arguments_to_settings()
+
+        # Assert — no failures found, falls back to the raw argument
+        assert settings.filter == str(csv_file)
+
+    @staticmethod
+    def test_filter_plain_string_is_passed_through(
+        override_command_line_args_with_filter,
+    ) -> None:
+        # Arrange
+        override_command_line_args_with_filter("testcase=some_test")
+        parser = TestBenchParameterParser()
+
+        # Act
+        settings = parser.parse_arguments_to_settings()
+
+        # Assert
+        assert settings.filter == "testcase=some_test"
+
+    @staticmethod
+    def test_filter_empty_string_is_passed_through(override_command_line_args) -> None:
+        # Arrange — no --filter argument supplied, default is ""
+        parser = TestBenchParameterParser()
+
+        # Act
+        settings = parser.parse_arguments_to_settings()
+
+        # Assert
+        assert settings.filter == ""
+
+    @staticmethod
+    def test_filter_csv_missing_required_columns_raises(
+        override_command_line_args_with_filter, tmp_path: Path
+    ) -> None:
+        # Arrange
+        csv_file = tmp_path / "tests.csv"
+        csv_file.write_text(
+            "Order#,TestName,Result\n"
+            "1,test_a,Failure\n",
+            encoding="utf-8",
+        )
+        override_command_line_args_with_filter(str(csv_file))
+        parser = TestBenchParameterParser()
+
+        # Act / Assert
+        with pytest.raises(ValueError, match="missing required columns"):
+            parser.parse_arguments_to_settings()

--- a/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
+++ b/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
@@ -1,3 +1,4 @@
+import io
 import sys
 from pathlib import Path
 
@@ -21,14 +22,6 @@ class TestTestBenchParameterParser:
     def override_command_line_args_with_server_base_url(self, override_command_line_args):
         override_command_line_args.extend(["--server-base-url", "https://abcdef.ij"])
         return sys.argv
-
-    @pytest.fixture()
-    def override_command_line_args_with_filter(self, override_command_line_args):
-        def _set_filter(value: str):
-            override_command_line_args.extend(["--filter", value])
-            return sys.argv
-
-        return _set_filter
 
     @staticmethod
     def test_parse_arguments_default_server_base_url(override_command_line_args) -> None:
@@ -55,87 +48,51 @@ class TestTestBenchParameterParser:
         assert settings.server_base_url == "https://abcdef.ij"
 
     @staticmethod
-    def test_filter_csv_extracts_failed_tests(
-        override_command_line_args_with_filter, tmp_path: Path
-    ) -> None:
-        # Arrange
-        csv_file = tmp_path / "tests.csv"
-        csv_file.write_text(
+    def test_read_failed_tests_from_csv_returns_failed_names() -> None:
+        csv_content = io.StringIO(
             "Order#,Test Name,Status,Duration(ms)\n"
             "1,test_passing,OK,100\n"
             "2,test_failing_a,Failure,200\n"
-            "3,test_failing_b,Failure,300\n",
-            encoding="utf-8",
+            "3,test_failing_b,Failure,300\n"
         )
-        override_command_line_args_with_filter(str(csv_file))
-        parser = TestBenchParameterParser()
 
-        # Act
-        settings = parser.parse_arguments_to_settings()
+        result = TestBenchParameterParser.read_failed_tests_from_csv(csv_content)
 
-        # Assert
-        assert settings.filter == "testcase=test_failing_a,test_failing_b"
+        assert result == ["test_failing_a", "test_failing_b"]
 
     @staticmethod
-    def test_filter_csv_with_no_failures_returns_path_unchanged(
-        override_command_line_args_with_filter, tmp_path: Path
-    ) -> None:
-        # Arrange
-        csv_file = tmp_path / "tests.csv"
-        csv_file.write_text(
-            "Order#,Test Name,Status,Duration(ms)\n"
-            "1,test_passing_a,OK,100\n"
-            "2,test_passing_b,OK,200\n",
-            encoding="utf-8",
+    def test_read_failed_tests_from_csv_no_failures_returns_empty() -> None:
+        csv_content = io.StringIO(
+            "Order#,Test Name,Status,Duration(ms)\n" "1,test_passing_a,OK,100\n" "2,test_passing_b,OK,200\n"
         )
-        override_command_line_args_with_filter(str(csv_file))
-        parser = TestBenchParameterParser()
 
-        # Act
-        settings = parser.parse_arguments_to_settings()
+        result = TestBenchParameterParser.read_failed_tests_from_csv(csv_content)
 
-        # Assert — no failures found, falls back to the raw argument
-        assert settings.filter == str(csv_file)
+        assert result == []
 
     @staticmethod
-    def test_filter_plain_string_is_passed_through(
-        override_command_line_args_with_filter,
-    ) -> None:
-        # Arrange
-        override_command_line_args_with_filter("testcase=some_test")
-        parser = TestBenchParameterParser()
+    def test_read_failed_tests_from_csv_missing_columns_raises() -> None:
+        csv_content = io.StringIO("Order#,TestName,Result\n" "1,test_a,Failure\n")
 
-        # Act
-        settings = parser.parse_arguments_to_settings()
-
-        # Assert
-        assert settings.filter == "testcase=some_test"
-
-    @staticmethod
-    def test_filter_empty_string_is_passed_through(override_command_line_args) -> None:
-        # Arrange — no --filter argument supplied, default is ""
-        parser = TestBenchParameterParser()
-
-        # Act
-        settings = parser.parse_arguments_to_settings()
-
-        # Assert
-        assert settings.filter == ""
-
-    @staticmethod
-    def test_filter_csv_missing_required_columns_raises(
-        override_command_line_args_with_filter, tmp_path: Path
-    ) -> None:
-        # Arrange
-        csv_file = tmp_path / "tests.csv"
-        csv_file.write_text(
-            "Order#,TestName,Result\n"
-            "1,test_a,Failure\n",
-            encoding="utf-8",
-        )
-        override_command_line_args_with_filter(str(csv_file))
-        parser = TestBenchParameterParser()
-
-        # Act / Assert
         with pytest.raises(ValueError, match="missing required columns"):
-            parser.parse_arguments_to_settings()
+            TestBenchParameterParser.read_failed_tests_from_csv(csv_content)
+
+    @staticmethod
+    def test_filter_csv_nonexistent_file_aborts(override_command_line_args) -> None:
+        override_command_line_args.extend(["--filter-csv", "/nonexistent/path/tests.csv"])
+
+        with pytest.raises(SystemExit) as exc_info:
+            TestBenchParameterParser().parse_arguments_to_settings()
+
+        assert exc_info.value.code == 2
+
+    @staticmethod
+    def test_filter_and_filter_csv_are_mutually_exclusive(override_command_line_args, tmp_path: Path) -> None:
+        csv_file = tmp_path / "tests.csv"
+        csv_file.write_text("Order#,Test Name,Status\n1,test_a,Failure\n", encoding="utf-8")
+        override_command_line_args.extend(["--filter", "testcase=something", "--filter-csv", str(csv_file)])
+
+        with pytest.raises(SystemExit) as exc_info:
+            TestBenchParameterParser().parse_arguments_to_settings()
+
+        assert exc_info.value.code == 2

--- a/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
+++ b/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
@@ -1,9 +1,7 @@
 import io
 import sys
-from pathlib import Path
-
 import pytest
-
+from pathlib import Path
 from src.utils.test_bench_parameter_parser import TestBenchParameterParser
 
 

--- a/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
+++ b/test/deltares_testbench/test/utils/test_TestBenchParameterParser.py
@@ -1,7 +1,9 @@
 import io
 import sys
-import pytest
 from pathlib import Path
+
+import pytest
+
 from src.utils.test_bench_parameter_parser import TestBenchParameterParser
 
 


### PR DESCRIPTION
…or run_testbench.py

# What was done 

<a short description with bullets> 

- added .csv parser to the --filter argument of testbench.py, so that you can easily run a list of failed testcases downloaded from teamcity
 

# Evidence of the work done 

<img width="2542" height="188" alt="image" src="https://github.com/user-attachments/assets/7f94125c-59f2-4402-8c22-d5c614a4572f" />

<img width="3040" height="209" alt="image" src="https://github.com/user-attachments/assets/3c1a7668-6c68-4a5c-b5e6-ee27c4edee7b" />

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
