### PR TITLE
Fix qqlat BMI setter to use the 2D pointer it assigns from

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_lib/include/bmi_set_var.inc
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_lib/include/bmi_set_var.inc
@@ -155,7 +155,7 @@
      call c_f_pointer(xptr, x_2d_double_ptr, shape(qplat))
      qplat(:,:) = x_2d_double_ptr
   case("qqlat")
-     call c_f_pointer(xptr, x_3d_double_ptr, shape(qqlat))
+     call c_f_pointer(xptr, x_2d_double_ptr, shape(qqlat))
      qqlat(:,:) = x_2d_double_ptr
   case("balat")
      call c_f_pointer(xptr, x_1d_double_ptr, shape(balat))


### PR DESCRIPTION
# Fix `qqlat` BMI setter: map C pointer into the 2D pointer it assigns from

## Problem
In `set_var` (`bmi_set_var.inc`), the `qqlat` case mapped the incoming C pointer
into the **3D** Fortran pointer, but then assigned `qqlat` from the **2D** pointer:

```fortran
case("qqlat")
   call c_f_pointer(xptr, x_3d_double_ptr, shape(qqlat))   ! 3D pointer associated
   qqlat(:,:) = x_2d_double_ptr                             ! 2D pointer never set!
```

`x_2d_double_ptr` was never associated with `xptr`, so `set_var("qqlat", ...)`
copied stale/garbage data instead of the value provided by the caller. In
addition, `qqlat` is rank-2, so passing `shape(qqlat)` (2 elements) to the 3D
pointer was itself malformed.

## Fix
Map the C pointer into the 2D pointer that the assignment actually reads from:

```fortran
case("qqlat")
   call c_f_pointer(xptr, x_2d_double_ptr, shape(qqlat))
   qqlat(:,:) = x_2d_double_ptr
```

One-line change, consistent with the neighbouring `qplat` case.
