### PR TITLE
DELWAQ-1260 Add discharge if either side of the sink source in not zero

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/mass_balance_areas.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/mass_balance_areas.f90
@@ -768,13 +768,11 @@ contains
       end do
 
       do n = 1, num_source_sink
-         qsrck = source_sink_water_discharge(n)
-         if (qsrck > 0) then
-            if (mbasorsin(2, n) /= 0) then
+         if (mbasorsin(2, n) /= 0 .or. mbasorsin(1, n) /= 0) then
+            qsrck = source_sink_water_discharge(n)
+            if (qsrck > 0) then
                mbaflowsorsin(2, n) = mbaflowsorsin(2, n) + qsrck * dts
-            end if
-         else if (qsrck < 0) then
-            if (mbasorsin(1, n) /= 0) then
+            else if (qsrck < 0) then
                mbaflowsorsin(1, n) = mbaflowsorsin(1, n) - qsrck * dts
             end if
          end if


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
