### PR TITLE
Fix out-of-bounds array index in EC harmonic-correction converter

### DIFF
--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -2960,7 +2960,7 @@ contains
                         if (np > 0 .and. mp > 0) then
                            do jj = 0, 1
                               do ii = 0, 1
-                                 ipt = (mp - 1 + ii) * n_cols + np - 1 + jj
+                                 ipt = (np - 1 + jj) * n_cols + mp + ii
                                  amplitude = sourceT1Field%arr1d(ipt)
                                  phase0 = sourceItem%hframe%phases(mp + ii, np + jj)
                                  if (comparereal(amplitude, sourceMissing, .true.) == 0 .or. &


### PR DESCRIPTION
# Fix out-of-bounds array index in EC harmonic-correction converter

**Branch:** `fm/bugfix/ec_harmonic_correction_array_index` (based on `main`)
**File:** `src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90`

## Problem

The `has_harmonics` (non-sparse) branch of `ecConverterNetcdf` flattens the
source-field index with column/row transposed and 0-based:

```fortran
np = indexWeight%indices(1, j)   ! row
mp = indexWeight%indices(2, j)   ! col
ipt = (mp - 1 + ii) * n_cols + np - 1 + jj     ! BUG
amplitude = sourceT1Field%arr1d(ipt)
```

`arr1d` is stored column-fastest with shape `(n_cols, n_rows)` — as used
everywhere else in the file, e.g. `s2D(1:n_cols,1:n_rows) => arr1d`
accessed as `s2D(mp+ii, np+jj)`. The expression above (a) multiplies the
*column* index by `n_cols` instead of the *row* index, and (b) is 0-based,
so at the grid corner (`mp=np=1, ii=jj=0`) it gives `ipt = 0` and accesses
`arr1d(0)`, one element before the array start. The same `ipt` feeds the two
`arr1d(ipt)` writes just below.

This is used for harmonic forcing corrections such as the SA/SSA
atmospheric-pressure corrections (`*_harmonic_SA/SSA_correction_*.nc`).

## Fix

```fortran
ipt = (np - 1 + jj) * n_cols + mp + ii
```

Matches the column-fastest, 1-based convention used by the `s2D`/`s3D`
pointer accesses: minimum `ipt = 1`, maximum `ipt = n_rows * n_cols`, both
in bounds.

## How it was found

This was discovered by **building and running the code with gfortran**
(gfortran/OpenMPI build) on the coupled DCSM-FM + SWAN model (8 MPI ranks).
The run crashed with SIGSEGV during the first external-forcings evaluation;
a per-rank `gdb` backtrace pinned it to the harmonic SA/SSA pressure
correction:

```
#0 ecconverternetcdf            ec_converter.f90:2902
#1 ecconverterperformconversions ec_converter.f90:1057
#2 ecitemupdatetargetitem        ec_item.f90:449
#3 ecitemgetvalues (itemid=1249) ec_item.f90:228
```

With Intel the stray `arr1d(0)` read lands on adjacent valid memory and goes
unnoticed; gfortran's stricter memory layout turns the same undefined
access into a hard segfault, which is what exposed the latent bug. After the
fix, all ranks complete forcing initialization and the coupled run proceeds
into the time loop.

## Risk

Low — a single-expression correctness fix on the `has_harmonics` path,
reproducing the indexing convention already used throughout the file. No
interface or behaviour change for non-harmonic forcings.