### PR TITLE
UNST-9954: prevent flux warnings for ghost cells

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -64,6 +64,8 @@ module m_flow ! flow arrays-999
    integer :: numtopsig = 0 !< number of top layers in sigma
    integer :: janumtopsiguniform = 1 !< specified nr of top layers in sigma is same everywhere
 
+   integer, allocatable :: ndkx2ndx(:)  ! Maps NDKX → NDX
+
    real(kind=dp) :: Tsigma = 100 !< relaxation period; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
 
    integer :: layertype !< Vertical layertype, use one of LAYTP_SIGMA, LAYTP_Z, LAYTP_POLYGON_MIXED, LAYTP_DENS_SIGMA parameters
@@ -729,5 +731,28 @@ contains
 
       res = (jasal > 0 .or. temperature_model /= TEMPERATURE_MODEL_NONE .or. jased > 0)
    end function use_density
+
+   subroutine mapndkx2ndx()
+      use m_cell_geometry, only: ndx
+      use m_alloc, only: realloc
+      
+      integer :: n, k
+
+      call realloc(ndkx2ndx, ndkx)
+
+      ! Fill the surface layer
+      do n = 1, ndx
+         ndkx2ndx(n) = n
+      end do
+
+      ! Fill the 3D layers
+      if (kmx > 0) then
+         do n = 1, ndx
+            do k = kbot(n), ktop(n)
+               ndkx2ndx(k) = n
+            end do
+         end do
+      end if
+   end subroutine mapndkx2ndx
 
 end module m_flow

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -748,7 +748,7 @@ contains
       ! Fill the 3D layers
       if (kmx > 0) then
          do n = 1, ndx
-            do k = kbot(n), ktop(n)
+            do k = kbot(n), kbot(n) + kmxn(n) - 1
                ndkx2ndx(k) = n
             end do
          end do

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -64,7 +64,7 @@ module m_flow ! flow arrays-999
    integer :: numtopsig = 0 !< number of top layers in sigma
    integer :: janumtopsiguniform = 1 !< specified nr of top layers in sigma is same everywhere
 
-   integer, allocatable :: ndkx2ndx(:)  ! Maps NDKX → NDX
+   integer, allocatable :: ndkx_to_ndx(:)  ! Maps NDKX → NDX
 
    real(kind=dp) :: Tsigma = 100 !< relaxation period; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
 
@@ -732,27 +732,27 @@ contains
       res = (jasal > 0 .or. temperature_model /= TEMPERATURE_MODEL_NONE .or. jased > 0)
    end function use_density
 
-   subroutine mapndkx2ndx()
+   subroutine map_ndkx_to_ndx()
       use m_cell_geometry, only: ndx
       use m_alloc, only: realloc
       
       integer :: n, k
 
-      call realloc(ndkx2ndx, ndkx)
+      call realloc(ndkx_to_ndx, ndkx)
 
       ! Fill the surface layer
       do n = 1, ndx
-         ndkx2ndx(n) = n
+         ndkx_to_ndx(n) = n
       end do
 
       ! Fill the 3D layers
       if (kmx > 0) then
          do n = 1, ndx
             do k = kbot(n), kbot(n) + kmxn(n) - 1
-               ndkx2ndx(k) = n
+               ndkx_to_ndx(k) = n
             end do
          end do
       end if
-   end subroutine mapndkx2ndx
+   end subroutine map_ndkx_to_ndx
 
 end module m_flow

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
@@ -6489,7 +6489,7 @@ contains
    !< if there is no mapping, assumes true
    !< also returns true if there is no partitioning 
    function is_3d_layer_in_current_partition(idx_ndkx) result(is_in_partition)
-      use m_flow, only: ndkx2ndx, ndkx, kmx
+      use m_flow, only: ndkx_to_ndx, ndkx, kmx
       
       integer, intent(in) :: idx_ndkx !< 3d layer index
       logical :: is_in_partition
@@ -6507,7 +6507,7 @@ contains
       end if
 
       if (idx_ndkx >= 1 .and. idx_ndkx <= ndkx) then
-         ndx = ndkx2ndx(idx_ndkx)
+         ndx = ndkx_to_ndx(idx_ndkx)
       else
          ndx = -1
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
@@ -6489,7 +6489,7 @@ contains
    !< if there is no mapping, assumes true
    !< also returns true if there is no partitioning 
    function is_3d_layer_in_current_partition(idx_ndkx) result(is_in_partition)
-      use m_flow, only: ndkx2ndx, ndkx
+      use m_flow, only: ndkx2ndx, ndkx, kmx
       
       integer, intent(in) :: idx_ndkx !< 3d layer index
       logical :: is_in_partition

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
@@ -6496,13 +6496,13 @@ contains
 
       integer :: ndx
 
-      if (kmx == 0) then
-         is_in_partition  = idomain(idx_ndkx) == my_rank
+      if (jampi == 0 .or. (.not. allocated(idomain))) then
+         is_in_partition = .true.
          return
       end if
 
-      if (jampi == 0 .or. (.not. allocated(idomain))) then
-         is_in_partition = .true.
+      if (kmx == 0) then
+         is_in_partition  = idomain(idx_ndkx) == my_rank
          return
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
@@ -6496,6 +6496,11 @@ contains
 
       integer :: ndx
 
+      if (kmx == 0) then
+         is_in_partition  = idomain(idx_ndkx) == my_rank
+         return
+      end if
+
       if (jampi == 0 .or. (.not. allocated(idomain))) then
          is_in_partition = .true.
          return

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/partition.F90
@@ -6484,4 +6484,34 @@ contains
 
    end function reduce_cells
 
+   !< checks if a 3d layer is in the current partition
+   !< uses ndkx2ndx mapping.
+   !< if there is no mapping, assumes true
+   !< also returns true if there is no partitioning 
+   function is_3d_layer_in_current_partition(idx_ndkx) result(is_in_partition)
+      use m_flow, only: ndkx2ndx, ndkx
+      
+      integer, intent(in) :: idx_ndkx !< 3d layer index
+      logical :: is_in_partition
+
+      integer :: ndx
+
+      if (jampi == 0 .or. (.not. allocated(idomain))) then
+         is_in_partition = .true.
+         return
+      end if
+
+      if (idx_ndkx >= 1 .and. idx_ndkx <= ndkx) then
+         ndx = ndkx2ndx(idx_ndkx)
+      else
+         ndx = -1
+      end if
+
+      if (ndx > 0) then
+         is_in_partition  = idomain(ndx) == my_rank
+      else ! if there is no mapping, assume the layer is in the partition
+         is_in_partition = .true.
+      end if
+   end function is_3d_layer_in_current_partition
+
 end module m_partitioninfo

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
@@ -53,8 +53,9 @@ contains
       use m_flowtimes, only: dts
       use m_flowparameters, only: cflmx
       use m_flow, only: jadiusp, diusp, dicouv, jacreep, dsalL, dtemL, &
-                        number_steps_limited_visc_flux_links, MAX_PRINTS_LIMITED_VISC_FLUX_LINKS
+                        number_steps_limited_visc_flux_links, MAX_PRINTS_LIMITED_VISC_FLUX_LINKS, ndkx2ndx
       use m_transport, only: ISALT, ITEMP
+      use m_partitioninfo, only:  idomain, my_rank, jampi
 
       implicit none
 
@@ -372,8 +373,16 @@ contains
                      flux_max_limit = min(fluxfacMaxL, fluxfacMaxR)
                      if (fluxfac > flux_max_limit) then
                         fluxfac = flux_max_limit ! zie Borsboom sobek note
-                        !$omp atomic
-                        number_limited_links = number_limited_links + 1
+                        if (jampi == 1 .and. allocated(idomain)) then
+                           !check if the flow nodes are real nodes (not ghost nodes). In ghost nodes, the flux is not computed and limited
+                           if (idomain(ndkx2ndx(k1)) == my_rank .and. idomain(ndkx2ndx(k2)) == my_rank) then
+                              !$omp atomic
+                              number_limited_links = number_limited_links + 1
+                           end if
+                        else 
+                           !$omp atomic
+                           number_limited_links = number_limited_links + 1
+                        end if
                      end if
                   end if
                   fluxfac = max(fluxfac, 0.0_dp)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
@@ -55,7 +55,7 @@ contains
       use m_flow, only: jadiusp, diusp, dicouv, jacreep, dsalL, dtemL, &
                         number_steps_limited_visc_flux_links, MAX_PRINTS_LIMITED_VISC_FLUX_LINKS, ndkx2ndx
       use m_transport, only: ISALT, ITEMP
-      use m_partitioninfo, only:  idomain, my_rank, jampi
+      use m_partitioninfo, only:  is_3d_layer_in_current_partition
 
       implicit none
 
@@ -372,14 +372,8 @@ contains
                   if (jalimitdiff == 1) then
                      flux_max_limit = min(fluxfacMaxL, fluxfacMaxR)
                      if (fluxfac > flux_max_limit) then
-                        fluxfac = flux_max_limit ! zie Borsboom sobek note
-                        if (jampi == 1 .and. allocated(idomain)) then
-                           !check if the flow nodes are real nodes (not ghost nodes). In ghost nodes, the flux is not computed and limited
-                           if (idomain(ndkx2ndx(k1)) == my_rank .and. idomain(ndkx2ndx(k2)) == my_rank) then
-                              !$omp atomic
-                              number_limited_links = number_limited_links + 1
-                           end if
-                        else 
+                        fluxfac = flux_max_limit
+                        if (is_3d_layer_in_current_partition(k1) .and. is_3d_layer_in_current_partition(k2)) then
                            !$omp atomic
                            number_limited_links = number_limited_links + 1
                         end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_transport/comp_fluxhor3d.f90
@@ -53,7 +53,7 @@ contains
       use m_flowtimes, only: dts
       use m_flowparameters, only: cflmx
       use m_flow, only: jadiusp, diusp, dicouv, jacreep, dsalL, dtemL, &
-                        number_steps_limited_visc_flux_links, MAX_PRINTS_LIMITED_VISC_FLUX_LINKS, ndkx2ndx
+                        number_steps_limited_visc_flux_links, MAX_PRINTS_LIMITED_VISC_FLUX_LINKS
       use m_transport, only: ISALT, ITEMP
       use m_partitioninfo, only:  is_3d_layer_in_current_partition
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
@@ -445,6 +445,9 @@ contains
          end do
          ndkx = kk
 
+         ! Create mapping from 3D indices (ndkx) to 2D horizontal cells (ndx)
+         call mapndkx2ndx()
+         
          LL = Lnx ! Stapelen vanaf grondlaag
          do L = 1, lnx
             n1 = ln(1, L)
@@ -1238,7 +1241,5 @@ contains
 
       call set_kbot_ktop(jazws0=1)
       
-      ! Create mapping from 3D indices (ndkx) to 2D horizontal cells (ndx)
-      call mapndkx2ndx()
    end subroutine flow_allocflow
 end module m_flow_allocflow

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
@@ -64,7 +64,7 @@ contains
                         soiltempthick, his_write_settings, qtotmap, qevamap, qfrevamap, qconmap, qfrconmap, qsunmap, qlongmap, ustbc, &
                         idensform, jarichardsononoutput, q1waq, qwwaq, itstep, sqwave, infiltrationmodel, dfm_hyd_noinfilt, infilt, &
                         dfm_hyd_infilt_const, infiltcap, infiltcapuni, jagrw, pgrw, bgrw, sgrw1, sgrw0, h_aquiferuni, bgrwuni, janudge, zcs, &
-                        use_density
+                        use_density, mapndkx2ndx
       use m_flowtimes, only: dtcell, time_wetground, autotimestep, AUTO_TIMESTEP_2D_OUT, AUTO_TIMESTEP_3D_HOR_OUT, &
                              AUTO_TIMESTEP_3D_HOR_INOUT, ja_timestep_nostruct, ti_waq
       use m_missing, only: dmiss
@@ -1237,5 +1237,8 @@ contains
       end if
 
       call set_kbot_ktop(jazws0=1)
+      
+      ! Create mapping from 3D indices (ndkx) to 2D horizontal cells (ndx)
+      call mapndkx2ndx()
    end subroutine flow_allocflow
 end module m_flow_allocflow

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
@@ -64,7 +64,7 @@ contains
                         soiltempthick, his_write_settings, qtotmap, qevamap, qfrevamap, qconmap, qfrconmap, qsunmap, qlongmap, ustbc, &
                         idensform, jarichardsononoutput, q1waq, qwwaq, itstep, sqwave, infiltrationmodel, dfm_hyd_noinfilt, infilt, &
                         dfm_hyd_infilt_const, infiltcap, infiltcapuni, jagrw, pgrw, bgrw, sgrw1, sgrw0, h_aquiferuni, bgrwuni, janudge, zcs, &
-                        use_density, mapndkx2ndx
+                        use_density, map_ndkx_to_ndx
       use m_flowtimes, only: dtcell, time_wetground, autotimestep, AUTO_TIMESTEP_2D_OUT, AUTO_TIMESTEP_3D_HOR_OUT, &
                              AUTO_TIMESTEP_3D_HOR_INOUT, ja_timestep_nostruct, ti_waq
       use m_missing, only: dmiss
@@ -446,7 +446,7 @@ contains
          ndkx = kk
 
          ! Create mapping from 3D indices (ndkx) to 2D horizontal cells (ndx)
-         call mapndkx2ndx()
+         call map_ndkx_to_ndx()
          
          LL = Lnx ! Stapelen vanaf grondlaag
          do L = 1, lnx


### PR DESCRIPTION
# What was done 

Remove 
** WARNING: Horizontal transport flux was limited for 6 links.

when this is issued for ghost cells (parallel runs).

# Evidence of the work done 

- [ ]	Video/figures 
- [ ]	Clear from the issue description 
- [X]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9954