### PR TITLE
UNST-9795: Test if source/sinks with more than 2 polylines exist in testbench

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
@@ -159,7 +159,7 @@ contains
       ierr = DFM_WRONGINPUT
 
       num_points = size(x_points)
-      if (num_points == 0) then
+      if (num_points == 0 .or. num_points > 2) then
          return
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/addsorsin.f90
@@ -159,7 +159,7 @@ contains
       ierr = DFM_WRONGINPUT
 
       num_points = size(x_points)
-      if (num_points == 0 .or. num_points > 2) then
+      if (num_points == 0 .or. num_points > 2) then ! For now only support 1 & 2 point polylines
          return
       end if
 


### PR DESCRIPTION
# What was done 

Added a crash when a source/sink is specified with a polyline file with more than 2 points to investigate if this exists in the testbench. 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
