### PR TITLE
Fix crash when loading old external forcings file with 'initialtracer'

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -4512,8 +4512,6 @@ contains
          isfun = find_name(sfunname, waqinput)
          itemPtr1 => item_waqsfun(isfun)
          dataPtr1 => sfuninp(isfun, :)
-      case ('initialtracer')
-         continue
       case ('friction_coefficient_chezy', 'friction_coefficient_manning', 'friction_coefficient_walllawnikuradse', &
             'friction_coefficient_whitecolebrook', 'friction_coefficient_stricklernikuradse', &
             'friction_coefficient_strickler', 'friction_coefficient_debosbijkerk')


### PR DESCRIPTION
This crashed the noordzee model in SOFTSUP-39999: https://issuetracker.deltares.nl/browse/SOFTSUP-39999
The actual problem reported in SOFTSUP-39999 is unrelated though.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
