### PR TITLE
UNST-9945: Fix allocation of bubblescreen sourcesink array in parralel

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1294,6 +1294,8 @@ contains
       use messageHandling, only: err_flush, msgbuf
       use m_bubblescreen, only: compute_bubblescreen_area
       use m_structures, only: nNodesBubbleScreen, nodeCountBubbleScreen
+      use m_partitioninfo, only: jampi, reduce_cells
+      use m_flowgeom, only: ndx
 
       ! Parameters
       type(tree_data), pointer, intent(in) :: bnd_ptr !< tree of extForceBnd-file's [boundary] blocks
@@ -1318,6 +1320,8 @@ contains
 
       type(tree_data), pointer :: block_ptr
       type(t_Bubblescreen) :: bubblescreen
+      integer :: n_cells
+      integer, dimension(:), allocatable :: bubblescreen_cells
 
       ! Initialization
       i_bubblescreen = 0
@@ -1355,7 +1359,15 @@ contains
                ! Find cells crossed by the polyline and pre-init the bubblescreen data structure
                call find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, bubblescreen%flowcell_indices, error)
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
-               num_bubblescreen_source_sinks = num_bubblescreen_source_sinks + bubblescreen%num_flowcells
+               n_cells = bubblescreen%num_flowcells
+               ! we need the global number of bubblescreen cells, addsorsin must be called on every partition
+               bubblescreen_cells = bubblescreen%flowcell_indices
+               if (jampi == 1) then
+                  bubblescreen_cells = reduce_cells(bubblescreen%flowcell_indices, ndx)
+                  n_cells = size(bubblescreen_cells)
+               end if
+
+               num_bubblescreen_source_sinks = num_bubblescreen_source_sinks + n_cells
                bubblescreen%total_area = compute_bubblescreen_area(bubblescreen)
             end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1360,7 +1360,8 @@ contains
                call find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, bubblescreen%flowcell_indices, error)
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
                n_cells = bubblescreen%num_flowcells
-               ! we need the global number of bubblescreen cells, addsorsin must be called on every partition
+               ! we need the global number of bubblescreen cells, otherswise when doing addSourceSink the vectors will be re-allocated
+               ! and then EC-module will be left with dangling pointers. 
                bubblescreen_cells = bubblescreen%flowcell_indices
                if (jampi == 1) then
                   bubblescreen_cells = reduce_cells(bubblescreen%flowcell_indices, ndx)


### PR DESCRIPTION
# What was done 

Fix allocation of bubblescreen sourcesink array in parralel
 

# Evidence of the work done 

- [ ]	Video/figures  
- [X ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9945