### PR TITLE
UNST-9961: Test new `jposhchk` via branch

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wrwaq.F90
@@ -469,14 +469,10 @@ contains
 
       write (lunhyd, '(a,a)') 'task      ', 'full-coupling'
 
-      if (layertype == LAYTP_SIGMA) then ! sigma-layers
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured sigma-layers'
-      elseif (layertype == LAYTP_Z) then ! z- or z-sigma-layers
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured z- or z-sigma-layers'
-      elseif (layertype == LAYTP_POLYGON_MIXED) then
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured polygon defined z-layers'
-      elseif (layertype == LAYTP_DENS_SIGMA) then
-         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured density controlled sigma-layers'
+      if ((layertype == LAYTP_SIGMA) .or. (layertype == LAYTP_DENS_SIGMA)) then ! (density controlled) sigma-layers
+         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured'
+      elseif ((layertype == LAYTP_Z) .or. (layertype == LAYTP_POLYGON_MIXED)) then ! (polygon defined) z- or z-sigma-layers
+         write (lunhyd, '(a,a)') 'geometry  ', 'unstructured z-layers'
       else ! other?
          write (lunhyd, '(a,a)') 'geometry  ', 'unstructured other'
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/poshcheck.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/poshcheck.f90
@@ -170,7 +170,7 @@ contains
                               is_hu_changed = .true.
                            end if
                         end do
-                     case (8) ! set dry all attached links
+                     case (8) ! set dry all attached links, do not redo timestep
                         do link_index = 1, nd(node)%lnx
                            link = abs(nd(node)%ln(link_index))
                            upwind_waterheight(link) = SET_VALUE

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/poshcheck.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/poshcheck.f90
@@ -170,6 +170,12 @@ contains
                               is_hu_changed = .true.
                            end if
                         end do
+                     case (8) ! set dry all attached links
+                        do link_index = 1, nd(node)%lnx
+                           link = abs(nd(node)%ln(link_index))
+                           upwind_waterheight(link) = SET_VALUE
+                           is_hu_changed = .true.
+                        end do
                      end select
                   end if
 


### PR DESCRIPTION
# What was done 

Branch created from 2026.02 release.

Added an 8th option to `jposhchk` that is the same as option 2, however without the redo of the timestep. This is for testing of the DCSM by Firmijn. 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
