### PR TITLE
DEVOPSDSC-940: Add build counter to NuGet package names

### DIFF
--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -21,6 +21,7 @@ object PublishToGui : BuildType({
         param("DIMR_nuget_version", "%release_version%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
+        param("tc_build_number", "%build.number%")
     }
 
     vcs {
@@ -35,7 +36,7 @@ object PublishToGui : BuildType({
             name = "Pack DIMR NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/Dimr.Libs/Dimr.Libs.nuspec"
-            version = "%DIMR_nuget_version%-%build.number%"
+            version = "%DIMR_nuget_version%-%tc_build_number%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true
@@ -49,7 +50,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion-%build.number%']"
+                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve ECModule version."
                         exit 1
@@ -75,7 +76,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion-%build.number%']"
+                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve GridGeom version."
                         exit 1
@@ -96,7 +97,7 @@ object PublishToGui : BuildType({
             name = "Publish NuGet artifacts to Nexus"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             packages = "target/*.nupkg"
-            serverUrl = "https://artifacts.deltares.nl/repository/nuget-release/"
+            serverUrl = "https://artifacts.deltares.nl/repository/nuget-dev/"
             apiKey = "%nexus_nuget_apikey%"
         }
     }

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -18,10 +18,10 @@ object PublishToGui : BuildType({
     }
 
     params {
-        param("DIMR_nuget_version", "%release_version%")
+        param("tc_build_number", "%build.number%")
+        param("DIMR_nuget_version", "%release_version%_%tc_build_number%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
-        param("tc_build_number", "%build.number%")
     }
 
     vcs {
@@ -47,10 +47,10 @@ object PublishToGui : BuildType({
             scriptMode = script {
                 content = """
                     ${'$'}pathToDll = "source\x64\lib\ec_module.dll"
-                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw_%tc_build_number%
+                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion']"
+                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion:-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve ECModule version."
                         exit 1
@@ -73,10 +73,10 @@ object PublishToGui : BuildType({
             scriptMode = script {
                 content = """
                     ${'$'}pathToDll = "source\x64\lib\gridgeom.dll"
-                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw_%tc_build_number%
+                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion']"
+                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion:-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve GridGeom version."
                         exit 1

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -36,7 +36,7 @@ object PublishToGui : BuildType({
             name = "Pack DIMR NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/Dimr.Libs/Dimr.Libs.nuspec"
-            version = "%DIMR_nuget_version%_%tc_build_number%"
+            version = "%DIMR_nuget_version%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true
@@ -47,7 +47,7 @@ object PublishToGui : BuildType({
             scriptMode = script {
                 content = """
                     ${'$'}pathToDll = "source\x64\lib\ec_module.dll"
-                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
+                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw_%tc_build_number%
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
                     	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion']"
@@ -62,7 +62,7 @@ object PublishToGui : BuildType({
             name = "Pack EC Module NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/ECModule.Native/ECModule.Native.nuspec"
-            version = "%ec_module_version%_%tc_build_number%"
+            version = "%ec_module_version%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true
@@ -73,7 +73,7 @@ object PublishToGui : BuildType({
             scriptMode = script {
                 content = """
                     ${'$'}pathToDll = "source\x64\lib\gridgeom.dll"
-                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
+                    ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw_%tc_build_number%
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
                     	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion']"
@@ -88,7 +88,7 @@ object PublishToGui : BuildType({
             name = "Pack GridGeom NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/GridGeom.Native/GridGeom.Native.nuspec"
-            version = "%grid_geom_version%_%tc_build_number%"
+            version = "%grid_geom_version%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -21,7 +21,7 @@ object PublishToGui : BuildType({
         param("DIMR_nuget_version", "%release_version%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
-        param("tc_build_number", "%build.number%")
+        param("tc_build_number", "%build.counter%")
     }
 
     vcs {
@@ -36,7 +36,7 @@ object PublishToGui : BuildType({
             name = "Pack DIMR NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/Dimr.Libs/Dimr.Libs.nuspec"
-            version = "%DIMR_nuget_version%-%tc_build_number%"
+            version = "%DIMR_nuget_version%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -50,7 +50,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion-%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion.%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve ECModule version."
                         exit 1
@@ -76,7 +76,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion-%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion.%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve GridGeom version."
                         exit 1

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -18,7 +18,7 @@ object PublishToGui : BuildType({
     }
 
     params {
-        param("DIMR_nuget_version", "%release_version%-%build.number%")
+        param("DIMR_nuget_version", "%release_version%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
     }
@@ -35,7 +35,7 @@ object PublishToGui : BuildType({
             name = "Pack DIMR NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/Dimr.Libs/Dimr.Libs.nuspec"
-            version = "%DIMR_nuget_version%"
+            version = "%DIMR_nuget_version%-%build.number%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -18,8 +18,7 @@ object PublishToGui : BuildType({
     }
 
     params {
-        param("tc_build_number", "%build.number%")
-        param("DIMR_nuget_version", "%release_version%_%tc_build_number%")
+        param("DIMR_nuget_version", "%release_version%-%build.number%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
     }
@@ -50,7 +49,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion:-%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion-%build.number%']"
                     } else {
                         Write-Output "Unable to retrieve ECModule version."
                         exit 1
@@ -76,7 +75,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion:-%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion-%build.number%']"
                     } else {
                         Write-Output "Unable to retrieve GridGeom version."
                         exit 1

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -21,6 +21,7 @@ object PublishToGui : BuildType({
         param("DIMR_nuget_version", "%release_version%")
         param("grid_geom_version", "1.0.0")
         param("ec_module_version", "1.0.0")
+        param("tc_build_number", "%build.number%")
     }
 
     vcs {
@@ -35,7 +36,7 @@ object PublishToGui : BuildType({
             name = "Pack DIMR NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/Dimr.Libs/Dimr.Libs.nuspec"
-            version = "%DIMR_nuget_version%"
+            version = "%DIMR_nuget_version%_%tc_build_number%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true
@@ -61,7 +62,7 @@ object PublishToGui : BuildType({
             name = "Pack EC Module NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/ECModule.Native/ECModule.Native.nuspec"
-            version = "%ec_module_version%"
+            version = "%ec_module_version%_%tc_build_number%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true
@@ -87,7 +88,7 @@ object PublishToGui : BuildType({
             name = "Pack GridGeom NuGet"
             toolPath = "%teamcity.tool.NuGet.CommandLine.DEFAULT%"
             paths = "ci/nuget/GridGeom.Native/GridGeom.Native.nuspec"
-            version = "%grid_geom_version%"
+            version = "%grid_geom_version%_%tc_build_number%"
             outputDir = "target"
             cleanOutputDir = false
             publishPackages = true

--- a/ci/teamcity/Delft3D/publishToGui.kt
+++ b/ci/teamcity/Delft3D/publishToGui.kt
@@ -50,7 +50,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion.%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='ec_module_version' value='${'$'}fileVersion-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve ECModule version."
                         exit 1
@@ -76,7 +76,7 @@ object PublishToGui : BuildType({
                     ${'$'}fileVersion = (Get-Item ${'$'}pathToDll).VersionInfo.FileVersionRaw
                     
                     if (${'$'}fileVersion -ne ${'$'}null) {
-                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion.%tc_build_number%']"
+                    	Write-Output "##teamcity[setParameter name='grid_geom_version' value='${'$'}fileVersion-%tc_build_number%']"
                     } else {
                         Write-Output "Unable to retrieve GridGeom version."
                         exit 1


### PR DESCRIPTION
# What was done 
Added %build.number% to the NuGet packages name.
 

# Tests 
Artifacts of successful [build](https://dpcbuild.deltares.nl/buildConfiguration/Temporary_PersonalBuildsMdj_Delft3DNexus_PublishToGui/7196749?buildTab=artifacts)

# Issue link
DEVOPSDSC-940

Note: Roel vindt deze oplossing prima voor nu.