### PR TITLE
UNST-9218: Update interpolationMethod-setting in testcases with QUANTITY = initialvertical*

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -1377,6 +1377,13 @@ contains
 
       call split_qid(qid, qid_base, qid_specific)
 
+      if (index(str_tolower(qid_base), 'initialvertical') == 1) then
+         write (msgbuf, '(3a)') 'Fatal error: Quantity '''//trim(qid_base)//''' starting with ''initialvertical'' is not allowed.'
+         call err_flush()
+         success = .false.
+         return
+      end if
+
       ! UNST-8840: temporarily support hydrological quanties either as [Parameter] or [Initial] blocks.
       success = process_hydrological_quantities(qid_base, inifilename, target_location_type, target_array)
       if (associated(target_array)) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -1377,13 +1377,6 @@ contains
 
       call split_qid(qid, qid_base, qid_specific)
 
-      if (index(str_tolower(qid_base), 'initialvertical') == 1) then
-         write (msgbuf, '(3a)') 'Fatal error: Quantity '''//trim(qid_base)//''' starting with ''initialvertical'' is not allowed.'
-         call err_flush()
-         success = .false.
-         return
-      end if
-
       ! UNST-8840: temporarily support hydrological quanties either as [Parameter] or [Initial] blocks.
       success = process_hydrological_quantities(qid_base, inifilename, target_location_type, target_array)
       if (associated(target_array)) then

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -715,7 +715,7 @@
     </testCase>
 
     <testCase name="e02_f021_c001_bedwithobstacle_anticreep" ref="dflowfm_default">
-      <path version="2026-05-26T09:01:36.951000">e02_dflowfm/f021_anti-creep/c001_bedwithobstacle_anticreep</path>
+      <path version="2026-05-26T12:01:36.951000">e02_dflowfm/f021_anti-creep/c001_bedwithobstacle_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
@@ -730,7 +730,7 @@
     </testCase>
 
     <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
-      <path version="2026-05-26T09:01:41.162000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <path version="2026-05-26T12:01:41.162000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -745,7 +745,7 @@
     </testCase>
 
     <testCase name="e02_f021_c003_slopingbed_anticreep_z" ref="dflowfm_default">
-      <path version="2026-05-26T09:01:44.833000">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
+      <path version="2026-05-26T12:01:44.833000">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -760,7 +760,7 @@
     </testCase>
 
     <testCase name="e02_f021_c004_slopingbed_anticreep_z_sigma" ref="dflowfm_default">
-      <path version="2026-05-26T09:01:49.228000">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
+      <path version="2026-05-26T12:01:49.228000">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -775,7 +775,7 @@
     </testCase>
 
     <testCase name="e02_f021_c101_bedwithobstacle_anticreep_nonequi_3d" ref="dflowfm_default">
-      <path version="2026-05-26T09:00:46.653000">e02_dflowfm/f021_anti-creep/c101_bedwithobstacle_anticreep_nonequi_3d</path>
+      <path version="2026-05-26T12:00:46.653000">e02_dflowfm/f021_anti-creep/c101_bedwithobstacle_anticreep_nonequi_3d</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
@@ -790,7 +790,7 @@
     </testCase>
 
     <testCase name="e02_f021_c102_slopingbed_anticreep_nonequi_3d" ref="dflowfm_default">
-      <path version="2026-05-26T09:00:54.544000">e02_dflowfm/f021_anti-creep/c102_slopingbed_anticreep_nonequi_3d</path>
+      <path version="2026-05-26T12:00:54.544000">e02_dflowfm/f021_anti-creep/c102_slopingbed_anticreep_nonequi_3d</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -715,7 +715,7 @@
     </testCase>
 
     <testCase name="e02_f021_c001_bedwithobstacle_anticreep" ref="dflowfm_default">
-      <path version="2025-10-07T06:57:58.555000">e02_dflowfm/f021_anti-creep/c001_bedwithobstacle_anticreep</path>
+      <path version="2026-05-26T09:01:36.951000">e02_dflowfm/f021_anti-creep/c001_bedwithobstacle_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
@@ -730,7 +730,7 @@
     </testCase>
 
     <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
-      <path version="2025-10-07T06:58:02.648000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
+      <path version="2026-05-26T09:01:41.162000">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -745,7 +745,7 @@
     </testCase>
 
     <testCase name="e02_f021_c003_slopingbed_anticreep_z" ref="dflowfm_default">
-      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
+      <path version="2026-05-26T09:01:44.833000">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -760,7 +760,7 @@
     </testCase>
 
     <testCase name="e02_f021_c004_slopingbed_anticreep_z_sigma" ref="dflowfm_default">
-      <path version="2026-05-04T16:00:00">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
+      <path version="2026-05-26T09:01:49.228000">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
@@ -775,7 +775,7 @@
     </testCase>
 
     <testCase name="e02_f021_c101_bedwithobstacle_anticreep_nonequi_3d" ref="dflowfm_default">
-      <path version="2025-10-07T06:58:06.480000">e02_dflowfm/f021_anti-creep/c101_bedwithobstacle_anticreep_nonequi_3d</path>
+      <path version="2026-05-26T09:00:46.653000">e02_dflowfm/f021_anti-creep/c101_bedwithobstacle_anticreep_nonequi_3d</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
@@ -790,7 +790,7 @@
     </testCase>
 
     <testCase name="e02_f021_c102_slopingbed_anticreep_nonequi_3d" ref="dflowfm_default">
-      <path version="2025-10-07T06:58:11.100000">e02_dflowfm/f021_anti-creep/c102_slopingbed_anticreep_nonequi_3d</path>
+      <path version="2026-05-26T09:00:54.544000">e02_dflowfm/f021_anti-creep/c102_slopingbed_anticreep_nonequi_3d</path>
       <maxRunTime>15000.0000000</maxRunTime>
       <checks>
         <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">


### PR DESCRIPTION
# What was done 
- Change "interpolationMethod = linearSpaceTime" to "interpolationMethod = constant" for QUANTITY = initialvertical*
 
# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9218