### PR TITLE
DELWAQ-1265: Correct the handling of the mesh name

### DIFF
--- a/src/engines_gpl/waq/waq_netcdf/waq_netcdf_utils.F90
+++ b/src/engines_gpl/waq/waq_netcdf/waq_netcdf_utils.F90
@@ -1640,6 +1640,7 @@ contains
                             'up                                      ', &
                             'ocean_sigma_coordinate                  '  /)
 
+            k = len_trim(mesh_name)
             write(layer_dim_name, '(3a)') mesh_name(1:k), '_layer_dlwq'
             ierror = nf90_def_var(nc_id, layer_dim_name, nf90_float, (/ layers_dim_id /), cum_layer_var_id)
             if (ierror /= 0) then


### PR DESCRIPTION
I had forgotten to nicely determine the length of the mesh name in case of the fallback option. That is repaired with this commit.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
