### PR TITLE
UNST-9874: increase numerical range of time variables in D-WAVES

### DIFF
--- a/src/engines_gpl/wave/packages/data/src/flow_data.f90
+++ b/src/engines_gpl/wave/packages/data/src/flow_data.f90
@@ -61,7 +61,7 @@ subroutine flow_init (mode, it01, tscale)
 !
    integer, intent(in) :: mode
    integer             :: it01
-   real                :: tscale
+   real(hp)            :: tscale
 !
 ! Local variables
 !

--- a/src/engines_gpl/wave/packages/data/src/swan_input.f90
+++ b/src/engines_gpl/wave/packages/data/src/swan_input.f90
@@ -557,7 +557,7 @@ contains
       real :: def_enddir
       real :: def_freqmin
       real :: def_freqmax
-      real :: tscale
+      real(hp) :: tscale
       real, dimension(2) :: xy
       character(10) :: exemode
       character(10) :: versionstring
@@ -768,7 +768,7 @@ contains
       sr%tzone = 0.0
       call prop_get(mdw_ptr, 'General', 'TZone', sr%tzone)
       !
-      tscale = 60.0
+      tscale = 60.0_hp
       call prop_get(mdw_ptr, 'General', 'TScale', tscale)
       call settscale(wavedata%time, tscale)
       !
@@ -1641,9 +1641,8 @@ contains
             ! Read vegetation map
             !
             call prop_get(tmp_ptr, '*', 'VegetationMap', dom%vegfil)
-            if (dom%vegfil == '') then
+            if (dom%vegetation> 0 .and. dom%vegfil == '') then
                write (*, *) 'SWAN_INPUT: no vegetation map used for domain ', domainnr
-               !call handle_errors_mdw(sr)
             end if
          end if
          !

--- a/src/engines_gpl/wave/packages/data/src/wave_data.f90
+++ b/src/engines_gpl/wave/packages/data/src/wave_data.f90
@@ -62,7 +62,7 @@ type wave_time_type
    integer  :: calctimtscale_prev ! calctimtscale from "previous" time point
                                   ! Only used when sr%modsim == 3 for output at the start of the simulation
    integer  :: calccount       ! [-]        Counts the number of calculations. Used for naming the sp2 output files
-   real     :: tscale          ! [sec]      Basic time unit: default = 60.0,
+   real(hp)     :: tscale          ! [sec]      Basic time unit: default = 60.0,
                                ! when running online with FLOW tscale = FLOW_time_step
    real(hp) :: timsec          ! [sec]      Current time of simulation since reference date (0:00h)
    real(hp) :: timmin          ! [min]      Current time of simulation since reference date (0:00h)
@@ -100,7 +100,7 @@ subroutine initialize_wavedata(wavedata)
    wavedata%time%calctimtscale        =  0
    wavedata%time%calctimtscale_prev   =  -999
    wavedata%time%calccount            =  0
-   wavedata%time%tscale               = 60.0
+   wavedata%time%tscale               = 60.0_hp
    wavedata%time%timsec               =  0.0_hp
    wavedata%time%timmin               =  0.0_hp
    wavedata%output%count              =  0
@@ -142,7 +142,7 @@ subroutine settimtscale(wavetime, timtscale_in, modsim, nonstat_interval)
    wavetime%timsec    = real(wavetime%timtscale,hp) * wavetime%tscale
    wavetime%timmin    = wavetime%timsec / 60.0_hp
    if (modsim == 3) then
-      wavetime%calctimtscale = wavetime%timtscale + int(nonstat_interval*60.0/wavetime%tscale)
+      wavetime%calctimtscale = wavetime%timtscale + nint(real(nonstat_interval,hp)*60.0_hp/wavetime%tscale)
       wavetime%calctimtscale_prev = wavetime%timtscale
    else
       wavetime%calctimtscale = wavetime%timtscale
@@ -152,7 +152,7 @@ end subroutine settimtscale
 !
 !===============================================================================
 subroutine settscale(wavetime, tscale_in)
-   real :: tscale_in
+   real(hp) :: tscale_in
    type(wave_time_type) :: wavetime
 
    wavetime%tscale    = tscale_in
@@ -172,7 +172,7 @@ subroutine settimsec(wavetime, timsec_in, modsim, nonstat_interval)
    wavetime%timmin    = wavetime%timsec / 60.0_hp
    wavetime%timtscale = nint(wavetime%timsec / wavetime%tscale)
    if (modsim == 3) then
-      wavetime%calctimtscale = wavetime%timtscale + int(nonstat_interval*60.0/wavetime%tscale)
+      wavetime%calctimtscale = wavetime%timtscale + nint(real(nonstat_interval,hp)*60.0_hp/wavetime%tscale)
       wavetime%calctimtscale_prev = wavetime%timtscale
    else
       wavetime%calctimtscale = wavetime%timtscale
@@ -191,7 +191,7 @@ subroutine settimmin(wavetime, timmin_in, modsim, nonstat_interval)
    wavetime%timsec    = wavetime%timmin * 60.0_hp
    wavetime%timtscale = nint(wavetime%timsec / wavetime%tscale)
    if (modsim == 3) then
-      wavetime%calctimtscale = wavetime%timtscale + int(nonstat_interval*60.0/wavetime%tscale)
+      wavetime%calctimtscale = wavetime%timtscale + nint(real(nonstat_interval,hp)*60.0_hp/wavetime%tscale)
       wavetime%calctimtscale_prev = wavetime%timtscale
    else
       wavetime%calctimtscale = wavetime%timtscale

--- a/src/engines_gpl/wave/packages/io/src/get_params.f90
+++ b/src/engines_gpl/wave/packages/io/src/get_params.f90
@@ -32,6 +32,8 @@ subroutine get_params(tscale, rho, filnam)
 !!--pseudo code and references--------------------------------------------------
 ! NONE
 !!--declarations----------------------------------------------------------------
+    use precision
+   
     implicit none
 !
 ! Local parameters
@@ -40,7 +42,7 @@ subroutine get_params(tscale, rho, filnam)
 !
 ! Global variables
 !
-    real, intent(out)               :: tscale
+    real(hp), intent(out)           :: tscale
     real, intent(out)               :: rho
     character(256)                  :: filnam  ! filename com-file
 !
@@ -72,7 +74,7 @@ subroutine get_params(tscale, rho, filnam)
 !! executable statements -------------------------------------------------------
 !
     rho    = -999.0
-    tscale = -999.0
+    tscale = -999.0_hp
     allocate(rbuff(1))
     wrswch = .false.
     ielem  = 1
@@ -106,7 +108,7 @@ subroutine get_params(tscale, rho, filnam)
               & elmqty    ,elmunt    ,elmdes    ,elmtps    ,nbytsg    , &
               & elmnms(ielem)        ,celidt    ,wrswch    ,error     ,rbuff     )
     if (error /= 0) goto 200
-    tscale = rbuff(1)
+    tscale = real(rbuff(1),hp)
   200 continue
     if (error /= 0) then
        write(*,'(5a)') '*** ERROR: Reading file "', trim(filnam), '.dat" or "', trim(filnam), '.def"'

--- a/src/engines_gpl/wave/packages/io/src/put_wave_fields.f90
+++ b/src/engines_gpl/wave/packages/io/src/put_wave_fields.f90
@@ -705,7 +705,7 @@ subroutine crewav_netcdf(fg       ,itide    ,hrms     ,tp       ,dir      , &
 !
 ! Global variables
 !
-    type (grid)                                 :: fg           ! flow grid
+    type (grid)                     :: fg           ! flow grid
     integer                         :: itide
     integer                         :: mmax
     integer                         :: nmax
@@ -724,7 +724,7 @@ subroutine crewav_netcdf(fg       ,itide    ,hrms     ,tp       ,dir      , &
     real, dimension(mmax, nmax)     :: wsbv
     logical                         :: swflux
     logical                         :: netcdf_sp
-    type (wave_data_type)                       :: wavedata
+    type (wave_data_type)           :: wavedata
 
 !
 ! Local variables
@@ -770,7 +770,7 @@ subroutine crewav_netcdf(fg       ,itide    ,hrms     ,tp       ,dir      , &
     !
     if (netcdf_sp) then
        precision = nf90_float
-       write(*,*) "Writing data to netcdf file in single precision (except the grid)"
+       write(*,*) "Writing data to netcdf file in single precision (except the grid and time)"
     else
        ! default
        precision = nf90_double
@@ -865,40 +865,6 @@ subroutine crewav_netcdf(fg       ,itide    ,hrms     ,tp       ,dir      , &
     endif
     !
     ! put vars (time dependent)
-!hrms = 5.0E-2
-!tp   = 0.9
-!dir  = 270.0
-!diss(:,:,1) = 0.0
-!diss(:,:,2) = 0.0
-!diss(:,:,3) = 0.0
-!diss(:,:,4) = 0.0
-!fx   = 2.0e-3
-!fy   = -9.0e-3
-!wsbu = 5.0e-4
-!wsbv = -4.0e-4
-!mx   = 7.0e-4
-!my   = -2.0e-3
-!tps  = 0.0
-!ubot = 0.0
-!wlen = 0.0
-!
-!hrms = 0.0
-!tp   = 0.0
-!dir  = 0.0
-!diss(:,:,1) = 0.0
-!diss(:,:,2) = 0.0
-!diss(:,:,3) = 0.0
-!diss(:,:,4) = 0.0
-!fx   = 0.0
-!fy   = 0.0
-!wsbu = 0.0
-!wsbv = 0.0
-!mx   = 0.0
-!my   = 0.0
-!tps  = 0.0
-!ubot = 0.0
-!wlen = 0.0
-    !
     ierror = nf90_put_var(idfile, idvar_time   , wavedata%time%timsec, start=(/ localcomcount /)); call nc_check_err(ierror, "put_var time", filename)
     ierror = nf90_put_var(idfile, idvar_hrms   , hrms           , start=(/ 1, localcomcount /), count = (/ mmax, 1 /)); call nc_check_err(ierror, "put_var hrms   ", filename)
     ierror = nf90_put_var(idfile, idvar_tp     , tp             , start=(/ 1, localcomcount /), count = (/ mmax, 1 /)); call nc_check_err(ierror, "put_var tp     ", filename)

--- a/src/engines_gpl/wave/packages/io/src/write_wave_map.f90
+++ b/src/engines_gpl/wave/packages/io/src/write_wave_map.f90
@@ -219,7 +219,7 @@ subroutine write_wave_map(sg, sof, sif, n_swan_grids, wavedata, casl, prevtime, 
    !
    it02 = 0
    itlen = 0
-   call wrpara(filnam, .true., wavedata%time%tscale, idum, 5, ierror)
+   call wrpara(filnam, .true., real(wavedata%time%tscale,sp), idum, 5, ierror)
    call wrpara(filnam, .true., xdum, wavedata%time%refdate, 6, ierror)
    call wrpara(filnam, .true., xdum, it02, 7, ierror)
    call wrpara(filnam, .true., xdum, itlen, 8, ierror)

--- a/src/engines_gpl/wave/packages/io/src/write_wave_map_netcdf.f90
+++ b/src/engines_gpl/wave/packages/io/src/write_wave_map_netcdf.f90
@@ -114,7 +114,7 @@ subroutine write_wave_map_netcdf(sg, sof, sif, n_swan_grids, wavedata, casl, &
    integer :: year
    integer :: month
    integer :: day
-   integer, dimension(1) :: idummy ! Help array to read/write Nefis files
+   real(hp), dimension(1) :: idummy ! Help array to read/write Nefis files
    integer, external :: nc_def_var
    integer :: count_xymiss
    real(hp) :: dearthrad
@@ -359,9 +359,9 @@ subroutine write_wave_map_netcdf(sg, sof, sif, n_swan_grids, wavedata, casl, &
    ! put vars (time dependent)
    !
    if (prevtime) then
-      idummy(1) = wavedata%time%calctimtscale_prev * wavedata%time%tscale
+      idummy(1) = real(wavedata%time%calctimtscale_prev,hp) * wavedata%time%tscale
    else
-      idummy(1) = wavedata%time%calctimtscale * wavedata%time%tscale
+      idummy(1) = real(wavedata%time%calctimtscale,hp) * wavedata%time%tscale
    end if
 
    ierror = nf90_put_var(idfile, idvar_time, idummy(1), start=(/wavedata%output%count/)); call nc_check_err(ierror, "put_var time", filename)

--- a/src/engines_gpl/wave/packages/manager/src/swan_tot.f90
+++ b/src/engines_gpl/wave/packages/manager/src/swan_tot.f90
@@ -93,7 +93,7 @@ subroutine swan_tot(n_swan_grids, n_flow_grids, wavedata, selectedtime)
    else
       if (wavedata%time%timsec >= wavedata%output%nexttim) then
          call setwrite_wavm(wavedata%output, .true.)
-         call setnexttim(wavedata%output, wavedata%time%timsec + swan_run%wavm_write_interval * 60.0)
+         call setnexttim(wavedata%output, wavedata%time%timsec + swan_run%wavm_write_interval * 60.0_hp)
       else
          call setwrite_wavm(wavedata%output, .false.)
       end if
@@ -390,7 +390,7 @@ subroutine swan_tot(n_swan_grids, n_flow_grids, wavedata, selectedtime)
                   if (allocated(tempveg)) deallocate(tempveg)
                   allocate(tempveg(swan_input_fields%mmax, swan_input_fields%nmax))
                   tempveg = swan_input_fields%veg * mult
-                  write (*, '(a,i10,a,f10.3)') '  Write WAVE NetCDF map file, nest ', i_swan, ' time ', wavedata%time%timmin
+                  write (*, '(a,i10,a,f15.3)') '  Write WAVE NetCDF map file, nest ', i_swan, ' time ', wavedata%time%timmin
                   call write_wave_map_netcdf(swan_grids(i_swan), swan_output_fields, swan_input_fields, &
                                      & n_swan_grids, wavedata, swan_run%casl, DataFromPreviousTimestep, &
                                      & swan_run%netcdf_sp, swan_input_fields%mmax, swan_input_fields%nmax, &
@@ -437,7 +437,7 @@ subroutine swan_tot(n_swan_grids, n_flow_grids, wavedata, selectedtime)
                if (allocated(tempveg)) deallocate(tempveg)
                allocate(tempveg(swan_input_fields%mmax, swan_input_fields%nmax))
                tempveg = swan_input_fields%veg * mult
-               write (*, '(a,i10,a,f10.3)') '  Write WAVE NetCDF map file, nest ', i_swan, ' time ', wavedata%time%timmin
+               write (*, '(a,i10,a,f15.3)') '  Write WAVE NetCDF map file, nest ', i_swan, ' time ', wavedata%time%timmin
                call write_wave_map_netcdf(swan_grids(i_swan), swan_output_fields, swan_input_fields, &
                                   & n_swan_grids, wavedata, swan_run%casl, DataFromPreviousTimestep, &
                                   & swan_run%netcdf_sp, swan_input_fields%mmax, swan_input_fields%nmax, &
@@ -445,7 +445,7 @@ subroutine swan_tot(n_swan_grids, n_flow_grids, wavedata, selectedtime)
             end if
          end if
          if (swan_run%output_points .and. swan_run%output_table) then
-            write (*, '(a,i10,a,f10.3)') '  Write WAVE NetCDF his file, nest ', i_swan, ' time ', wavedata%time%timmin
+            write (*, '(a,i10,a,f15.3)') '  Write WAVE NetCDF his file, nest ', i_swan, ' time ', wavedata%time%timmin
             call write_wave_his_netcdf(swan_grids(i_swan), swan_output_fields, n_swan_grids, i_swan, &
                                & wavedata, swan_run%nautical_convention)
          end if

--- a/src/engines_gpl/wave/packages/manager/src/wave_main.f90
+++ b/src/engines_gpl/wave/packages/manager/src/wave_main.f90
@@ -157,7 +157,7 @@ function wave_init(mode_in, mdw_file) result(retval)
    integer                                      :: i_swan       ! counter
    integer                                      :: it01flow     ! reference date obtained from FLOW
    integer                                      :: mtdim
-   real                                         :: tscaleflow   ! basic time unit == flow time step (s)
+   real(hp)                                     :: tscaleflow   ! basic time unit == flow time step (s)
    real(fp)       , dimension(:,:), allocatable :: x_fp         ! Copy of x-coordinate of grid in flexible precision, needed for external forcing module
    real(fp)       , dimension(:,:), allocatable :: y_fp         ! Copy of y-coordinate of grid in flexible precision, needed for external forcing module
    character(60) , dimension(:), allocatable    :: extforce_quantities
@@ -462,7 +462,7 @@ function wave_master_step(stepsize) result(retval)
          if (swan_run%flowgridfile == ' ') then
             call settimtscale(wavedata%time, timtscale, swan_run%modsim, swan_run%nonstat_interval)
          else
-            call settimsec(wavedata%time, wavedata%time%timsec + real(stepsize,sp), swan_run%modsim, swan_run%nonstat_interval)
+            call settimsec(wavedata%time, wavedata%time%timsec + real(stepsize,hp), swan_run%modsim, swan_run%nonstat_interval)
          endif
          !
          ! Run n_swan nested SWAN runs


### PR DESCRIPTION
- Change time variable precision to hp
- Cleanup

TO DO: check if the integer TIME dimension of the wavm file in seconds does not cause more trouble, as that is essentially left alone by casting upscaled tscale back to sp


# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
Test to add @marcio-albernaz 
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ x]	Not applicable 

# Issue link
closes UNST-9874