### PR TITLE
fix link in testbench manual

### DIFF
--- a/test/deltares_testbench/doc/readme-testbench.tex
+++ b/test/deltares_testbench/doc/readme-testbench.tex
@@ -203,7 +203,7 @@ Running the testbench will usually follow these steps, arguments to overwrite th
 \newpage
 \section{Users}
 \subsection{Run testcase}
-Once the installation steps are done you can now use the testbench. To run tests we need engines. They can be build locally or you can get them from TeamCity for windows here: \url{https://dpcbuild.deltares.nl/buildConfiguration/Dimr\_DimrCollectors\_1aDimrCollectorDailyWin64}.
+Once the installation steps are done you can now use the testbench. To run tests we need engines. They can be build locally or you can get them from TeamCity for windows here: \url{https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_WindowsCollect/}.
 
 Open the build tab artifacts and download the recent main branch dimrset zip file. Extract the contents of the zip file into \dir{data/engines/teamcity\_artifacts/} \autoref{fig:artifact}.
 \begin{figure}[H]


### PR DESCRIPTION
# What was done 


- A link in the docs was broken, so I updated it to a new place where people can download the engines. 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [x]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
[DEVOPSDSC-620](https://issuetracker.deltares.nl/browse/DEVOPSDSC-620)