### PR TITLE
UNST-9849: Update Splitterplaat testcase

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_physcoef.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_physcoef.f90
@@ -66,7 +66,6 @@ module m_physcoef
 
    real(kind=dp) :: Elder !< add Elder viscosity
    real(kind=dp) :: Smagorinsky !< add Smagorinsky Cs coefficient, vic = vic + (Cs*dx)**2 * S
-   real(kind=dp), parameter :: viuchk = 0.24_dp !< if < 0.5 then eddy viscosity cell peclet check viu<viuchk*dx*dx/dt
 
    real(kind=dp) :: vicoww !< user specified constant vertical eddy viscosity (m2/s)
    real(kind=dp) :: constant_dicoww !< user specified constant vertical eddy diffusivity (m2/s)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/caching.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/caching.f90
@@ -252,7 +252,7 @@ contains
       ! Apparently there is no caching file, so return without further processing
       !
       if (ierr /= 0) then
-         call mess(LEVEL_INFO, 'No cache file available initially. Proceeding with normal initialization.')
+         call mess(LEVEL_WARN, 'No cache file available initially. Proceeding with normal initialization.')
          return
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
@@ -853,11 +853,11 @@ contains
                      turkin1(Lb - 1) = tke * (1.0_dp - alfaT) + alfaT * turkin1(Lb - 1)
                      eps = epsbot / (hu(Lb) - hu(Lb - 1))
                      tureps1(Lb - 1) = eps * (1.0_dp - alfaT) + alfaT * tureps1(Lb - 1)
-
-                     if (jamodelspecific == 1) then
-                        call update_turkin_modelspecific(LL) ! will update turkin1 and tureps1 for all layers of flow link LL.
-                     end if
                   end if
+               end if
+
+               if (jamodelspecific == 1) then
+                  call update_turkin_modelspecific(LL) ! will update turkin1 and tureps1 for all layers of flow link LL.
                end if
 
                vicwmax = 0.1_dp * hu(LL) ! 0.009UH, Elder, uavmax=

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -307,7 +307,7 @@
      </checks>
     </testCase>
     <testCase name="e02_f019_c040_vertical_mixing_layer_3d" ref="dflowfm_default">
-     <path version="2026-03-13T16:21:18.110000">e02_dflowfm/f019_transport/c040_vertical_mixing_layer_3d</path>
+     <path version="2026-04-20T19:07:40.635000">e02_dflowfm/f019_transport/c040_vertical_mixing_layer_3d</path>
      <maxRunTime>15000.0000000</maxRunTime>
      <checks>
       <file name="dflowfmoutput/sp_his.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -307,7 +307,7 @@
      </checks>
     </testCase>
     <testCase name="e02_f019_c040_vertical_mixing_layer_3d" ref="dflowfm_default">
-     <path version="2026-04-20T19:07:40.635000">e02_dflowfm/f019_transport/c040_vertical_mixing_layer_3d</path>
+     <path version="2026-05-19T21:00:00">e02_dflowfm/f019_transport/c040_vertical_mixing_layer_3d</path>
      <maxRunTime>15000.0000000</maxRunTime>
      <checks>
       <file name="dflowfmoutput/sp_his.nc" type="netCDF">


### PR DESCRIPTION
# What was done 
- Updated the splitterplaat testcase:  e02_019_c040_vertical_mixing_layer_3d
- Code changes: the model specific model forcing can now be reached again as it is placed outside unneeded if-statements
- testcase changes: added [model] ModelSpecific = splitter and [model] InputSpecific = 1 to the .mdu. I've set [numerics] verticalAdvectionType = centralImplicit (like Delft3D 4)
- Small additional change: Remove unused keyword viuchk
-  Small additional change: Change an INFO into WARNING
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated: e02_019_c040_vertical_mixing_layer_3d

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9849