### PR TITLE
fix: remove trigger rules on ci python test

### DIFF
--- a/ci/teamcity/Delft3D/ciUtilities/TestPythonCiTools.kt
+++ b/ci/teamcity/Delft3D/ciUtilities/TestPythonCiTools.kt
@@ -38,14 +38,6 @@ object TestPythonCiTools : BuildType({
 
     triggers {
         vcs { 
-            // Trigger this build only if there are changes to the files matching these rules.
-            // Absolute paths match paths relative to the VCS root.
-            // See: https://www.jetbrains.com/help/teamcity/configuring-vcs-triggers.html#General+Syntax
-            triggerRules = """
-                +:/ci/python/**/*.py
-                +:/ci/python/pyproject.toml
-                +:/ci/python/uv.lock
-            """.trimIndent()
             branchFilter = "+:pull/*"
         }
     }


### PR DESCRIPTION
# What was done 

- Teamcity only evaluates trigger rules based on a commit-by-commit basis instead of a whole branch, so it becomes possible to merge failing changes if you don't modify those files in the latest commit. Since they are fairly quick to run, this PR lmakes the python CI checks run for all commits. 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link

[DEVOPS-949](https://issuetracker.deltares.nl/browse/DEVOPSDSC-949)
