### PR TITLE
UNST-9795 Do not reallocate the source_sinks%is_normal array

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2594,8 +2594,11 @@ contains
         call reduce_logical_array_or(source_sinks%num_total, is_source_sink_bubblescreen)
       end if
 
-      ! Negate to get is_source_sink_normal (as we actually compute is_source_sink_bubble)
-      source_sinks%is_normal = .NOT. is_source_sink_bubblescreen
+      ! Negate to get is_source_sink_normal (as we actually compute is_source_sink_bubble).
+      ! Note: source_sinks%is_normal (and the other source/sink arrays) are sized to the over-allocated
+      ! capacity, while is_source_sink_bubblescreen is sized to num_total.
+      source_sinks%is_normal(1:source_sinks%num_total) = .not. is_source_sink_bubblescreen
+      source_sinks%is_normal(source_sinks%num_total + 1:) = .false.
       source_sinks%num_normal = count(source_sinks%is_normal)
 
       call fill_geometry_source_sinks()


### PR DESCRIPTION
See title, bug causes issues in output file writing.

Copilot:
Root cause
The recent source/sink refactor (#911, "Migrate source/sink variables to own module") changed the source/sink arrays to be over-allocated to a capacity (max_num_src, doubled on growth) rather than sized exactly to the number of source/sinks. The arrays source_sinks%name, x, y, discharge, cumulative_volume, average_discharge_previous and the module array source_sink_all_discharges all keep that capacity size.

In [fm_external_forcings.f90:2597](vscode-file://vscode-app/c:/Users/wierenga/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) the mask was set with a whole-array assignment:

is_source_sink_bubblescreen is sized to num_total, so this assignment (Fortran auto-reallocate-LHS) shrinks is_normal to num_total. After that, is_normal no longer conforms to the capacity-sized arrays. Every pack(<capacity array>, source_sinks%is_normal) in the output filter [f](vscode-file://vscode-app/c:/Users/wierenga/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html)unctions (f[m_statistical_output.f90](vscode-file://vscode-app/c:/Users/wierenga/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) lines 199–264) and the name writer ([unc_write_his.F90 line 1583](vscode-file://vscode-app/c:/Users/wierenga/AppData/Local/Programs/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html)) then runs with mismatched array/mask shapes → out-of-bounds access / heap corruption. The corruption clobbers a neighboring station output config's allocatable nc_dim_ids, which finally trips the unrelated-looking check in write_station_netcdf_variable:

Programming error: Station NetCDF variable must have the station dimension

This only triggers when the capacity exceeds the actual count (e.g. nearfield/cosumo or source-sinks partly outside the grid), which is why it shows up in specific testcases.

Fix
Assign the mask through an array section so is_normal keeps its full capacity extent, and explicitly mark the unused trailing slots as non-normal. This keeps it conformable with the other capacity-sized arrays and yields the correct num_normal, regardless of compiler auto-realloc behavior.