### PR TITLE
UNST-9795: Fix incorrect cardinality in source_sinks%indices

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/source_sink.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/source_sink.f90
@@ -439,10 +439,10 @@ contains
          end if
 
          do i = 1, source_sinks%num_total - 1
-            if (source_sinks%indices(1, i) /= 0 .and. kk == source_sinks%indices(1, i)) then
+            if (source_sinks%indices(i, 1) /= 0 .and. kk == source_sinks%indices(i, 1)) then
                write (msgbuf, '(4a)') 'FROM point of ', trim(source_sinks%name(source_sinks%num_total)), ' coincides with FROM point of ', trim(source_sinks%name(i))
                call warn_flush()
-            else if (source_sinks%indices(4, i) /= 0 .and. kk == source_sinks%indices(4, i)) then
+            else if (source_sinks%indices(i, 4) /= 0 .and. kk == source_sinks%indices(i, 4)) then
                write (msgbuf, '(4a)') 'FROM point of ', trim(source_sinks%name(source_sinks%num_total)), ' coincides with TO   point of ', trim(source_sinks%name(i))
                call warn_flush()
             end if


### PR DESCRIPTION
# What was done 

The cardinality of `source_sinks%indices` was incorrect in a part of the `addsorsin` routine. Hopefully this fixes the flaky testcases 🤞 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
