### PR TITLE
UNST-9957 don't write averaged dmiss

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
@@ -141,18 +141,36 @@ contains
    !> Update the stat_output of an item, depending on the operation_type.
    elemental subroutine update_statistical_output(item, dts)
       use precision, only: dp
+      use m_missing, only: dmiss
+      use precision_basics, only: equal
       type(t_output_variable_item), intent(inout) :: item !< statistical output item to update
       real(kind=dp), intent(in) :: dts !< current timestep
+      logical, allocatable :: mask(:)
+      real(kind=dp), pointer :: source(:)
+
+      if (item%operation_type == SO_CURRENT) then
+         return
+      end if
+
+      ! Check for dmiss values, they may not be included in any averaging
+      mask = equal(item%source_input, dmiss)
+      if (any(mask)) then ! we cannot modify input, create a copy with dmiss values set to 0.
+         allocate(source(size(item%source_input)))
+         source = item%source_input
+         where (mask)
+            source = 0.0_dp
+         end where
+      else
+         source => item%source_input
+      end if
 
       if (item%operation_type == SO_MIN .or. item%operation_type == SO_MAX) then ! max/min of moving average requested
-         call update_moving_average_data(item%moving_average_data, item%source_input, dts)
+         call update_moving_average_data(item%moving_average_data, source, dts)
       end if
 
       select case (item%operation_type)
-      case (SO_CURRENT)
-         return
       case (SO_AVERAGE)
-         item%stat_output = item%stat_output + item%source_input * dts
+         item%stat_output = item%stat_output + source * dts
          item%time_step_sum = item%time_step_sum + dts
       case (SO_MAX)
          item%stat_output = max(item%stat_output, calculate_moving_average(item%moving_average_data))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
@@ -141,36 +141,18 @@ contains
    !> Update the stat_output of an item, depending on the operation_type.
    elemental subroutine update_statistical_output(item, dts)
       use precision, only: dp
-      use m_missing, only: dmiss
-      use precision_basics, only: equal
       type(t_output_variable_item), intent(inout) :: item !< statistical output item to update
       real(kind=dp), intent(in) :: dts !< current timestep
-      logical, allocatable :: mask(:)
-      real(kind=dp), pointer :: source(:)
-
-      if (item%operation_type == SO_CURRENT) then
-         return
-      end if
-
-      ! Check for dmiss values, they may not be included in any averaging
-      mask = equal(item%source_input, dmiss)
-      if (any(mask)) then ! we cannot modify input, create a copy with dmiss values set to 0.
-         allocate(source(size(item%source_input)))
-         source = item%source_input
-         where (mask)
-            source = 0.0_dp
-         end where
-      else
-         source => item%source_input
-      end if
 
       if (item%operation_type == SO_MIN .or. item%operation_type == SO_MAX) then ! max/min of moving average requested
-         call update_moving_average_data(item%moving_average_data, source, dts)
+         call update_moving_average_data(item%moving_average_data, item%source_input, dts)
       end if
 
       select case (item%operation_type)
+      case (SO_CURRENT)
+         return
       case (SO_AVERAGE)
-         item%stat_output = item%stat_output + source * dts
+         item%stat_output = item%stat_output + item%source_input * dts
          item%time_step_sum = item%time_step_sum + dts
       case (SO_MAX)
          item%stat_output = max(item%stat_output, calculate_moving_average(item%moving_average_data))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
@@ -141,16 +141,24 @@ contains
    !> Update the stat_output of an item, depending on the operation_type.
    elemental subroutine update_statistical_output(item, dts)
       use precision, only: dp
+      use m_missing, only: dmiss
+      use precision_basics, only: equal
+
       type(t_output_variable_item), intent(inout) :: item !< statistical output item to update
       real(kind=dp), intent(in) :: dts !< current timestep
+
+      if (item%operation_type == SO_CURRENT) then
+         return
+      end if
+
+      item%missing = item%missing .or. equal(item%source_input, dmiss)
 
       if (item%operation_type == SO_MIN .or. item%operation_type == SO_MAX) then ! max/min of moving average requested
          call update_moving_average_data(item%moving_average_data, item%source_input, dts)
       end if
 
       select case (item%operation_type)
-      case (SO_CURRENT)
-         return
+
       case (SO_AVERAGE)
          item%stat_output = item%stat_output + item%source_input * dts
          item%time_step_sum = item%time_step_sum + dts
@@ -163,14 +171,19 @@ contains
       end select
    end subroutine update_statistical_output
 
-   !> Perform the final time interval averaging on an item,
-   !! after all values haven been summed up in %stat_output.
+   !> Perform the final time interval averaging on an item, after all values haven been summed up in %stat_output.
+   ! additionally, set the final output value to dmiss if any data was missing during the interval.
    elemental subroutine finalize_average(item)
+      use m_missing, only: dmiss
 
       type(t_output_variable_item), intent(inout) :: item !< The item to be processed. Will be double-checked on its operation type.
 
       if (item%operation_type == SO_AVERAGE) then
          item%stat_output = item%stat_output / item%time_step_sum
+      end if
+
+      if (any(item%operation_type == [SO_AVERAGE, SO_MIN, SO_MAX])) then ! missing array is allocated for any averaging output
+         item%stat_output(item%missing) = dmiss
       end if
 
    end subroutine finalize_average
@@ -194,6 +207,9 @@ contains
       case default
          return
       end select
+
+      item%missing = .false. ! reset missing flag for new output interval
+
    end subroutine reset_statistical_output
 
    !> Create a new output item and add it to the output set according to output quantity config
@@ -324,10 +340,9 @@ contains
       select case (item%operation_type)
       case (SO_CURRENT)
          item%stat_output => item%source_input
-      case (SO_AVERAGE)
+      case (SO_MIN, SO_MAX, SO_AVERAGE)
          allocate (item%stat_output(input_size))
-      case (SO_MIN, SO_MAX)
-         allocate (item%stat_output(input_size))
+         allocate(item%missing(input_size))
       case (SO_NONE)
          continue
       case default

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output.f90
@@ -183,7 +183,9 @@ contains
       end if
 
       if (any(item%operation_type == [SO_AVERAGE, SO_MIN, SO_MAX])) then ! missing array is allocated for any averaging output
-         item%stat_output(item%missing) = dmiss
+         where (item%missing)
+            item%stat_output = dmiss
+         end where
       end if
 
    end subroutine finalize_average

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output_types.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_statistical_output_types.f90
@@ -59,6 +59,7 @@ module m_statistical_output_types
                                                      !! required this variable points to the basic variable (e.g. s1).
                                                      !! Otherwise during the simulation the intermediate results are stored.
       real(dp), pointer, dimension(:) :: source_input !< The (possibly transformed) data over which statistics are gathered
+      logical, dimension(:), allocatable :: missing !< logical array, set to true if value in stat_output was missing at any point in the current output interval.
       procedure(process_data_interface_double), nopass, pointer :: source_input_function_pointer => null() !< Function pointer for operation that needs to be performed to produce source_input
       real(dp) :: time_step_sum !< Sum of time steps since the last output interval, used for average calculation
       type(t_moving_average_data), allocatable :: moving_average_data !< Data stored for keeping track of a moving average


### PR DESCRIPTION
… statistical output

# What was done 

<a short description with bullets> 

- for averaging output, if at any point during the output interval a missing value is encountered, the entire output interval is skipped and dmiss is written
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
