### PR TITLE
UNST-9834: update d-sle test model to work with temperature

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dsle.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dsle.xml
@@ -34,26 +34,15 @@
                 </file>
             </checks>
         </testCase>
-        <testCase name="e119_f001_c003_2D_pw_1sl_uic_cbc" ref="dimr">
-            <path version="2025-10-14T14:14:38.869000">e119_dflowfm_dsle/f001/c003_2D_pw_1sl_uic_cbc</path>
-            <maxRunTime>60.0</maxRunTime>
-            <checks>
-                <file name="dhydro/output/FlowFM_map.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
-                        <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-            </checks>
-        </testCase>
         <testCase name="e119_f001_c004_2D_pw_2sl_uic_cbc" ref="dimr">
-            <path version="2025-11-03T08:06:48.472000">e119_dflowfm_dsle/f001/c004_2D_pw_2sl_uic_cbc</path>
+            <path version="2026-05-06T10:48:50.199000">e119_dflowfm_dsle/f001/c004_2D_pw_2sl_uic_cbc</path>
             <maxRunTime>60.0</maxRunTime>
             <checks>
                 <file name="dhydro/output/FlowFM_map.nc" type="netcdf">
                     <parameters>
                         <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
                         <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
+                        <parameter name="mesh2d_tem1" toleranceAbsolute="0.0001" />
                     </parameters>
                 </file>
                 <file name="dhydro/output/FlowFM_his.nc" type="netcdf">
@@ -64,92 +53,21 @@
                 </file>
             </checks>
         </testCase>
-        <testCase name="e119_f001_c005_3D_ca_1sl_1e_nuic_profile_1" ref="dimr">
-            <path version="2026-03-13T16:39:15.260000">e119_dflowfm_dsle/f001/c005_3D_ca_1sl_1e_nuic_profile_1</path>
-            <maxRunTime>60.0</maxRunTime>
-            <checks>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_map.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
-                        <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_his.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="salinity" toleranceAbsolute="0.0001" />
-                        <parameter name="waterlevel" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-            </checks>
-        </testCase>
-        <testCase name="e119_f001_c006_3D_ca_1sl_1e_uic_profile_2" ref="dimr">
-            <path version="2026-03-13T16:39:19.415000">e119_dflowfm_dsle/f001/c006_3D_ca_1sl_1e_uic_profile_2</path>
-            <maxRunTime>60.0</maxRunTime>
-            <checks>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_map.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
-                        <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_his.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="salinity" toleranceAbsolute="0.0001" />
-                        <parameter name="waterlevel" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-            </checks>
-        </testCase>
-        <testCase name="e119_f001_c007_3D_ca_1sl_me_uic_profile_1" ref="dimr">
-            <path version="2026-03-18T14:31:14.625000">e119_dflowfm_dsle/f001/c007_3D_ca_1sl_me_uic_profile_1</path>
-            <maxRunTime>60.0</maxRunTime>
-            <checks>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_map.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
-                        <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-                <file name="3D_dhydro_zlayer_rst/output/FlowFM_his.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="salinity" toleranceAbsolute="0.0001" />
-                        <parameter name="waterlevel" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-            </checks>
-        </testCase>
         <testCase name="e119_f001_c008_3D_ca_2sl_me_uic_cbc" ref="dimr">
-            <path version="2025-11-03T08:07:04.134000">e119_dflowfm_dsle/f001/c008_3D_ca_2sl_me_uic_cbc</path>
+            <path version="2026-05-06T10:52:33.240000">e119_dflowfm_dsle/f001/c008_3D_ca_2sl_me_uic_cbc</path>
             <maxRunTime>60.0</maxRunTime>
             <checks>
                 <file name="dhydro/output/FlowFM_map.nc" type="netcdf">
                     <parameters>
                         <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
                         <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
+                        <parameter name="mesh2d_tem1" toleranceAbsolute="0.0001" />
                     </parameters>
                 </file>
                 <file name="dhydro/output/FlowFM_his.nc" type="netcdf">
                     <parameters>
                         <parameter name="cross_section_salt" toleranceAbsolute="0.0001" />
                         <parameter name="cross_section_discharge" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-            </checks>
-        </testCase>
-        <testCase name="e119_f001_c009_3D_ca_2sl_me_uic_cbc_3s" ref="dimr">
-            <path version="2025-10-14T13:46:15.254000">e119_dflowfm_dsle/f001/c009_3D_ca_2sl_me_uic_cbc_3s</path>
-            <maxRunTime>60.0</maxRunTime>
-            <checks>
-                <file name="dhydro/output/FlowFM_map.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="mesh2d_sa1" toleranceAbsolute="0.0001" />
-                        <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
-                    </parameters>
-                </file>
-                <file name="dhydro/output/FlowFM_his.nc" type="netcdf">
-                    <parameters>
-                        <parameter name="cross_section_discharge" toleranceAbsolute="0.0001" />
-                        <parameter name="cross_section_salt" toleranceRelative="1e-7" />
                     </parameters>
                 </file>
             </checks>
@@ -173,13 +91,14 @@
             </checks>
         </testCase>
         <testCase name="e119_f001_c011_3D_pw_2sl_uic_cbc" ref="dimr">
-            <path version="2025-11-03T08:08:28.093000">e119_dflowfm_dsle/f001/c011_3D_pw_2sl_uic_cbc</path>
+            <path version="2026-05-06T10:54:13.430000">e119_dflowfm_dsle/f001/c011_3D_pw_2sl_uic_cbc</path>
             <maxRunTime>60.0</maxRunTime>
             <checks>
                 <file name="dhydro/output/FlowFM_map.nc" type="netcdf">
                     <parameters>
                         <parameter name="mesh2d_sa1" toleranceAbsolute="1e-3" />
                         <parameter name="mesh2d_waterdepth" toleranceAbsolute="0.0001" />
+                        <parameter name="mesh2d_tem1" toleranceAbsolute="0.0001" />
                     </parameters>
                 </file>
                 <file name="dhydro/output/FlowFM_his.nc" type="netcdf">


### PR DESCRIPTION
# What was done 

- Update the following d-sle test cases to exchange water temperature too:
	   e119_f001_c004_2D_pw_2sl_uic_cbc
	   e119_f001_c008_3D_ca_2sl_me_uic_cbc
	   e119_f001_c011_3D_pw_2sl_uic_cbc

- Remove the following test cases: 
	   e119_f001_c003_2D_pw_1sl_uic_cbc
	   e119_f001_c005_3D_ca_1sl_1e_nuic_profile_1
	   e119_f001_c006_3D_ca_1sl_1e_uic_profile_2
	   e119_f001_c007_3D_ca_1sl_me_uic_profile_1
	   e119_f001_c009_3D_ca_2sl_me_uic_cbc_3s

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [X] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9834