### PR TITLE
UNST-10012: Fix flaky getprof 1d unit test

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_getprof_1d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_getprof_1d.f90
@@ -463,6 +463,7 @@ contains
       real(kind=dp) :: area, width, perim, hydrad, chezy
 
       ! Arrange
+      call default_physcoef()
       call disable_timers_logging_and_mpi()
       ! Generate mesh
       grid_helper = t_grid_helper()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_getprof_1d.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_getprof_1d.f90
@@ -458,7 +458,7 @@ contains
 
       type(t_grid_helper) :: grid_helper
       integer, parameter :: japerim = 1
-      integer, parameter :: calcconv = 0
+      integer, parameter :: calcconv = 1
       integer :: new_link, error_code
       real(kind=dp) :: area, width, perim, hydrad, chezy
 


### PR DESCRIPTION
# What was done 

The bug is fixed.
- In the debugger I get a sensible friction value now
- By running ctest with 'repeat until-failure=1000' it succeeds a thousand times in a row.
 
# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
