### PR TITLE
UNST-9877: improve warning messages

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
@@ -71,7 +71,7 @@ contains
                                      ipnt_ws1, ipnt_sed, ipnt_smx, smxobs, ipnt_zws, ipnt_vicwws, ipnt_difwws, ipnt_bruv, ipnt_richs, ival_seddif1, &
                                      ival_seddifn, ipnt_seddif1, ipnt_zwu, ipnt_vicwwu, ipnt_tkin, ipnt_teps, ipnt_rich, ipnt_rain, ipnt_airdensity, &
                                      ipnt_infiltcap, ipnt_infiltact, ipnt_wind, ipnt_tair, ipnt_rhum, ipnt_clou, ipnt_qsun, ipnt_qeva, ipnt_qcon, &
-                                     ipnt_qlon, ipnt_qfre, ipnt_qfrc, ipnt_qtot, neighbour_nodes_obs, neighbour_weights_obs, intobs, xobs, yobs
+                                     ipnt_qlon, ipnt_qfre, ipnt_qfrc, ipnt_qtot, neighbour_nodes_obs, neighbour_weights_obs, intobs, xobs, yobs, namobs
       use m_sediment, only: stm_included, stmpar, ustokes, hwav, twav, phiwav, rlabda, uorb, sedtra, fp, mtd, sed
       use Timers, only: timon, timstrt, timstop
       use m_gettaus, only: gettaus
@@ -231,8 +231,8 @@ contains
          if ((intobs(i) == 0) .or. (neighbour_nodes_obs(1, i) == 0)) then
             ! Treat snapped stations as interpolated ones!
             ! And treat interpolated ones that could not have been interpolated as snapped ones (because they are out of interpolation boundaries)
-            if (intobs(i) /= 0) then
-               write (msgbuf, '(a, i0, a, f0.10, a, f0.10, a)') "Unable to interpolate #", i, " (", xobs(i), ", ", yobs(i), "). It's probably at the edge and will be snapped!"
+            if (intobs(i) /= 0 .and. kobs(i) /= 0) then
+               write (msgbuf, '(a, a, a, f0.10, a, f0.10, a)') "Unable to interpolate ", trim(namobs(i)), " (", xobs(i), ", ", yobs(i), ").  It is probably located near the grid boundary and therefore snapped."
                call mess(LEVEL_WARN, msgbuf)
             end if
             neighbour_nodes_obs(1, i) = k

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_find_flownode.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_find_flownode.f90
@@ -125,7 +125,7 @@ contains
 
       do i = 1, n
          if (node_nrs_nearest(i) == 0) then
-            write (msgbuf, '(a,i0,a,a,a)') 'Could not find flowcell for point #', i, ' (', trim(names(i)), '). Discarding.'
+            write (msgbuf, '(a,i0,a,a,a,f0.10,a,f0.10,a)') 'Could not find flowcell for point #', i, ' (', trim(names(i)), ') (', xx(i), ', ', yy(i), '). Discarding.'
             call msg_flush()
          end if
       end do


### PR DESCRIPTION
# What was done 

Reworked warning messages

# Evidence of the work done 

- [x ]	Video/figures
```
** INFO   : Could not find flowcell for point #3 (c) (2470.1652830000, -39.5665890000). Discarding.
** INFO   : Could not find flowcell for point #6 (L1_0003) (2470.1652830000, -39.5665890000). Discarding.
** WARNING: find_flowlinks: point      3([x, y] = [     2470.1653,      -39.5666]) lies outside of the model grid; closest flowlink might be inaccurate
** WARNING: find_flowlinks: point      6([x, y] = [     2470.1653,      -39.5666]) lies outside of the model grid; closest flowlink might be inaccurate
** WARNING: Unable to interpolate L1_0002 (2470.1652830000, 30.5640260000).  It is probably located near the grid boundary and therefore snapped.
 
```
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9877