### PR TITLE
Correct trachytope formula 152 for emerged vegetation

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/fm_dredge.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/fm_dredge.f90
@@ -122,6 +122,7 @@ contains
       integer :: istat
       real(kind=fp) :: dtmor 
       real(kind=fp) :: sbtot(ndx,stmpar%lsedtot)
+      real(fp), dimension(:), pointer :: dunelength_tmp
       !
    !! executable statements -------------------------------------------------------
       !
@@ -167,12 +168,21 @@ contains
          !In case of coarse-layer (HANNEKE) model, we do not want to update coarse layer fluxes.
          dtmor = 0 
          sbtot = 0.0_fp
-         if (updmorlyr(stmpar%morlyr, dbodsd, dz_dummy,bfmpar%dunelength, sbtot, dtmor, mtd%messages) /= 0) then
+         if (associated(bfmpar%dunelength)) then
+            dunelength_tmp => bfmpar%dunelength
+         else
+            allocate(dunelength_tmp(1:ndx))
+            dunelength_tmp = 1.0e10_fp
+         end if
+         if (updmorlyr(stmpar%morlyr, dbodsd, dz_dummy,dunelength_tmp, sbtot, dtmor, mtd%messages) /= 0) then
             call writemessages(mtd%messages, mdia)
             error = .true.
             return
          else
             call writemessages(mtd%messages, mdia)
+         end if
+         if (.not. associated(bfmpar%dunelength)) then
+            deallocate(dunelength_tmp)
          end if
          deallocate (dz_dummy, stat=istat)
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/m_fm_bott3d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/m_fm_bott3d.f90
@@ -116,8 +116,7 @@ contains
       real(kind=dp) :: dtmor
       real(kind=dp) :: timhr
       real(kind=dp) :: sbtot(ndx,stmpar%lsedtot)
-      real(fp), dimension(:), pointer :: dunelength
-      real(fp), dimension(1:0), target :: empty_dunelength
+      real(fp), dimension(:), pointer :: dunelength_tmp
 
    !!
    !! Point
@@ -128,11 +127,11 @@ contains
          )
 
       if (associated(bfmpar%dunelength)) then
-         dunelength => bfmpar%dunelength
+         dunelength_tmp => bfmpar%dunelength
       else
-         dunelength => empty_dunelength
+         allocate(dunelength_tmp(1:ndx))
+         dunelength_tmp = 1.0e10_fp
       end if
-         
 
    !!
    !! Execute
@@ -262,7 +261,7 @@ contains
             ! Update layers and obtain the depth change
             !
             !See: UNST-7369
-            if (updmorlyr(stmpar%morlyr, dbodsd, blchg, dunelength, sbtot, dtmor, mtd%messages) /= 0) then
+            if (updmorlyr(stmpar%morlyr, dbodsd, blchg, dunelength_tmp, sbtot, dtmor, mtd%messages) /= 0) then
                call writemessages(mtd%messages, mdia)
                write (errmsg, '(a,a,a)') 'fm_bott3d :: updmorlyr returned an error.'
                call write_error(errmsg, unit=mdia)
@@ -278,6 +277,10 @@ contains
             call bndmorlyr(lsedtot, timhr, nopenbndsect, bc_mor_array, stmpar)
          end if
       end if ! time1>tcmp
+
+      if (.not. associated(bfmpar%dunelength)) then
+         deallocate(dunelength_tmp)
+      end if
 
       if (time1 >= tstart_user + tmor * tfac) then
          !

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/saadf90.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/saadf90.F90
@@ -843,7 +843,7 @@ contains
             print *, 'Iterative solver was not given enough work space.'
             print *, 'The work space should at least have ', ipar(4), ' elements.'
          else if (ipar(1) == -3) then
-            print *, 'Iterative sovler is facing a break-down. a'
+            print *, 'Iterative solver is facing a break-down. a'
          else
             print *, 'Iterative solver terminated. code =', ipar(1)
          end if
@@ -960,7 +960,7 @@ contains
             print *, 'Iterative solver was not given enough work space.'
             print *, 'The work space should at least have ', ipar(4), ' elements.'
          else if (ipar(1) == -3) then
-            print *, 'Iterative sovler is facing a break-down. b'
+            print *, 'Iterative solver is facing a break-down. b'
          else
             print *, 'Iterative solver terminated. code =', ipar(1)
          end if

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/trtrou.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute/trtrou.f90
@@ -768,7 +768,7 @@ subroutine trtrou(lundia    ,nmax      ,mmax      ,nmaxus    ,kmax      , &
                 ! For flow through vegetation only
                 !
                 if (ircod==152) then
-                   rc0  = sqrt(1.0_fp/((drag*densit*vheigh)/(2.0_fp*ag)+1.0_fp/(cbed*cbed)))
+                   rc0  = sqrt(1.0_fp/((drag*densit*depth)/(2.0_fp*ag)+1.0_fp/(cbed*cbed)))
                 else
                    rc0  = sqrt((2.0_fp*ag)/(drag*densit*depth))
                 endif

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/bott3d.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/bott3d.f90
@@ -140,8 +140,6 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
     real(fp), dimension(:,:,:)           , pointer :: fluxv
     logical                              , pointer :: lfbedfrm
     logical                              , pointer :: crslyr
-    real(fp), dimension(:)               , pointer :: duneheight
-    real(fp), dimension(:)               , pointer :: dunelength
     integer                              , pointer :: iflufflyr
     real(fp), dimension(:,:)             , pointer :: mfluff
     real(fp), dimension(:,:)             , pointer :: sinkf
@@ -265,7 +263,7 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
     real(fp) :: trndiv
     real(fp) :: z
     real(hp) :: dim_real
-    real(fp) , dimension(:)   , allocatable :: dunelength_tmp  !  Copy of dune length. It is necessary in case of using the coarse-layer (HANNEKE) model. 
+    real(fp) , dimension(:)   , pointer     :: dunelength_tmp  !  Copy of dune length. It is necessary in case of using the coarse-layer (HANNEKE) model. 
     real(fp) , dimension(:,:) , allocatable :: sbot       !  Description and declaration in rjdim.f90
 !
 !! executable statements -------------------------------------------------------
@@ -273,7 +271,6 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
     lundia              => gdp%gdinout%lundia
     hydrt               => gdp%gdmorpar%hydrt
     lfbedfrm            => gdp%gdbedformpar%lfbedfrm
-    dunelength          => gdp%gdbedformpar%dunelength
     morft               => gdp%gdmorpar%morft
     morfac              => gdp%gdmorpar%morfac
     sus                 => gdp%gdmorpar%sus
@@ -336,16 +333,15 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
     ntstep              => gdp%gdinttim%ntstep
     fluxu               => gdp%gdflwpar%fluxu
     fluxv               => gdp%gdflwpar%fluxv
-    duneheight          => gdp%gdbedformpar%duneheight
     iflufflyr           => gdp%gdmorpar%flufflyr%iflufflyr
     mfluff              => gdp%gdmorpar%flufflyr%mfluff
     sinkf               => gdp%gdmorpar%flufflyr%sinkf
     sourf               => gdp%gdmorpar%flufflyr%sourf
     !
-    lstart   = max(lsal, ltem)
-    bedload  = .false.
-    dtmor    = dt*morfac
-    nm_pos   = 1
+    lstart  = max(lsal, ltem)
+    bedload = .false.
+    dtmor   = dt*morfac
+    nm_pos  = 1
     dim_real = real(nmmax*lsedtot,hp)
     !
     !   Calculate suspended sediment transport correction vector (for SAND)
@@ -1037,9 +1033,13 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
           enddo
           !
           allocate(sbot     (gdp%d%nmlb:gdp%d%nmub, lsedtot))
-          allocate(dunelength_tmp(gdp%d%nmlb:gdp%d%nmub))
-          sbot      = 0.0_fp 
-          dunelength_tmp = 1.0e10_fp
+          sbot      = 0.0_fp
+          if (associated(gdp%gdbedformpar%dunelength)) then
+              dunelength_tmp => gdp%gdbedformpar%dunelength
+          else
+              allocate(dunelength_tmp(gdp%d%nmlb:gdp%d%nmub))
+              dunelength_tmp = 1.0e10_fp
+          endif
           !
           istat =  bedcomp_getpointer_logical(gdp%gdmorlyr,'crslyr',crslyr)
           istat =  bedcomp_getpointer_integer(gdp%gdmorlyr,'imobility',imobility)
@@ -1052,10 +1052,6 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
           endif    
           ! 
           if (crslyr) then 
-              !
-              ! Get dunelength
-              !
-              dunelength_tmp = dunelength
               !
               ! Compute average bed load transport in cel
               ! 
@@ -1086,6 +1082,10 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
              call writemessages(gdp%messages, lundia)
           endif
           call lyrdiffusion(gdp%gdmorlyr, dtmor)
+          !
+          if (.not.associated(gdp%gdbedformpar%dunelength)) then
+              deallocate(dunelength_tmp)
+          endif
           !
           ! Apply composition boundary conditions
           !

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/bott3d.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/bott3d.f90
@@ -1083,10 +1083,6 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
           endif
           call lyrdiffusion(gdp%gdmorlyr, dtmor)
           !
-          if (.not.associated(gdp%gdbedformpar%dunelength)) then
-              deallocate(dunelength_tmp)
-          endif
-          !
           ! Apply composition boundary conditions
           !
           call bndmorlyr(lsedtot   ,timhr        , &
@@ -1094,7 +1090,9 @@ subroutine bott3d(nmmax     ,kmax      ,lsed      ,lsedtot  , &
                        & gdp       )
           !
           deallocate(sbot)
-          deallocate(dunelength_tmp)
+          if (.not.associated(gdp%gdbedformpar%dunelength)) then
+              deallocate(dunelength_tmp)
+          endif
           !
        endif
     endif ! nst >= itcmp

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/z_bott3d.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/z_bott3d.f90
@@ -1118,10 +1118,6 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
           endif
           call lyrdiffusion(gdp%gdmorlyr, dtmor)
           !
-          if (.not.associated(gdp%gdbedformpar%dunelength)) then
-              deallocate(dunelength_tmp)
-          endif
-          !
           ! Apply composition boundary conditions
           !
           call bndmorlyr(lsedtot   ,timhr        , &
@@ -1129,7 +1125,9 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                        & gdp       )
           !
           deallocate(sbot)
-          deallocate(dunelength_tmp)
+          if (.not.associated(gdp%gdbedformpar%dunelength)) then
+              deallocate(dunelength_tmp)
+          endif
           !
        endif
     endif ! nst >= itcmp

--- a/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/z_bott3d.f90
+++ b/src/engines_gpl/flow2d3d/packages/flow2d3d_kernel/src/compute_sediment/z_bott3d.f90
@@ -11,7 +11,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                   & kcv       ,icx       ,icy       ,timhr     , &
                   & nto       ,volum0    ,volum1    ,dzs1      ,dzu1      , &
                   & dzv1      ,kfsmin    ,kfumin    ,kfumax    ,kfvmin    , &
-                  & kfvmax    ,dt        ,gdp       )
+                  & kfvmax    ,dt        ,taubmx    ,gdp       )
 !----- GPL ---------------------------------------------------------------------
 !                                                                               
 !  Copyright (C)  Stichting Deltares, 2011-2026.                                
@@ -106,6 +106,8 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     logical                              , pointer :: snelli
     logical                              , pointer :: l_suscor
     logical, dimension(:)                , pointer :: cmpupdfrac
+    real(fp)                             , pointer :: ag
+    real(fp)                             , pointer :: rhow
     real(fp), dimension(:)               , pointer :: factor
     real(fp)                             , pointer :: slope
     real(fp), dimension(:)               , pointer :: bc_mor_array
@@ -134,16 +136,19 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     real(fp)      , dimension(:)         , pointer :: rhosol
     real(fp)      , dimension(:)         , pointer :: cdryb
     integer       , dimension(:)         , pointer :: tratyp
+    real(fp)      , dimension(:)         , pointer :: sedd50
     integer                              , pointer :: julday
     integer                              , pointer :: ntstep
     real(fp), dimension(:,:,:)           , pointer :: fluxu
     real(fp), dimension(:,:,:)           , pointer :: fluxv
-    real(fp), dimension(:)               , pointer :: duneheight
+    logical                              , pointer :: lfbedfrm
+    logical                              , pointer :: crslyr
     real(fp)                             , pointer :: dzmin
     integer                              , pointer :: iflufflyr
     real(fp), dimension(:,:)             , pointer :: mfluff
     real(fp), dimension(:,:)             , pointer :: sinkf
     real(fp), dimension(:,:)             , pointer :: sourf
+    integer                              , pointer :: imobility
 !
 ! Local parameters
 !
@@ -199,16 +204,19 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     real(fp), dimension(gdp%d%nmlb:gdp%d%nmub, lsedtot)              :: sbvv   !  Description and declaration in esm_alloc_real.f90
     real(fp), dimension(0:kmax)                        , intent(in)  :: sig    !  Description and declaration in esm_alloc_real.f90
     real(fp), dimension(kmax)                          , intent(in)  :: thick  !  Description and declaration in esm_alloc_real.f90
+    real(fp), dimension(gdp%d%nmlb:gdp%d%nmub)         , intent(in)  :: taubmx !  Description and declaration in rjdim.f90
     real(fp), dimension(gdp%d%nmlb:gdp%d%nmub, kmax)   , intent(in)  :: dzs1   !  Description and declaration in rjdim.f90
     real(fp), dimension(gdp%d%nmlb:gdp%d%nmub, kmax)   , intent(in)  :: dzu1   !  Description and declaration in rjdim.f90
     real(fp), dimension(gdp%d%nmlb:gdp%d%nmub, kmax)   , intent(in)  :: dzv1   !  Description and declaration in rjdim.f90
 !
 ! Local variables
 !
+    integer  :: fac
     integer  :: i
     integer  :: ib
     integer  :: icond
     integer  :: idir_scalar
+    integer  :: istat
     integer  :: jb
     integer  :: k
     integer  :: kk
@@ -224,7 +232,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     integer  :: nhystp
     integer  :: nm
     integer  :: nmd
-    integer  :: nm_pos              ! indicating the array to be exchanged has nm index at the 2nd place, e.g., dbodsd(lsedtot,nm)
+    integer  :: nm_pos ! indicating the array to be exchanged has nm index at the 2nd place, e.g., dbodsd(lsedtot,nm)
     integer  :: nmu
     integer  :: num
     integer  :: numu
@@ -258,6 +266,8 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     real(fp) :: rate
     real(fp) :: r1avg
     real(fp) :: sedflx
+    real(fp) :: sb1
+    real(fp) :: sb2
     real(fp) :: thet
     real(fp) :: thick0
     real(fp) :: thick1
@@ -268,14 +278,14 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     real(hp) :: dim_real
     real(fp) :: cellht
     real(fp) :: zusum
-    real(fp) , dimension(:)   , allocatable :: dunelngth  !  Copy of dune length in case of 
+    real(fp) , dimension(:)   , pointer     :: dunelength_tmp  !  Copy of dune length. It is necessary in case of using the coarse-layer (HANNEKE) model. 
     real(fp) , dimension(:,:) , allocatable :: sbot       !  Description and declaration in rjdim.f90
-
 !
 !! executable statements -------------------------------------------------------
 !
     lundia              => gdp%gdinout%lundia
     hydrt               => gdp%gdmorpar%hydrt
+    lfbedfrm            => gdp%gdbedformpar%lfbedfrm
     morft               => gdp%gdmorpar%morft
     morfac              => gdp%gdmorpar%morfac
     sus                 => gdp%gdmorpar%sus
@@ -293,8 +303,10 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     bedupd              => gdp%gdmorpar%bedupd
     cmpupd              => gdp%gdmorpar%cmpupd
     neglectentrainment  => gdp%gdmorpar%neglectentrainment
-    l_suscor            => gdp%gdmorpar%l_suscor    
+    l_suscor            => gdp%gdmorpar%l_suscor
     multi               => gdp%gdmorpar%multi
+    ag                  => gdp%gdphysco%ag
+    rhow                => gdp%gdphysco%rhow
     wind                => gdp%gdprocs%wind
     temp                => gdp%gdprocs%temp
     const               => gdp%gdprocs%const
@@ -331,12 +343,12 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
     cmpupdfrac          => gdp%gdsedpar%cmpupdfrac
     rhosol              => gdp%gdsedpar%rhosol
     cdryb               => gdp%gdsedpar%cdryb
+    sedd50              => gdp%gdsedpar%sedd50
     tratyp              => gdp%gdsedpar%tratyp
     julday              => gdp%gdinttim%julday
     ntstep              => gdp%gdinttim%ntstep
     fluxu               => gdp%gdflwpar%fluxu
     fluxv               => gdp%gdflwpar%fluxv
-    duneheight          => gdp%gdbedformpar%duneheight
     dzmin               => gdp%gdzmodel%dzmin
     iflufflyr           => gdp%gdmorpar%flufflyr%iflufflyr
     mfluff              => gdp%gdmorpar%flufflyr%mfluff
@@ -619,6 +631,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
           enddo     ! l
        endif        ! sscomp .or. nst>=itmor
     endif           ! sus /= 0.0
+    !
     ! make sure that the transport layer thickness is known
     ! if the bed composition computations have started or
     ! if dredging is active
@@ -767,7 +780,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                      !
                      ! Only cross-shore component
                      !
-                     trndiv = trndiv + gsqsinv &
+                     trndiv = trndiv + gsqsinv                                   &
                             & *(  ssuu(nmd, l)*guu(nmd) - ssuu(nm, l)*guu(nm))
                    else
                      trndiv = trndiv + gsqsinv                                   &
@@ -808,11 +821,11 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                       ! Only cross-shore component
                       !
                       trndiv = trndiv + gsqsinv                                     &
-                             &          *( sucor(nmd,l)*guu(nmd)-sucor(nm,l)*guu(nm))
+                             &         *( sucor(nmd,l)*guu(nmd)-sucor(nm,l)*guu(nm))
                    else
                       trndiv = trndiv + gsqsinv                                     &
-                             &          *( sucor(nmd,l)*guu(nmd)-sucor(nm,l)*guu(nm) &
-                             &            +svcor(ndm,l)*gvv(ndm)-svcor(nm,l)*gvv(nm))
+                             &         *( sucor(nmd,l)*guu(nmd)-sucor(nm,l)*guu(nm) &
+                             &           +svcor(ndm,l)*gvv(ndm)-svcor(nm,l)*gvv(nm))
                    endif
                 endif
              endif
@@ -822,11 +835,11 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                   ! Only cross-shore component
                   !
                   trndiv = trndiv + gsqsinv                                     &
-                         &          *( sbuu(nmd,l)*guu(nmd)-sbuu(nm,l)*guu(nm))
+                         &         *( sbuu(nmd,l)*guu(nmd)-sbuu(nm,l)*guu(nm))
                 else
                   trndiv = trndiv + gsqsinv                                     &
-                         &          *( sbuu(nmd,l)*guu(nmd)-sbuu(nm,l)*guu(nm)   &
-                         &            +sbvv(ndm,l)*gvv(ndm)-sbvv(nm,l)*gvv(nm))
+                         &         *( sbuu(nmd,l)*guu(nmd)-sbuu(nm,l)*guu(nm)   &
+                         &           +sbvv(ndm,l)*gvv(ndm)-sbvv(nm,l)*gvv(nm))
                 endif
              endif
              !
@@ -985,7 +998,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                    endif
                    !
                    if (from_num) then
-                      dv = thet*fixfac(num, l)*frac(num, l)
+                      dv             = thet*fixfac(num, l)*frac(num, l)
                       dbodsd(l, num) = dbodsd(l, num) - dv/gsqs(num)
                       dbodsd(l, nm ) = dbodsd(l, nm ) + dv/gsqs(nm)
                       sbvv(nm, l)    = sbvv(nm, l) - dv/(dtmor*gvv(nm))
@@ -1055,19 +1068,59 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
           enddo
           !
           allocate(sbot     (gdp%d%nmlb:gdp%d%nmub, lsedtot))
-          allocate(dunelngth(gdp%d%nmlb:gdp%d%nmub))
-          sbot      = 0.0_fp 
-          dunelngth = 1.0e10_fp
+          sbot      = 0.0_fp
+          if (associated(gdp%gdbedformpar%dunelength)) then
+              dunelength_tmp => gdp%gdbedformpar%dunelength
+          else
+              allocate(dunelength_tmp(gdp%d%nmlb:gdp%d%nmub))
+              dunelength_tmp = 1.0e10_fp
+          endif
+          !
+          istat =  bedcomp_getpointer_logical(gdp%gdmorlyr,'crslyr',crslyr)
+          istat =  bedcomp_getpointer_integer(gdp%gdmorlyr,'imobility',imobility)
+          !
+          ! 
+          ! Compute mobile fractions
+          ! 
+          if (imobility > 0) then 
+              call compmobile(gdp%gdmorlyr, ag, sedd50, taubmx, rhosol, rhow, gdp%gderosed%hidexp)
+          endif    
+          ! 
+          if (crslyr) then 
+              !
+              ! Compute average bed load transport in cel
+              ! 
+              do l = 1, lsedtot
+                  do nm = 1, nmmax
+                      if (kcs(nm)*kfs(nm) == 1) then
+                          nmd = nm - icx
+                          ndm = nm - icy
+                          fac = max(kfu(nm)+kfu(nmd),1)
+                          sb1 = (kfu(nm)*sbuu(nm,l)+kfu(nmd)*sbuu(nmd,l))/fac
+                          fac = max(kfv(nm)+kfv(ndm),1)
+                          sb2 = (kfv(nm)*sbvv(nm,l)+kfv(ndm)*sbvv(ndm,l))/fac
+                          sbot(nm, l)  = sqrt( sb1**2 + sb2**2 )
+                      else
+                          sbot(nm, l) = -999.0_fp  
+                      endif
+                  enddo
+              enddo
+          endif
+          !
           ! Update layers and obtain the depth change
           !
           call morstats(gdp, dbodsd, s1, dps, umean, vmean, sbuu, sbvv, ssuu, ssvv, gdp%d%nmlb, gdp%d%nmub, lsedtot, lsed)
-          if (updmorlyr(gdp%gdmorlyr, dbodsd, depchg, dunelngth, sbot, dtmor, gdp%messages) /= 0) then
+          if (updmorlyr(gdp%gdmorlyr, dbodsd, depchg, dunelength_tmp, sbot, dtmor, gdp%messages) /= 0) then
              call writemessages(gdp%messages, lundia)
              call d3stop(1, gdp)
           else
              call writemessages(gdp%messages, lundia)
           endif
           call lyrdiffusion(gdp%gdmorlyr, dtmor)
+          !
+          if (.not.associated(gdp%gdbedformpar%dunelength)) then
+              deallocate(dunelength_tmp)
+          endif
           !
           ! Apply composition boundary conditions
           !
@@ -1076,7 +1129,7 @@ subroutine z_bott3d(nmmax     ,kmax      ,lsed      ,lsedtot   , &
                        & gdp       )
           !
           deallocate(sbot)
-          deallocate(dunelngth)
+          deallocate(dunelength_tmp)
           !
        endif
     endif ! nst >= itcmp

--- a/src/utils_gpl/morphology/packages/morphology_kernel/src/bedcomposition_module.f90
+++ b/src/utils_gpl/morphology/packages/morphology_kernel/src/bedcomposition_module.f90
@@ -249,7 +249,7 @@ function updmorlyr(this, dbodsd, dz, dunelength, sbot, hdt, messages) result (is
     type(bedcomp_data)                                                                           :: this 
     real(fp), dimension(this%settings%nfrac, this%settings%nmlb:this%settings%nmub), intent(in)  :: dbodsd  !  change in sediment composition, units : kg/m2
     real(fp), dimension(this%settings%nmlb:this%settings%nmub)                     , intent(out) :: dz      !  change in bed level, units : m
-    real(fp), dimension(this%settings%nmlb:this%settings%nmub)                     , intent(in)  :: dunelength   !  length of the dunes, units : m 
+    real(fp), dimension(:), pointer                                                , intent(in)  :: dunelength   !  length of the dunes, units : m 
     real(fp)                                                                       , intent(in)  :: hdt          !  half time step
     real(fp), dimension(this%settings%nmlb:this%settings%nmub, this%settings%nfrac), intent(in)  :: sbot    
     type(message_stack)                                                                          :: messages
@@ -1904,7 +1904,6 @@ subroutine updcrslyr(this, nm, hdt, sbot, dunelength, thick, dmi)
     real(fp)                                :: mtot_ac      ! total mass in active layer
     real(fp)                                :: mtot_crs     ! total mass in coarse layer
     real(fp)                                :: mup          ! total mass that rises from coarse to active layer
-    real(fp)                                :: pi           ! 3.14....
     real(fp)                                :: pmob_ac      ! fraction mobile sediment in active layer
     real(fp)                                :: pmob_crs     ! fraction mobile sediment in coarse layer
     real(fp)                                :: sinkfrac     ! fraction immobile sediment that sinks from active to coarse layer
@@ -1933,8 +1932,6 @@ subroutine updcrslyr(this, nm, hdt, sbot, dunelength, thick, dmi)
     mobile          => this%state%mobile
     msed            => this%state%msed
     thlyr           => this%state%thlyr
-    !
-    pi = 4.0_fp*atan(1.0_fp)
     !
     ! compute mobile sediment fractions in active and coarse layer
     !

--- a/src/utils_gpl/morphology/packages/morphology_kernel/src/bedcomposition_module.f90
+++ b/src/utils_gpl/morphology/packages/morphology_kernel/src/bedcomposition_module.f90
@@ -249,7 +249,7 @@ function updmorlyr(this, dbodsd, dz, dunelength, sbot, hdt, messages) result (is
     type(bedcomp_data)                                                                           :: this 
     real(fp), dimension(this%settings%nfrac, this%settings%nmlb:this%settings%nmub), intent(in)  :: dbodsd  !  change in sediment composition, units : kg/m2
     real(fp), dimension(this%settings%nmlb:this%settings%nmub)                     , intent(out) :: dz      !  change in bed level, units : m
-    real(fp), dimension(:), pointer                                                , intent(in)  :: dunelength   !  length of the dunes, units : m 
+    real(fp), dimension(this%settings%nmlb:this%settings%nmub)                     , intent(in)  :: dunelength   !  length of the dunes, units : m 
     real(fp)                                                                       , intent(in)  :: hdt          !  half time step
     real(fp), dimension(this%settings%nmlb:this%settings%nmub, this%settings%nfrac), intent(in)  :: sbot    
     type(message_stack)                                                                          :: messages

--- a/src/utils_gpl/trachytopes/packages/trachytopes_kernel/src/trtrou.f90
+++ b/src/utils_gpl/trachytopes/packages/trachytopes_kernel/src/trtrou.f90
@@ -800,7 +800,7 @@ subroutine trtrou(lundia    ,kmax      ,nmmax   , &
                 ! For flow through vegetation only
                 !
                 if (ircod==152) then
-                   rc0  = sqrt(1.0_fp/((drag*densit*vheigh)/(2.0_fp*ag)+1.0_fp/(cbed*cbed)))
+                   rc0  = sqrt(1.0_fp/((drag*densit*depth)/(2.0_fp*ag)+1.0_fp/(cbed*cbed)))
                 else
                    rc0  = sqrt((2.0_fp*ag)/(drag*densit*depth))
                 endif

--- a/src/utils_gpl/trachytopes/packages/trachytopes_kernel/src/trtrou.f90
+++ b/src/utils_gpl/trachytopes/packages/trachytopes_kernel/src/trtrou.f90
@@ -145,8 +145,8 @@ subroutine trtrou(lundia    ,kmax      ,nmmax   , &
     integer                                                                          :: lsedtot       ! dito
     real(fp), dimension(lsedtot)        , optional                                   :: rhosol
     logical                                                                          :: spatial_bedform
-    real(fp), dimension(nmlbc:nmubc)                                                 :: bedformD50    !< 50-percentile of sediment diameters
-    real(fp), dimension(nmlbc:nmubc)                                                 :: bedformD90    !< 90-percentile of sediment diameters
+    real(fp), dimension(:), pointer                                                  :: bedformD50    !< 50-percentile of sediment diameters
+    real(fp), dimension(:), pointer                                                  :: bedformD90    !< 90-percentile of sediment diameters
     real(fp), dimension(nmlbc:nmubc)                                                 :: rksr          !< Ripple roughness height in zeta point
     real(fp), dimension(nmlbc:nmubc)                                                 :: rksmr         !< Mega-ripple roughness height in zeta point
     real(fp), dimension(nmlbc:nmubc)                                                 :: rksd          !< Dune roughness height in zeta point

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -983,7 +983,7 @@
         </checks>
     </testCase>
     <testCase name="e02_f203_c02_Waal_trachytopes_3D_sigma" ref="dflowfm_default">
-      <path version="2026-03-13T16:21:45.714000">e02_dflowfm/f203_3D_trachytopes/c02_Waal_trachytopes_3D_sigma</path>
+      <path version="2026-05-10T21:00:00.000000">e02_dflowfm/f203_3D_trachytopes/c02_Waal_trachytopes_3D_sigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/Waal_3D_sigma_map.nc" type="netCDF">
@@ -996,7 +996,7 @@
       </checks>
     </testCase>
     <testCase name="e02_f203_c04_Waal_trachytopes_3D_zsigma" ref="dflowfm_default">
-      <path version="2026-03-13T16:21:57.149000">e02_dflowfm/f203_3D_trachytopes/c04_Waal_trachytopes_3D_zsigma</path>
+      <path version="2026-05-10T21:00:00.000000">e02_dflowfm/f203_3D_trachytopes/c04_Waal_trachytopes_3D_zsigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/Waal_3D_zsigma_map.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
@@ -1,6 +1,6 @@
   <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
     <testCase name="e02_f090_c012_waal_mor_2d" ref="dflowfm_default">
-      <path version="2026-03-17T10:22:45.991000">e02_dflowfm/f090_validation_realworld/c012_waal_mor_2d</path>
+      <path version="2026-05-10T21:00:00.000000">e02_dflowfm/f090_validation_realworld/c012_waal_mor_2d</path>
       <maxRunTime>90.0</maxRunTime>
       <checks>
         <file name="results/RIJN_map.nc" type="netCDF">


### PR DESCRIPTION
Emerged vegetation only exerts a force over the water depth, not the full vegetation height. Bug introduced before Oct 2007 (probably during the implementation) ... the user manual states the correct equation \ref{Eqn:BarneveldTrachy2Emerged}.

# What was done 

Replaced the vegetation height`vheight` by the water depth `depth` in the flow resistance formula for emerged vegetation condition of formula 152 (Barneveld nr 2).

This was changed in both the Delft3D-FLOW version and the D-Flow FM version of the trachytope code. We are working in another branch on a shared implementation. Hence merging the two branches is out of scope for this pull request.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
