### PR TITLE
added original case field_name_lateral to handle case-sensitive later…

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -2050,8 +2050,8 @@ contains
       ! Store the name and convert var and field to lowercase to make them case-insensitive.
       var_name = str_tolower(char_array_to_string(c_var_name))
       item_name = char_array_to_string(c_item_name)
-      field_name = str_tolower(char_array_to_string(c_field_name))
       field_name_original = char_array_to_string(c_field_name)
+      field_name = str_tolower(field_name_original)
 
       select case (var_name)
          ! PUMPS

--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -2445,7 +2445,7 @@ contains
       use m_laterals, only: qplat, nnlat, n1latsg, n2latsg, outgoing_lat_concentration, incoming_lat_concentration, apply_transport, &
                             lateral_volume_per_layer, num_layers, average_waterlevels_per_lateral, numlatsg
       use m_flow, only: s1
-      use string_module, only: str_token
+      use string_module, only: str_token, str_tolower
 
       implicit none
       character(len=MAXSTRLEN), intent(in) :: item_name
@@ -2462,7 +2462,7 @@ contains
          return
       end if
 
-      select case (field_name)
+      select case (str_tolower(field_name))
       case ("water_discharge")
          if (apply_transport(item_index) == 1 .or. kmx == 0) then
             c_lateral_pointer = c_loc(qplat(1:num_layers, item_index))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -2046,12 +2046,12 @@ contains
       character(len=MAXSTRLEN) :: var_name
       character(len=MAXSTRLEN) :: item_name
       character(len=MAXSTRLEN) :: field_name
-      character(len=MAXSTRLEN) :: field_name_case_sensitive !< special extra field name in original casing, as constituents are case-sensitive
+      character(len=MAXSTRLEN) :: field_name_original !< special extra field name in original casing, as constituents are case-sensitive
       ! Store the name and convert var and field to lowercase to make them case-insensitive.
       var_name = str_tolower(char_array_to_string(c_var_name))
       item_name = char_array_to_string(c_item_name)
       field_name = str_tolower(char_array_to_string(c_field_name))
-      field_name_case_sensitive = char_array_to_string(c_field_name)
+      field_name_original = char_array_to_string(c_field_name)
 
       select case (var_name)
          ! PUMPS
@@ -2350,14 +2350,14 @@ contains
          case default
             !       assume this is a tracer
             !       get constituent number for this tracer
-            iconst = find_name(const_names, field_name_case_sensitive)
+            iconst = find_name(const_names, field_name_original)
 
             if (iconst == 0) then
                !          tracer not found
-               call mess(LEVEL_ERROR, 'get_compound_field: cannot find '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_case_sensitive))
+               call mess(LEVEL_ERROR, 'get_compound_field: cannot find '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_original))
             else
                if (kmx > 1) then
-                  call mess(LEVEL_ERROR, 'get_compound_field: 3D not supported for '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_case_sensitive))
+                  call mess(LEVEL_ERROR, 'get_compound_field: 3D not supported for '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_original))
                else
                   !             find tracer number
                   itrac = iconst - ITRA1 + 1
@@ -2394,7 +2394,7 @@ contains
          end select
          ! LATERAL DISCHARGES
       case ("laterals")
-         x = get_pointer_to_lateral_variable(item_name, field_name_case_sensitive)
+         x = get_pointer_to_lateral_variable(item_name, field_name_original)
          ! GEOMETRY
       case ("geometry")
          select case (item_name)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -2046,12 +2046,12 @@ contains
       character(len=MAXSTRLEN) :: var_name
       character(len=MAXSTRLEN) :: item_name
       character(len=MAXSTRLEN) :: field_name
-      character(len=MAXSTRLEN) :: field_name_lateral !< special extra field name in original casing, as constituents are case-sensitive
+      character(len=MAXSTRLEN) :: field_name_case_sensitive !< special extra field name in original casing, as constituents are case-sensitive
       ! Store the name and convert var and field to lowercase to make them case-insensitive.
       var_name = str_tolower(char_array_to_string(c_var_name))
       item_name = char_array_to_string(c_item_name)
       field_name = str_tolower(char_array_to_string(c_field_name))
-      field_name_lateral = char_array_to_string(c_field_name)
+      field_name_case_sensitive = char_array_to_string(c_field_name)
 
       select case (var_name)
          ! PUMPS
@@ -2350,14 +2350,14 @@ contains
          case default
             !       assume this is a tracer
             !       get constituent number for this tracer
-            iconst = find_name(const_names, field_name)
+            iconst = find_name(const_names, field_name_case_sensitive)
 
             if (iconst == 0) then
                !          tracer not found
-               call mess(LEVEL_ERROR, 'get_compound_field: cannot find '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name))
+               call mess(LEVEL_ERROR, 'get_compound_field: cannot find '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_case_sensitive))
             else
                if (kmx > 1) then
-                  call mess(LEVEL_ERROR, 'get_compound_field: 3D not supported for '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name))
+                  call mess(LEVEL_ERROR, 'get_compound_field: 3D not supported for '//trim(var_name)//'/'//trim(item_name)//'/'//trim(field_name_case_sensitive))
                else
                   !             find tracer number
                   itrac = iconst - ITRA1 + 1
@@ -2394,7 +2394,7 @@ contains
          end select
          ! LATERAL DISCHARGES
       case ("laterals")
-         x = get_pointer_to_lateral_variable(item_name, field_name_lateral)
+         x = get_pointer_to_lateral_variable(item_name, field_name_case_sensitive)
          ! GEOMETRY
       case ("geometry")
          select case (item_name)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/src/unstruc_bmi.F90
@@ -2046,10 +2046,12 @@ contains
       character(len=MAXSTRLEN) :: var_name
       character(len=MAXSTRLEN) :: item_name
       character(len=MAXSTRLEN) :: field_name
+      character(len=MAXSTRLEN) :: field_name_lateral !< special extra field name in original casing, as constituents are case-sensitive
       ! Store the name and convert var and field to lowercase to make them case-insensitive.
       var_name = str_tolower(char_array_to_string(c_var_name))
       item_name = char_array_to_string(c_item_name)
       field_name = str_tolower(char_array_to_string(c_field_name))
+      field_name_lateral = char_array_to_string(c_field_name)
 
       select case (var_name)
          ! PUMPS
@@ -2392,7 +2394,7 @@ contains
          end select
          ! LATERAL DISCHARGES
       case ("laterals")
-         x = get_pointer_to_lateral_variable(item_name, field_name)
+         x = get_pointer_to_lateral_variable(item_name, field_name_lateral)
          ! GEOMETRY
       case ("geometry")
          select case (item_name)
@@ -2518,7 +2520,7 @@ contains
          constituent_index = ITEMP
       case default
          constituent_index = find_name(const_names, constituent_name)
-         if (iconst == 0) then
+         if (constituent_index == 0) then
             !        tracer not found
             c_lateral_pointer = c_null_ptr
             return
@@ -2803,7 +2805,7 @@ contains
                constituent_index = ITEMP
             case default
                constituent_index = find_name(const_names, constituent_name)
-               if (iconst == 0) then
+               if (constituent_index == 0) then
                   !        tracer not found
                   return
                end if


### PR DESCRIPTION
…als.

Now actually check constituent_index before returning.

# What was done 

<a short description with bullets> 

- fix two bugs in constituent handling in bmi get/set var

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
