### PR TITLE
UNST-9902: Add conan to linux and windows build envs

### DIFF
--- a/.devcontainer/delft3d/Dockerfile
+++ b/.devcontainer/delft3d/Dockerfile
@@ -4,18 +4,25 @@ FROM containers.deltares.nl/delft3d-dev/delft3d-third-party-libs:${THIRD_PARTY_L
 
 ARG USER_UID=1000
 
+ARG THIRD_PARTY_LIBS_TAG
+ARG ENABLE_JAVA=0
+ARG CACHE_SUFFIX=cache-${THIRD_PARTY_LIBS_TAG}-java=${ENABLE_JAVA}
+
 # Set bash as the default shell for RUN commands.
 SHELL ["/bin/bash", "-eo", "pipefail", "-c"]
 
 # Install some tools from the almalinux package manager
-RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked <<"EOF"
+RUN --mount=type=cache,target=/var/cache/dnf,sharing=locked,id=dnf-install-${CACHE_SUFFIX} <<"EOF"
 
-dnf install -y sudo git dos2unix which less tree strace \
-    jq java-17-openjdk java-17-openjdk-devel maven 
-update-alternatives --set java java-17-openjdk.x86_64
+PACKAGES=(sudo dos2unix tree strace)
+[[ "${ENABLE_JAVA}" == "0" ]] || PACKAGES+=(java-17-openjdk java-17-openjdk-devel maven)
+dnf install -y "${PACKAGES[@]}"
+
+if [[ "${ENABLE_JAVA}" != "0" ]]; then
+    update-alternatives --set java java-17-openjdk.x86_64
+    echo 'JAVA_HOME=/usr/lib/jvm/java-17-openjdk' >> /etc/bashrc
+fi
 EOF
-
-ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk
 
 # Create non-root user and grant it sudo privileges:
 # See: https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user
@@ -35,12 +42,12 @@ mkdir ~/.history ~/.aws
 touch ~/.history/.bash_history
 EOF
 
-# Install uv, python, and python tools.
-RUN curl -LsSf https://astral.sh/uv/0.8.4/install.sh | sh
-ENV PATH=/home/dev/.local/bin:$PATH \
-    UV_LINK_MODE=copy
+# Add `uv` binaries in `dev` home folder to the PATH
+ENV PATH=/home/dev/.local/bin:$PATH UV_LINK_MODE=copy
+
+# Use `uv` to install some tools.
 RUN <<"EOF"
-uv python install 3.12
+export UV_PYTHON_DOWNLOADS=never
 uv tool install fortls
 uv tool install fprettify
 EOF

--- a/ci/dockerfiles/linux/buildtools.Dockerfile
+++ b/ci/dockerfiles/linux/buildtools.Dockerfile
@@ -155,10 +155,10 @@ export UV_TOOL_DIR=/opt/uv/share/uv/tools
 export UV_PYTHON_BIN_DIR=/opt/uv/bin
 export UV_TOOL_BIN_DIR=/opt/uv/bin
 
-# Add `/opt/uv/bin` to the `PATH` of all users.
-echo 'PATH=/opt/uv/bin:${PATH}' >> /etc/bashrc
-
 # Install python and python tools.
 uv python install 3.12 --default
 uv tool install conan
 EOF
+
+# Add python 3.12 and uv tools to PATH for all users.
+ENV PATH=/opt/uv/bin:$PATH

--- a/ci/dockerfiles/linux/buildtools.Dockerfile
+++ b/ci/dockerfiles/linux/buildtools.Dockerfile
@@ -13,6 +13,9 @@ ARG INTEL_ONEAPI_VERSION=2024
 RUN --mount=type=cache,target=/var/cache/dnf,id=compilers-cache-${INTEL_ONEAPI_VERSION} <<"EOF"
 set -eo pipefail
 
+# Enable RPM caching in the /var/cache/dnf directory.
+echo 'keepcache=1' >> /etc/dnf/dnf.conf
+
 cat <<EOT > /etc/yum.repos.d/oneAPI.repo
 [oneAPI]
 name=Intel® oneAPI repository
@@ -32,8 +35,8 @@ dnf config-manager --set-enabled powertools
 # modern version than the standard, since the Intel C++ compiler
 # uses the standard library of gcc/g++.
 dnf install --assumeyes \
-    which binutils patchelf diffutils procps m4 make gcc-toolset-14 \
-    wget perl python3 xz
+    binutils patchelf diffutils xz procps m4 make gcc-toolset-14 \
+    perl wget which less unzip git
 
 # For Intel oneAPI, explicitly list the common-vars version, otherwise some much newer versions of packages will also be installed
 # as dependencies. Furthure, do not use intel 2023.2.1, since the dependencies of mkl 2023.2.0 will then also install the C++
@@ -105,36 +108,57 @@ done
 EOF
 
 # ninja is required for building cmake
-RUN <<"EOF"
+RUN --mount=type=cache,target=/var/cache/ninja <<"EOF"
 set -eo pipefail
-wget https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+
+URL=https://github.com/ninja-build/ninja/releases/download/v1.12.1/ninja-linux.zip
+INSTALLER_DIR=/var/cache/ninja/$(basename $(dirname "$URL"))
+if [[ -d "$INSTALLER_DIR" ]]; then
+echo "CACHED $INSTALLER_DIR"
+else
+    mkdir -p $INSTALLER_DIR
+    wget --quiet --output-document="${INSTALLER_DIR}/ninja-linux.zip" $URL
+fi
+
+pushd $INSTALLER_DIR
 unzip ninja-linux.zip
 chmod +x ninja
 mv ninja /usr/bin/
-rm ninja-linux.zip
-
-echo "Installed ninja version:" $(ninja --version)
+popd
 EOF
 
-# CMake
-RUN --mount=type=cache,target=/var/cache/src/,id=cmake-cache-${INTEL_ONEAPI_VERSION} <<"EOF"
-source /etc/bashrc
+RUN --mount=type=cache,target=/var/cache/cmake <<"EOF"
 set -eo pipefail
 
-URL='https://github.com/Kitware/CMake/releases/download/v4.2.3/cmake-4.2.3.tar.gz'
-BASEDIR=$(basename -s '.tar.gz' "$URL")
-if [[ -d "/var/cache/src/${BASEDIR}" ]]; then
-    echo "CACHED ${BASEDIR}"
+URL=https://github.com/Kitware/CMake/releases/download/v4.2.3/cmake-4.2.3-linux-x86_64.sh
+INSTALLER_DIR=/var/cache/cmake/$(basename -s '.sh' "$URL")
+if [[ -d "$INSTALLER_DIR" ]]; then
+    echo "CACHED $INSTALLER_DIR"
 else
-    echo "Fetching ${BASEDIR}.tar.gz..."
-    wget --quiet --output-document=- "$URL" | tar --extract --gzip --file=- --directory='/var/cache/src'
+    mkdir -p $INSTALLER_DIR
+    wget --quiet --output-document="${INSTALLER_DIR}/install_cmake.sh" $URL
 fi
 
-export CC=icx CXX=icpx CFLAGS="-O3" CXXFLAGS="-O3"
-
-pushd /var/cache/src/cmake-4.2.3
-./bootstrap --parallel=$(nproc) -- -DCMAKE_USE_OPENSSL=OFF
-make --jobs=$(nproc)
-make install
+pushd $INSTALLER_DIR
+sh install_cmake.sh --skip-license --prefix=/usr
 popd
+EOF
+
+RUN wget --quiet --output-document=- https://astral.sh/uv/0.11.11/install.sh | UV_INSTALL_DIR=/usr/bin sh
+
+RUN <<"EOF"
+set -eo pipefail
+
+# Configure `uv` to install python and tools in the `/opt/uv` directory. So they are shared with all users.
+export UV_PYTHON_INSTALL_DIR=/opt/uv/share/uv/python
+export UV_TOOL_DIR=/opt/uv/share/uv/tools
+export UV_PYTHON_BIN_DIR=/opt/uv/bin
+export UV_TOOL_BIN_DIR=/opt/uv/bin
+
+# Add `/opt/uv/bin` to the `PATH` of all users.
+echo 'PATH=/opt/uv/bin:${PATH}' >> /etc/bashrc
+
+# Install python and python tools.
+uv python install 3.12 --default
+uv tool install conan
 EOF

--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
@@ -49,17 +49,25 @@ RUN Remove-Item C:\\cmake-3.31.0-rc1-windows-x86_64.msi
 ENV ONEAPI_ROOT="C:\\Program Files (x86)\\Intel\\oneAPI\\"
 ENV VS2022INSTALLDIR="C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\Community\\"
 
-# Download and install Python 3.12.7
-ADD python-3.12.7-amd64.exe C:\\python-3.12.7-amd64.exe
-RUN Start-Process python-3.12.7-amd64.exe -ArgumentList '/quiet InstallAllUsers=1 PrependPath=1' -Wait
-RUN Remove-Item C:\\python-3.12.7-amd64.exe
-RUN New-Item -ItemType SymbolicLink -Path 'C:\\Program Files\\Python312\\python3.exe' -Target 'C:\\Program Files\\Python312\\python.exe'
-
 # Download and install git
 ADD Git-2.47.0-64-bit.exe C:\\Git-2.47.0-64-bit.exe
 RUN Start-Process -FilePath "C:\\Git-2.47.0-64-bit.exe" -ArgumentList "/SILENT" -Wait
 RUN Remove-Item C:\\Git-2.47.0-64-bit.exe
 RUN setx /M PATH $($Env:PATH + ';C:\\Program Files\\Git\\usr\\bin')
+
+# Install uv
+ENV UV_INSTALL_DIR="C:\Program Files\uv\install"
+RUN irm https://astral.sh/uv/0.11.11/install.ps1 | iex
+
+ENV UV_PYTHON_INSTALL_DIR="C:\Program Files\uv\python" \
+    UV_TOOL_DIR="C:\Program Files\uv\tools" \
+    UV_PYTHON_BIN_DIR="C:\Program Files\uv\bin" \
+    UV_TOOL_BIN_DIR="C:\Program Files\uv\bin"
+
+# Install python and conan
+RUN setx /M PATH \"C:\Program Files\uv\bin;C:\Program Files\uv\install;$env:PATH\"
+RUN uv python install 3.12 --default
+RUN uv tool install 'conan ~= 2.28.1'
 
 # Copy the setup script into the container
 COPY set-env-vs2022.cmd C:\\set-env-vs2022.cmd


### PR DESCRIPTION
# What was done 

Add conan to linux and windows build environment containers.

Conan is installed from the python package index. Even though it is a command line tool (not a python library). We use `uv tool` to install conan as a command line tool, so `conan` is in the `PATH`, and has it's own isolated virtual environment. This also means we add `uv` to the build environment, and we use `uv` to install python as well (3.12)

UPDATE:
- Verified that the new windows build environment dockerfile still builds: https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_WindowsBuildEnvironmentI24/7262117
- Verified that the 'all' build still works in the new build environment, and all the tests still pass. Notice I override the `container.tag` parameter to point to the container that was built and pushed earlier: https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_WindowsTest/7263182

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
