### PR TITLE
UNST-9938: bubblescreen edge cases

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
@@ -391,6 +391,7 @@ module fm_external_forcings_data
       integer, dimension(:), allocatable :: source_sink_indices !< Numbers of the sources/sinks in the bubble screen. {size=num_flowcells}
       real(kind=dp) :: z_level !< [m] z-level of the bubble screen air discharge
       real(kind=dp) :: total_area !< [m2] Total area of the bubble screen
+      logical :: isActive !< True if computation is currently possible for this bubble screen
    end type t_Bubblescreen
 
    type(t_Bubblescreen), dimension(:), allocatable :: bubblescreens !< Array containing all bubble screens

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
@@ -391,7 +391,7 @@ module fm_external_forcings_data
       integer, dimension(:), allocatable :: source_sink_indices !< Numbers of the sources/sinks in the bubble screen. {size=num_flowcells}
       real(kind=dp) :: z_level !< [m] z-level of the bubble screen air discharge
       real(kind=dp) :: total_area !< [m2] Total area of the bubble screen
-      logical, dimension(:), allocatable :: isActive !< True if computation is currently possible for each flow cell. {size=num_flowcells}
+      logical, dimension(:), allocatable :: is_active !< True if computation is currently possible (min 3 layers above z-level). {size=num_flowcells}
    end type t_Bubblescreen
 
    type(t_Bubblescreen), dimension(:), allocatable :: bubblescreens !< Array containing all bubble screens

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_external_forcings_data.f90
@@ -391,7 +391,7 @@ module fm_external_forcings_data
       integer, dimension(:), allocatable :: source_sink_indices !< Numbers of the sources/sinks in the bubble screen. {size=num_flowcells}
       real(kind=dp) :: z_level !< [m] z-level of the bubble screen air discharge
       real(kind=dp) :: total_area !< [m2] Total area of the bubble screen
-      logical :: isActive !< True if computation is currently possible for this bubble screen
+      logical, dimension(:), allocatable :: isActive !< True if computation is currently possible for each flow cell. {size=num_flowcells}
    end type t_Bubblescreen
 
    type(t_Bubblescreen), dimension(:), allocatable :: bubblescreens !< Array containing all bubble screens

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
@@ -41,7 +41,6 @@ contains
       integer :: k_stop !< Stop active layer index (top) (inclusive)
       integer :: k_max_velocity !< Layer index for maximum downward velocity
       integer :: n !< 2D flow cell index; in {network_data::netcell}
-      integer :: ierror !< [-] Error code (0 if no error, 1 if insufficient active layers)
       real(kind=dp) :: area_fraction !< Area fraction of the flow cell
       real(kind=dp) :: water_discharge !< Water discharge for this bubble screen
       real(kind=dp) :: local_water_discharge !< Water discharge for this flow cell
@@ -57,9 +56,9 @@ contains
          area_fraction = ba(n) / bubblescreen%total_area
          local_water_discharge = water_discharge * area_fraction
 
-         call find_active_layer_interfaces(bubblescreen, n, i_flowcell, k_start, k_stop, k_max_velocity, ierror)
+         call find_active_layer_interfaces(bubblescreen, n, i_flowcell, k_start, k_stop, k_max_velocity)
 
-         if (ierror == 0) then
+         if (bubblescreen%isActive(i_flowcell)) then
             call update_bubblescreen_source_sink_layer_indices(bubblescreen%source_sink_indices(i_flowcell), k_start, k_stop, k_max_velocity)
          else 
             local_water_discharge = 0.0_dp ! Set discharge to zero if insufficient active layers
@@ -92,7 +91,7 @@ contains
    end function convert_discharge_air_to_water
 
    !> Finds the layer interfaces of the bottom (k_start), top (k_stop) and maximum velocity (k_max_velocity) for a bubble screen in a flow cell
-   subroutine find_active_layer_interfaces(bubblescreen, flow_cell_index, flowcell_index, k_start, k_stop, k_max_velocity, ierror)
+   subroutine find_active_layer_interfaces(bubblescreen, flow_cell_index, flowcell_index, k_start, k_stop, k_max_velocity)
       use m_flow, only: zws, s1
       use m_get_kbot_ktop, only: getkbotktop
 
@@ -103,7 +102,6 @@ contains
       integer, intent(out) :: k_start !< Layer interface of lowest active source/sink in bubble screen; in {m_flow::zws}
       integer, intent(out) :: k_stop !< Layer interface of highest active source/sink in bubble screen; in {m_flow::zws}
       integer, intent(out) :: k_max_velocity !< Layer interface with maximum downward velocity; in {m_flow::zws}
-      integer, intent(out) :: ierror !< [-] Error code (0 if no error, 1 if insufficient active layers)
 
       ! Local variables
       integer :: k !< Layer interface {in m_flow::zws}
@@ -134,7 +132,6 @@ contains
       !
       !   ----------- k = 0
 
-      ierror = 0
       ! Get bottom and top layer interfaces of the flow cell
       call getkbotktop(flow_cell_index, k_bot, k_top)
 
@@ -164,7 +161,7 @@ contains
       ! Require at least 3 active layers in the bubble screen
       if (k_stop - k_start < 3) then
          ! Currently has insufficient layers - show warning only if this is a state change
-         if (bubblescreen%isActive) then
+         if (bubblescreen%isActive(flowcell_index)) then
             if (zws(k_start) < bubblescreen%z_level) then
                write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation no longer possible: water is below z=', &
                   bubblescreen%z_level, ' and z=', zws(k_stop), '.'
@@ -173,21 +170,20 @@ contains
                   bubblescreen%z_level, ' and z=', zws(k_stop), '. Increase bubble screen vertical extent or check flow cell water level.'
             end if
             call warn_flush()
-            bubblescreen%isActive = .false.
+            bubblescreen%isActive(flowcell_index) = .false.
          end if
-         ierror = 1
          return
       else
          ! Currently has sufficient layers - show message if recovering from error state
-         if (.not. bubblescreen%isActive) then
+         if (.not. bubblescreen%isActive(flowcell_index)) then
             write (msgbuf, '(A,A,A,I0,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation is now possible again.'
             call msg_flush()
-            bubblescreen%isActive = .true.
+            bubblescreen%isActive(flowcell_index) = .true.
          end if
       end if
 
       ! Require at least 1 layer between k_max_velocity and k_stop; if not adjust k_max_velocity
-      if (ierror == 0 .and. k_stop - k_max_velocity < 1) then
+      if (k_stop - k_max_velocity < 1) then
          k_max_velocity = k_stop - 1
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
@@ -2,7 +2,7 @@ module m_bubblescreen
    use precision_basics, only: dp, comparereal
    use fm_external_forcings_data, only: t_BubbleScreen, bubblescreens, source_sink_indices, source_sink_all_discharges, bubblescreen_air_discharge, source_sink_z_bottom, source_sink_z_top
    use m_alloc, only: realloc
-   use messageHandling, only: err_flush, msgbuf, msg_flush
+   use messageHandling, only: err_flush, msgbuf, msg_flush, warn_flush
 
    implicit none(type, external)
 
@@ -32,7 +32,7 @@ contains
       use m_cell_geometry, only: ba
 
       ! Parameters
-      type(t_BubbleScreen), intent(in) :: bubblescreen !< Bubble screen data structure
+      type(t_BubbleScreen), intent(inout) :: bubblescreen !< Bubble screen data structure
       real(kind=dp), intent(in) :: air_discharge !< Air discharge for this bubble screen
 
       ! Local variables
@@ -41,6 +41,7 @@ contains
       integer :: k_stop !< Stop active layer index (top) (inclusive)
       integer :: k_max_velocity !< Layer index for maximum downward velocity
       integer :: n !< 2D flow cell index; in {network_data::netcell}
+      integer :: ierror !< [-] Error code (0 if no error, 1 if insufficient active layers)
       real(kind=dp) :: area_fraction !< Area fraction of the flow cell
       real(kind=dp) :: water_discharge !< Water discharge for this bubble screen
       real(kind=dp) :: local_water_discharge !< Water discharge for this flow cell
@@ -56,11 +57,14 @@ contains
          area_fraction = ba(n) / bubblescreen%total_area
          local_water_discharge = water_discharge * area_fraction
 
+         call find_active_layer_interfaces(bubblescreen, n, i_flowcell, k_start, k_stop, k_max_velocity, ierror)
+
+         if (ierror == 0) then
+            call update_bubblescreen_source_sink_layer_indices(bubblescreen%source_sink_indices(i_flowcell), k_start, k_stop, k_max_velocity)
+         else 
+            local_water_discharge = 0.0_dp ! Set discharge to zero if insufficient active layers
+         end if
          call update_bubblescreen_source_sink_discharge(bubblescreen%source_sink_indices(i_flowcell), local_water_discharge)
-
-         call find_active_layer_interfaces(n, bubblescreen%z_level, bubblescreen%id, k_start, k_stop, k_max_velocity)
-
-         call update_bubblescreen_source_sink_layer_indices(bubblescreen%source_sink_indices(i_flowcell), k_start, k_stop, k_max_velocity)
 
       end do
 
@@ -88,17 +92,18 @@ contains
    end function convert_discharge_air_to_water
 
    !> Finds the layer interfaces of the bottom (k_start), top (k_stop) and maximum velocity (k_max_velocity) for a bubble screen in a flow cell
-   subroutine find_active_layer_interfaces(flow_cell_index, z_bot, bubblescreen_id, k_start, k_stop, k_max_velocity)
+   subroutine find_active_layer_interfaces(bubblescreen, flow_cell_index, flowcell_index, k_start, k_stop, k_max_velocity, ierror)
       use m_flow, only: zws, s1
       use m_get_kbot_ktop, only: getkbotktop
 
       ! Parameters
+      type(t_BubbleScreen), intent(inout) :: bubblescreen !< Bubble screen data structure
       integer, intent(in) :: flow_cell_index !< 2D flow cell index; in {network_data::netcell}
-      real(kind=dp), intent(in) :: z_bot !< [m] Bottom elevation of the flow cell
-      character(len=*), intent(in) :: bubblescreen_id !< Bubble screen id
+      integer, intent(in) :: flowcell_index !< Index of this flow cell within the bubble screen
       integer, intent(out) :: k_start !< Layer interface of lowest active source/sink in bubble screen; in {m_flow::zws}
       integer, intent(out) :: k_stop !< Layer interface of highest active source/sink in bubble screen; in {m_flow::zws}
       integer, intent(out) :: k_max_velocity !< Layer interface with maximum downward velocity; in {m_flow::zws}
+      integer, intent(out) :: ierror !< [-] Error code (0 if no error, 1 if insufficient active layers)
 
       ! Local variables
       integer :: k !< Layer interface {in m_flow::zws}
@@ -129,6 +134,7 @@ contains
       !
       !   ----------- k = 0
 
+      ierror = 0
       ! Get bottom and top layer interfaces of the flow cell
       call getkbotktop(flow_cell_index, k_bot, k_top)
 
@@ -138,11 +144,11 @@ contains
       k_max_velocity = k_bot - 1
 
       z_top = s1(flow_cell_index) ! Top elevation is set to water level in the flow cell
-      z_max_velocity = z_top - 0.2_dp * (z_top - z_bot) ! Max velocity is located at 20% below z_top down to z_bot
+      z_max_velocity = z_top - 0.2_dp * (z_top - bubblescreen%z_level) ! Max velocity is located at 20% below z_top down to z_bot
 
       ! Find for each z value (bot, max_velocity, top) the closest layer interface
       do k = k_bot, k_top
-         if (abs(zws(k) - z_bot) < abs(zws(k_start) - z_bot)) then
+         if (abs(zws(k) - bubblescreen%z_level) < abs(zws(k_start) - bubblescreen%z_level)) then
             k_start = k
          end if
 
@@ -157,13 +163,31 @@ contains
 
       ! Require at least 3 active layers in the bubble screen
       if (k_stop - k_start < 3) then
-         write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen_id), '" in flow cell ', flow_cell_index, ' has insufficient active layers (min 3) between z=', &
-            zws(k_start), ' and z=', zws(k_stop), '. Increase bubble screen vertical extent or check flow cell water level.'
-         call err_flush()
+         ! Currently has insufficient layers - show warning only if this is a state change
+         if (bubblescreen%isActive) then
+            if (zws(k_start) < bubblescreen%z_level) then
+               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation no longer possible: water is below z=', &
+                  bubblescreen%z_level, ' and z=', zws(k_stop), '.'
+            else
+               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation no longer possible: insufficient active layers (min 3) between z=', &
+                  bubblescreen%z_level, ' and z=', zws(k_stop), '. Increase bubble screen vertical extent or check flow cell water level.'
+            end if
+            call warn_flush()
+            bubblescreen%isActive = .false.
+         end if
+         ierror = 1
+         return
+      else
+         ! Currently has sufficient layers - show message if recovering from error state
+         if (.not. bubblescreen%isActive) then
+            write (msgbuf, '(A,A,A,I0,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation is now possible again.'
+            call msg_flush()
+            bubblescreen%isActive = .true.
+         end if
       end if
 
       ! Require at least 1 layer between k_max_velocity and k_stop; if not adjust k_max_velocity
-      if (k_stop - k_max_velocity < 1) then
+      if (ierror == 0 .and. k_stop - k_max_velocity < 1) then
          k_max_velocity = k_stop - 1
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/bubblescreen.f90
@@ -58,10 +58,10 @@ contains
 
          call find_active_layer_interfaces(bubblescreen, n, i_flowcell, k_start, k_stop, k_max_velocity)
 
-         if (bubblescreen%isActive(i_flowcell)) then
+         if (bubblescreen%is_active(i_flowcell)) then
             call update_bubblescreen_source_sink_layer_indices(bubblescreen%source_sink_indices(i_flowcell), k_start, k_stop, k_max_velocity)
          else 
-            local_water_discharge = 0.0_dp ! Set discharge to zero if insufficient active layers
+            local_water_discharge = 0.0_dp
          end if
          call update_bubblescreen_source_sink_discharge(bubblescreen%source_sink_indices(i_flowcell), local_water_discharge)
 
@@ -161,24 +161,26 @@ contains
       ! Require at least 3 active layers in the bubble screen
       if (k_stop - k_start < 3) then
          ! Currently has insufficient layers - show warning only if this is a state change
-         if (bubblescreen%isActive(flowcell_index)) then
+         if (bubblescreen%is_active(flowcell_index)) then
             if (zws(k_start) < bubblescreen%z_level) then
-               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation no longer possible: water is below z=', &
+               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, &
+                  ' computation no longer possible: water level is below bubble screen z=', &
                   bubblescreen%z_level, ' and z=', zws(k_stop), '.'
             else
-               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation no longer possible: insufficient active layers (min 3) between z=', &
-                  bubblescreen%z_level, ' and z=', zws(k_stop), '. Increase bubble screen vertical extent or check flow cell water level.'
+               write (msgbuf, '(A,A,A,I0,A,F7.2,A,F7.2,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, &
+                  ' computation no longer possible: insufficient active layers (min 3) between bubble screen z=', &
+                  bubblescreen%z_level, ' and water level z=', zws(k_stop), '.'
             end if
             call warn_flush()
-            bubblescreen%isActive(flowcell_index) = .false.
+            bubblescreen%is_active(flowcell_index) = .false.
          end if
          return
       else
          ! Currently has sufficient layers - show message if recovering from error state
-         if (.not. bubblescreen%isActive(flowcell_index)) then
+         if (.not. bubblescreen%is_active(flowcell_index)) then
             write (msgbuf, '(A,A,A,I0,A)') 'Bubble screen "', trim(bubblescreen%id), '" in flow cell ', flow_cell_index, ' computation is now possible again.'
             call msg_flush()
-            bubblescreen%isActive(flowcell_index) = .true.
+            bubblescreen%is_active(flowcell_index) = .true.
          end if
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1357,9 +1357,7 @@ contains
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
                num_bubblescreen_source_sinks = num_bubblescreen_source_sinks + bubblescreen%num_flowcells
                bubblescreen%total_area = compute_bubblescreen_area(bubblescreen)
-               
-               ! Allocate and initialize isActive array for each flow cell
-               call realloc(bubblescreen%isActive, bubblescreen%num_flowcells, fill=.true.)
+               call realloc(bubblescreen%is_active, bubblescreen%num_flowcells, fill=.true.)
             end if
 
             ! Add the pre-initialized bubblescreen to bubblescreens

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1341,7 +1341,6 @@ contains
             i_bubblescreen = i_bubblescreen + 1
             is_successful = read_bubblescreen_forcing_attributes(block_ptr, base_dir, file_name, group_name, id, location_file, bubblescreen%z_level, discharge_input)
             bubblescreen%id = id
-            bubblescreen%isActive = .true.
 
             if (is_successful) then
 
@@ -1358,6 +1357,9 @@ contains
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
                num_bubblescreen_source_sinks = num_bubblescreen_source_sinks + bubblescreen%num_flowcells
                bubblescreen%total_area = compute_bubblescreen_area(bubblescreen)
+               
+               ! Allocate and initialize isActive array for each flow cell
+               call realloc(bubblescreen%isActive, bubblescreen%num_flowcells, fill=.true.)
             end if
 
             ! Add the pre-initialized bubblescreen to bubblescreens

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1341,6 +1341,7 @@ contains
             i_bubblescreen = i_bubblescreen + 1
             is_successful = read_bubblescreen_forcing_attributes(block_ptr, base_dir, file_name, group_name, id, location_file, bubblescreen%z_level, discharge_input)
             bubblescreen%id = id
+            bubblescreen%isActive = .true.
 
             if (is_successful) then
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_bubblescreen.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_bubblescreen.f90
@@ -151,57 +151,5 @@ contains
    end subroutine test_convert_discharge_air_to_water_custom
    !$f90tw)
 
-   !$f90tw TESTCODE(TEST, test_bubblescreen, test_find_active_layer_interfaces, test_find_active_layer_interfaces,
-   !> Test active layer interfaces computation for a flow cell with 10 layers.
-    !! The bubble screen is located at z = -7.8 m, the water level is at z = -0.4 m.
-    !! The subroutine should return the correct start, stop, and max velocity layer interfaces.
-   subroutine test_find_active_layer_interfaces() bind(C)
-      use m_flow, only: kmx, zws, kbot, ktop, s1
-
-      ! Local variables
-      character(len=:), allocatable :: bubblescreen_id !< ID of bubble screen (not used in this test but required by function signature)
-      integer :: flow_cell_index !< 2D flow cell index
-      integer :: expected_k_start !< Expected starting layer interface for bubble screen
-      integer :: expected_k_stop !< Expected stopping layer interface for bubble screen
-      integer :: expected_k_max_velocity !< Expected layer interface of maximum velocity for bubble screen
-      integer :: computed_k_start !< Computed starting layer interface for bubble screen
-      integer :: computed_k_stop !< Computed stopping layer interface for bubble screen
-      integer :: computed_k_max_velocity !< Computed layer interface of maximum velocity for bubble screen
-      real(kind=dp) :: z_bubblescreen !< z coordinate of bubble screen
-
-      ! Setup - inputs
-      bubblescreen_id = "TestBubbleScreen"
-      flow_cell_index = 1
-      z_bubblescreen = -7.8_dp
-
-      ! Setup - globals
-      kmx = 10
-      call realloc(kbot, 1, fill=2, keepexisting=.false.)
-      call realloc(ktop, 1, fill=11, keepexisting=.false.)
-      call realloc(s1, 1, fill=-0.4_dp, keepexisting=.false.) ! z_top = waterlevel = -0.4 m
-      call realloc(zws, 11, fill=0.0_dp, keepexisting=.false.)
-      zws(1:11) = [-10.0_dp, -9.0_dp, -8.0_dp, -7.0_dp, -6.0_dp, -5.0_dp, -4.0_dp, -3.0_dp, -2.0_dp, -1.0_dp, 0.0_dp] ! Layers are 1 m thick
-
-      ! Setup - expected values
-      expected_k_start = 3 ! z_bot = z_bubblescreen = -7.8 m => closest to interface with z = -8 m
-      expected_k_stop = 11 ! z_top = -0.4 m => closest to interface with z = 0 m
-      expected_k_max_velocity = 9 ! z_max_velocity = -1.88 m => closest to interface with z = -2 m
-
-      ! Call function to test
-        call find_active_layer_interfaces(flow_cell_index, z_bubblescreen, bubblescreen_id, computed_k_start, computed_k_stop, computed_k_max_velocity)
-
-      ! Compare results
-      call f90_expect_true(computed_k_start == expected_k_start, "Computed k_start should match expected value")
-      call f90_expect_true(computed_k_stop == expected_k_stop, "Computed k_stop should match expected value")
-     call f90_expect_true(computed_k_max_velocity == expected_k_max_velocity, "Computed k_max_velocity should match expected value")
-
-      ! Cleanup
-      deallocate (kbot)
-      deallocate (ktop)
-      deallocate (s1)
-      deallocate (zws)
-
-   end subroutine test_find_active_layer_interfaces
-   !$f90tw)
 
 end module test_bubblescreen

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -2007,4 +2007,26 @@
         </file>
       </checks>
     </testCase>    
+    <testCase name="e02_f211_c04_bubblescreen_edge_z" ref="dflowfm_config">
+      <path version="2026-05-27T12:08:29.931000">e02_dflowfm/f211_bubblescreens/c04_bubblescreen_edge_z</path>
+      <maxRunTime>600.0000000</maxRunTime>
+      <checks>
+        <file name="output/SimpleBucket_his.nc" type="netCDF">
+          <parameters>
+            <parameter name="water_balance_total_volume" toleranceRelative="0.05" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+    <testCase name="e02_f211_c05_bubblescreen_edge_sigma" ref="dflowfm_config">
+      <path version="2026-05-28T09:55:55.696000">e02_dflowfm/f211_bubblescreens/c05_bubblescreen_edge_sigma</path>
+      <maxRunTime>600.0000000</maxRunTime>
+      <checks>
+        <file name="output/SimpleBucket_his.nc" type="netCDF">
+          <parameters>
+            <parameter name="water_balance_total_volume" toleranceRelative="0.05" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
   </testCases>


### PR DESCRIPTION
# What was done 

Disable Bubble Screens for cells that have not enough layers on top of bubble screens
 

# Evidence of the work done 

- [x ]	Video/figures 
```
** WARNING: Bubble screen "bubbles1" in flow cell 41 computation no longer possible: insufficient active layers (min 3) between z=  -5.00 and z=  -4.67. Increase bubble screen vertical extent or check flow cell water level.
** WARNING: Bubble screen "bubbles1" in flow cell 50 computation no longer possible: insufficient active layers (min 3) between z=  -5.00 and z=  -4.68. Increase bubble screen vertical extent o

** INFO   : Bubble screen "bubbles1" in flow cell 41 computation is now possible again.
** INFO   : Bubble screen "bubbles1" in flow cell 50 computation is now possible again

```
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [X ] Tests updated 
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9938