### PR TITLE
UNST-9914: correct the layer keywords in the .hyd file

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
@@ -470,9 +470,9 @@ contains
       write (lunhyd, '(a,a)') 'task      ', 'full-coupling'
 
       if (layertype == LAYTP_SIGMA) then ! sigma-layers
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured sigma-layers'
+         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured'
       elseif (layertype == LAYTP_Z) then ! z- or z-sigma-layers
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured z- or z-sigma-layers'
+         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured z-layers'
       elseif (layertype == LAYTP_POLYGON_MIXED) then
          write (lunhyd, '(a,a)') 'geometry  ', 'unstructured polygon defined z-layers'
       elseif (layertype == LAYTP_DENS_SIGMA) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
@@ -469,14 +469,10 @@ contains
 
       write (lunhyd, '(a,a)') 'task      ', 'full-coupling'
 
-      if (layertype == LAYTP_SIGMA) then ! sigma-layers
+      if ((layertype == LAYTP_SIGMA) .or. (layertype == LAYTP_DENS_SIGMA)) then ! (density controlled) sigma-layers
          write (lunhyd, '(a,a)') 'geometry  ', 'unstructured'
-      elseif (layertype == LAYTP_Z) then ! z- or z-sigma-layers
+      elseif ((layertype == LAYTP_Z) .or. (layertype == LAYTP_POLYGON_MIXED)) then ! (polygon defined) z- or z-sigma-layers
          write (lunhyd, '(a,a)') 'geometry  ', 'unstructured z-layers'
-      elseif (layertype == LAYTP_POLYGON_MIXED) then
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured polygon defined z-layers'
-      elseif (layertype == LAYTP_DENS_SIGMA) then
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured density controlled sigma-layers'
       else ! other?
          write (lunhyd, '(a,a)') 'geometry  ', 'unstructured other'
       end if


### PR DESCRIPTION

**Note that this is a PR to make a bugfix in the 2026.02 release branch. It is not been decided yet whether a new RC will be created. In case we decide to make a new RC, the bugfix is already in the release branch.**


# What was done 
- correct the layer keywords in the .hyd file. This reverts part of the changes made in #404 as part of UNST-9149.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9914