### PR TITLE
DEVOPSDSC-967 (fix-up): Do not bind the AWS credentials in the report build config

### DIFF
--- a/ci/teamcity/Delft3D/verschilanalyse/ReportVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/ReportVerschilanalyse.kt
@@ -45,7 +45,6 @@ object ReportVerschilanalyse: BuildType({
             dockerRunParameters = """
                 --rm
                 --entrypoint=/bin/bash
-                --volume="%env.AWS_SHARED_CREDENTIALS_FILE%:/root/.aws/credentials:ro"
                 -e AWS_CA_BUNDLE="/etc/pki/tls/cert.pem" 
             """.trimIndent()
         }


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSDSC-967