### PR TITLE
sedmor branch: bermslope and avalanching

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/bermslopenudging.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/bermslopenudging.f90
@@ -43,14 +43,16 @@ contains
       use m_fm_erosed, only: bermslopegamma, bermslopedepth, bermslopebed, bermslopesus, e_dzdn, e_dzdt, bermslopefac, bermslope, morfac, lsedtot, bed, has_bedload, e_sbcn, e_sbct, e_sbwn, e_sbwt, sus, lsed, e_ssn, e_sswn, e_sswt
       use m_waveconst, only: no_waves
       use m_flow, only: hu, epshu
-      use m_flowgeom, only: lnx, ln, wu_mor
+      use m_flowgeom, only: lnx, ln, wu_mor, snu, csu
       use m_flowparameters, only: jawave
+      use m_waves, only: phiwav
 
       logical, intent(out) :: error
 
       integer :: L, k1, k2
       integer :: lsd
-      real(kind=dp) :: hwavu, slope, flx, frc, fixf, trmag_u, slpfac
+      real(kind=dp) :: hwavu, slope, flx, fixf, trmag_u, slpfac
+      real(kind=dp) :: cosw, sinw, coswu
 
       error = .true.
       !
@@ -108,7 +110,15 @@ contains
          ! Transports positive outgoing
          !
          slope = max(hypot(e_dzdn(L), e_dzdt(L)), 1.0e-8_dp)
-         slpfac = bermslopefac * (-e_dzdn(L) + bermslope * e_dzdn(L) / slope) / max(morfac, 1.0_dp)
+         if (jawave /= NO_WAVES) then
+            cosw = 0.5_dp * (cosd(phiwav(k1)) + cosd(phiwav(k2)))
+            sinw = 0.5_dp * (sind(phiwav(k1)) + sind(phiwav(k2)))
+            coswu = cosw * csu(L) + sinw * snu(L)
+            slpfac = bermslopefac * (-e_dzdn(L) + bermslope * coswu) / max(morfac, 1.0_dp)
+         else
+            ! we have no good substitute, so old approach
+            slpfac = bermslopefac * (-e_dzdn(L) + bermslope * e_dzdn(L) / slope) / max(morfac, 1.0_dp)
+         end if
          do lsd = 1, lsedtot
             !
             ! slope magnitude smaller than bermslope leads to transport away from the cell, ie outward
@@ -120,28 +130,28 @@ contains
                trmag_u = hypot(e_sbcn(L, lsd), e_sbct(L, lsd))
                flx = trmag_u * slpfac
                e_sbcn(L, lsd) = e_sbcn(L, lsd) - flx
-               call getfracfixfac(L, k1, k2, lsd, e_sbcn(L, lsd), frc, fixf)
-               e_sbcn(L, lsd) = e_sbcn(L, lsd) * frc * fixf
+               call getfixfac(L, k1, k2, lsd, e_sbcn(L, lsd), fixf)
+               e_sbcn(L, lsd) = e_sbcn(L, lsd) * fixf
                !
                trmag_u = hypot(e_sbwn(L, lsd), e_sbwt(L, lsd))
                flx = trmag_u * slpfac
                e_sbwn(L, lsd) = e_sbwn(L, lsd) - flx
-               call getfracfixfac(L, k1, k2, lsd, e_sbwn(L, lsd), frc, fixf)
-               e_sbwn(L, lsd) = e_sbwn(L, lsd) * frc * fixf
+               call getfixfac(L, k1, k2, lsd, e_sbwn(L, lsd), fixf)
+               e_sbwn(L, lsd) = e_sbwn(L, lsd) * fixf
             end if
             !
             if (bermslopeindexsus(L) .and. sus /= 0.0 .and. lsd <= lsed) then
                trmag_u = abs(e_ssn(L, lsd))
                flx = trmag_u * slpfac
                e_ssn(L, lsd) = e_ssn(L, lsd) - flx
-               call getfracfixfac(L, k1, k2, lsd, e_ssn(L, lsd), frc, fixf)
-               e_ssn(L, lsd) = e_ssn(L, lsd) * frc * fixf
+               call getfixfac(L, k1, k2, lsd, e_ssn(L, lsd), fixf)
+               e_ssn(L, lsd) = e_ssn(L, lsd) * fixf
                !
                trmag_u = hypot(e_sswn(L, lsd), e_sswt(L, lsd))
                flx = trmag_u * slpfac
                e_sswn(L, lsd) = e_sswn(L, lsd) - flx
-               call getfracfixfac(L, k1, k2, lsd, e_sswn(L, lsd), frc, fixf)
-               e_sswn(L, lsd) = e_sswn(L, lsd) * frc * fixf
+               call getfixfac(L, k1, k2, lsd, e_sswn(L, lsd), fixf)
+               e_sswn(L, lsd) = e_sswn(L, lsd) * fixf
             end if
          end do
       end do
@@ -151,9 +161,9 @@ contains
 
    end subroutine bermslopenudging
 
-   subroutine getfracfixfac(L, k1, k2, lsd, transp, frc, fixf)
+   subroutine getfixfac(L, k1, k2, lsd, transp, fixf)
       use precision, only: dp
-      use m_fm_erosed, only: fixfac, frac
+      use m_fm_erosed, only: fixfac
       use m_flowgeom, only: lnxi
       use m_flow, only: hu, epshu
 
@@ -161,20 +171,17 @@ contains
 
       integer, intent(in) :: L, k1, k2, lsd
       real(kind=dp), intent(in) :: transp
-      real(kind=dp), intent(out) :: frc, fixf
+      real(kind=dp), intent(out) :: fixf
 
       if (L > lnxi .and. hu(L) > epshu) then
          fixf = fixfac(k2, lsd)
-         frc = frac(k2, lsd)
       else
          if (transp >= 0) then
             fixf = fixfac(k1, lsd)
-            frc = frac(k1, lsd)
          else
             fixf = fixfac(k2, lsd)
-            frc = frac(k2, lsd)
          end if
       end if
-   end subroutine getfracfixfac
+   end subroutine getfixfac
 
 end module m_bermslopenudging

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/bermslopenudging.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/bermslopenudging.f90
@@ -51,7 +51,7 @@ contains
 
       integer :: L, k1, k2
       integer :: lsd
-      real(kind=dp) :: hwavu, slope, flx, fixf, trmag_u, slpfac
+      real(kind=dp) :: hwavu, slope, flx, frc, fixf, trmag_u, slpfac
       real(kind=dp) :: cosw, sinw, coswu
 
       error = .true.
@@ -130,28 +130,28 @@ contains
                trmag_u = hypot(e_sbcn(L, lsd), e_sbct(L, lsd))
                flx = trmag_u * slpfac
                e_sbcn(L, lsd) = e_sbcn(L, lsd) - flx
-               call getfixfac(L, k1, k2, lsd, e_sbcn(L, lsd), fixf)
-               e_sbcn(L, lsd) = e_sbcn(L, lsd) * fixf
+               call getfracfixfac(L, k1, k2, lsd, e_sbcn(L, lsd), frc, fixf)
+               e_sbcn(L, lsd) = e_sbcn(L, lsd) * frc * fixf
                !
                trmag_u = hypot(e_sbwn(L, lsd), e_sbwt(L, lsd))
                flx = trmag_u * slpfac
                e_sbwn(L, lsd) = e_sbwn(L, lsd) - flx
-               call getfixfac(L, k1, k2, lsd, e_sbwn(L, lsd), fixf)
-               e_sbwn(L, lsd) = e_sbwn(L, lsd) * fixf
+               call getfracfixfac(L, k1, k2, lsd, e_sbwn(L, lsd), frc, fixf)
+               e_sbwn(L, lsd) = e_sbwn(L, lsd) * frc * fixf
             end if
             !
             if (bermslopeindexsus(L) .and. sus /= 0.0 .and. lsd <= lsed) then
                trmag_u = abs(e_ssn(L, lsd))
                flx = trmag_u * slpfac
                e_ssn(L, lsd) = e_ssn(L, lsd) - flx
-               call getfixfac(L, k1, k2, lsd, e_ssn(L, lsd), fixf)
-               e_ssn(L, lsd) = e_ssn(L, lsd) * fixf
+               call getfracfixfac(L, k1, k2, lsd, e_ssn(L, lsd), frc, fixf)
+               e_ssn(L, lsd) = e_ssn(L, lsd) * frc * fixf
                !
                trmag_u = hypot(e_sswn(L, lsd), e_sswt(L, lsd))
                flx = trmag_u * slpfac
                e_sswn(L, lsd) = e_sswn(L, lsd) - flx
-               call getfixfac(L, k1, k2, lsd, e_sswn(L, lsd), fixf)
-               e_sswn(L, lsd) = e_sswn(L, lsd) * fixf
+               call getfracfixfac(L, k1, k2, lsd, e_sswn(L, lsd), frc, fixf)
+               e_sswn(L, lsd) = e_sswn(L, lsd) * frc * fixf
             end if
          end do
       end do
@@ -161,9 +161,9 @@ contains
 
    end subroutine bermslopenudging
 
-   subroutine getfixfac(L, k1, k2, lsd, transp, fixf)
+   subroutine getfracfixfac(L, k1, k2, lsd, transp, frc, fixf)
       use precision, only: dp
-      use m_fm_erosed, only: fixfac
+      use m_fm_erosed, only: fixfac, frac
       use m_flowgeom, only: lnxi
       use m_flow, only: hu, epshu
 
@@ -171,17 +171,20 @@ contains
 
       integer, intent(in) :: L, k1, k2, lsd
       real(kind=dp), intent(in) :: transp
-      real(kind=dp), intent(out) :: fixf
+      real(kind=dp), intent(out) :: frc, fixf
 
       if (L > lnxi .and. hu(L) > epshu) then
          fixf = fixfac(k2, lsd)
+         frc = frac(k2, lsd)
       else
          if (transp >= 0) then
             fixf = fixfac(k1, lsd)
+            frc = frac(k1, lsd)
          else
             fixf = fixfac(k2, lsd)
+            frc = frac(k2, lsd)
          end if
       end if
-   end subroutine getfixfac
+   end subroutine getfracfixfac
 
 end module m_bermslopenudging

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/duneaval.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_sediment/duneaval.f90
@@ -43,7 +43,8 @@ contains
    subroutine duneaval(error)
       use precision, only: dp
       use m_fm_erosed, only: hswitch, wetslope, dryslope, e_dzdn, e_dzdt, avaltime, morfac, lsedtot, fixfac, frac, dzmaxdune, rhosol
-      use m_sediment, only: avalflux
+      use m_fm_erosed, only: bermslopetransport, bermslope
+      use m_sediment, only: avalflux, bermslopeindex
       use m_flowgeom, only: lnx, wu_mor, ln, acl, bl, dx, lnxi, ba
       use m_flow, only: hs
 
@@ -68,6 +69,11 @@ contains
          ac2 = 1.0_dp - ac1
          if (hs(k1) > hswitch .or. hs(k2) > hswitch) then
             slpmax = wetslope
+            if (bermslopetransport) then
+               if (bermslopeindex(L)) then
+                  slpmax = bermslope
+               end if
+            end if
          else
             slpmax = dryslope
          end if
@@ -103,7 +109,7 @@ contains
                   end if
                end if
                !
-               avalflux(L, lsd) = avalflux(L, lsd) - ba(k1) * ba(k2) / (ba(k1) + ba(k2)) * avflux * rhosol(lsd) / wu_mor(L)
+               avalflux(L, lsd) = avalflux(L, lsd) - ba(k1) * ba(k2) / (ba(k1) + ba(k2)) * avflux * rhosol(lsd) / wu_mor(L) !m2 m/s kg /m3 /m = kg/s/m
             end do
          end if
       end do

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_sedmorinit.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_sedmorinit.f90
@@ -472,12 +472,6 @@ contains
          end if
          call realloc(avalflux, [lnx, stmpar%lsedtot], stat=ierr, fill=0.0_dp, keepExisting=.false.)
          !
-         ! Warn user if default wetslope is still 10.0 when using dune avalanching. Reset default to reasonable 1.0 in that case.
-         if (comparereal(stmpar%morpar%wetslope, 10.0_dp) == 0) then
-            call mess(LEVEL_WARN, 'unstruc::flow_sedmorinit - Dune avalanching is switched on. Default wetslope reset to 0.1 from 10.0')
-            stmpar%morpar%wetslope = 1.0e-1_dp
-         end if
-         !
          ! Warn user if upperlimitssc is set icm with avalanching. This effectively removes sedimentation of the avalanching flux if set too strictly.
          if (comparereal(upperlimitssc, 1.0e6_dp) /= 0) then
             call mess(LEVEL_WARN, 'unstruc::flow_sedmorinit - Upper limit imposed on ssc. This will cause large mass errors icm avalanching. Check the mass error at the end of the run.')


### PR DESCRIPTION
# What was done 

- `bermslopenudging`: Effect of wave direction included in bermslope avalanching
- `duneaval`: Use `bermslope` instead of `wetslope` when bermslope is active, and use `wetslope` when wet and bermslope is not active
- `flow_sedmorinit`: Due to the previous change, there is no more limit on `wetslope` when bermslope is activated

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link