### PR TITLE
UNST-9558: Add testcases for anticreep = 1 in z- and z-sigma-simulations

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -730,7 +730,7 @@
     </testCase>
 
     <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
-      <path version="2026-04-05T16:00:00">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -745,7 +745,7 @@
     </testCase>
 
     <testCase name="e02_f021_c003_slopingbed_anticreep_z" ref="dflowfm_default">
-      <path version="2026-04-05T16:00:00">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
+      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -730,7 +730,7 @@
     </testCase>
 
     <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
-      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <path version="2025-10-07T06:58:02.648000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -760,7 +760,7 @@
     </testCase>
 
     <testCase name="e02_f021_c004_slopingbed_anticreep_z_sigma" ref="dflowfm_default">
-      <path version="2025-10-07T06:58:02.648000">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
+      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -730,7 +730,37 @@
     </testCase>
 
     <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
-      <path version="2025-10-07T06:58:02.648000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <path version="2026-04-05T16:00:00">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <maxRunTime>15000.0000000</maxRunTime>
+      <checks>
+        <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_s1" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_ucx" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_ucy" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+
+    <testCase name="e02_f021_c003_slopingbed_anticreep_z" ref="dflowfm_default">
+      <path version="2026-04-05T16:00:00">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
+      <maxRunTime>15000.0000000</maxRunTime>
+      <checks>
+        <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_s1" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_ucx" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_ucy" toleranceAbsolute="0.0001" />
+            <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+
+    <testCase name="e02_f021_c004_slopingbed_anticreep_z_sigma" ref="dflowfm_default">
+      <path version="2025-10-07T06:58:02.648000">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">


### PR DESCRIPTION
# What was done 
- Add testcases for anticreep = 1 in z- and z-sigma-simulations
 
# Evidence of the work done 
- [x]	I added concise documentation + a figure to the testcase. Example:
<img width="1320" height="344" alt="figure1" src="https://github.com/user-attachments/assets/0d6a2908-dcdd-47fd-89d2-ca765b2afcae" />

# Tests 
- [x] Tests added:
e02_f021_c003_slopingbed_anticreep_z
e02_f021_c003_slopingbed_anticreep_z_sigma

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9558