### PR TITLE
Fix prop_get_version_number leaving present major/minor undefined

### DIFF
--- a/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
+++ b/src/utils_lgpl/deltares_common/packages/deltares_common/src/properties.f90
@@ -3260,6 +3260,10 @@ contains
       integer :: iend
       integer :: major_, minor_
 
+      ! Default to version 1.0 when no version key is present or cannot be parsed.
+      major_ = 1
+      minor_ = 0
+
       if (present(chapterin)) then
          chapterin_ = chapterin
       else
@@ -3269,6 +3273,15 @@ contains
          keyin_ = keyin
       else
          keyin_ = 'fileVersion'
+      end if
+
+      ! Set the (optional) intent(out) results to their defaults before any early
+      ! return below, so that a present major/minor is never left undefined.
+      if (present(major)) then
+         major = major_
+      end if
+      if (present(minor)) then
+         minor = minor_
       end if
 
       call prop_get_string(tree, chapterin_, keyin_, string, success)


### PR DESCRIPTION
# Fix `prop_get_version_number`: never leave a present `major`/`minor` undefined

## Problem
`major` and `minor` are `intent(out), optional`. The routine returns early in two
places without assigning them:

- when the version key is absent (`prop_get_string` fails), and
- when the value cannot be parsed (`get_version_major_minor_integer` fails).

If the caller passed `major`/`minor`, those arguments are left **undefined** on
those paths — undefined behaviour on any compiler.

## Fix
Initialise the local results to the documented default (version 1.0) and write the
present `intent(out)` arguments before the early returns, so they always hold a
defined value. The success path continues to overwrite them with the parsed
version.
