### PR TITLE
UNST-10055 Increase timeout for windows build, because container pull…

### DIFF
--- a/ci/teamcity/Delft3D/windows/build.kt
+++ b/ci/teamcity/Delft3D/windows/build.kt
@@ -99,6 +99,11 @@ object WindowsBuild : BuildType({
             rules = "+:unit-test-report-windows.xml"
         }
     }
+
+    failureConditions {
+        executionTimeoutMin = 120
+    }
+
     requirements {
         doesNotEqual("teamcity.agent.jvm.os.name", "Windows Server 2022")
     }

--- a/ci/teamcity/Delft3D/windows/buildEnvironment-i24.kt
+++ b/ci/teamcity/Delft3D/windows/buildEnvironment-i24.kt
@@ -92,7 +92,10 @@ object WindowsBuildEnvironmentI24 : BuildType({
 
     triggers {
         vcs {
-            triggerRules = "+:ci/dockerfiles/windows/**".trimIndent()
+            triggerRules = """
+                +:ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+                +:ci/teamcity/Delft3D/windows/buildEnvironment-i24.kt
+            """.trimIndent()
             branchFilter = "+:<default>".trimIndent()
             buildParams {
                 param("trigger.type", "vcs")

--- a/ci/teamcity/Delft3D/windows/collectEnvironment.kt
+++ b/ci/teamcity/Delft3D/windows/collectEnvironment.kt
@@ -73,7 +73,7 @@ object WindowsCollectEnvironment : BuildType({
     triggers {
         vcs {
             triggerRules = """
-                +:ci/dockerfiles/windows/**
+                +:ci/dockerfiles/windows/Dockerfile-dhydro-collect
                 +:ci/teamcity/Delft3D/windows/collectEnvironment.kt
             """.trimIndent()
             branchFilter = "+:<default>".trimIndent()


### PR DESCRIPTION
… can take 60 minutes (default timeout). Only trigger docker builds when their sources change


# Issue link UNST-10055
