### PR TITLE
UNST-9274: Bugfix and add tests for "ininudge"-functionality

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
@@ -278,6 +278,12 @@ contains
          call restore_au_q1_3D_for_1st_history_record()
       end if
 
+      call set_external_forcings(tstart_user, INITIALIZATION_PHASE, error)
+      if (is_error_at_any_processor(error)) then
+         call qnerror('Error occurred when setting external forcings.', ' ', ' ')
+         return
+      end if
+
       call initialize_salinity_and_temperature_with_nudge_variables()
 
       if (jasal > OFF) then
@@ -288,12 +294,6 @@ contains
       end if
 
       call initialise_density_at_cell_centres()
-
-      call set_external_forcings(tstart_user, INITIALIZATION_PHASE, error)
-      if (is_error_at_any_processor(error)) then
-         call qnerror('Error occurred when setting external forcings.', ' ', ' ')
-         return
-      end if
 
       if (len_trim(md_restartfile) == 0) then
          if (ice_apply_pressure) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -539,8 +539,8 @@ contains
          if (jawel) then
             ext_force_bnd_used = .true.
          else
-            call qnerror('Boundary external forcing file '''//trim(md_extfile_new)//''' not found.', '  ', ' ')
-            write (msgbuf, '(a,a,a)') 'Boundary external forcing file ''', trim(md_extfile_new), ''' not found.'
+            call qnerror('External forcing file '''//trim(md_extfile_new)//''' not found.', '  ', ' ')
+            write (msgbuf, '(a,a,a)') 'External forcing file ''', trim(md_extfile_new), ''' not found.'
             call err_flush()
          end if
       end if
@@ -862,7 +862,7 @@ contains
       call tree_create(trim(filename), bnd_ptr)
       call prop_file('ini', trim(filename), bnd_ptr, istat)
       if (istat /= 0) then
-         call qnerror('Boundary external forcing file ', trim(filename), ' could not be read')
+         call qnerror('External forcing file ', trim(filename), ' could not be read.')
          return
       end if
 

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -1568,6 +1568,43 @@
       </checks>
     </testCase>
 
+    <testCase name="c001_ininudge_old_ext" ref="dflowfm_default">
+      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c001_ininudge_old_ext</path>
+      <maxRunTime>60.0000000</maxRunTime>
+      <checks>
+        <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_sa1" toleranceRelative="1e-6" />
+            <parameter name="mesh2d_tem1" toleranceRelative="1e-6" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+	<testCase name="c002_ininudge_ini" ref="dflowfm_default">
+      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c002_ininudge_ini</path>
+      <maxRunTime>60.0000000</maxRunTime>
+      <checks>
+        <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_sa1" toleranceRelative="1e-6" />
+            <parameter name="mesh2d_tem1" toleranceRelative="1e-6" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+	<testCase name="c003_ininudge_new_ext" ref="dflowfm_default">
+      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c003_ininudge_new_ext</path>
+      <maxRunTime>60.0000000</maxRunTime>
+      <checks>
+        <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">
+          <parameters>
+            <parameter name="mesh2d_sa1" toleranceRelative="1e-6" />
+            <parameter name="mesh2d_tem1" toleranceRelative="1e-6" />
+          </parameters>
+        </file>
+      </checks>
+    </testCase>
+	
     <testCase name="e02_f045_c010_nudgerate" ref="dflowfm_default">
       <path version="2025-10-07T07:16:58.261000">e02_dflowfm/f045_nudging/c010_nudgerate</path>
       <maxRunTime>15000.0000000</maxRunTime>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -1569,7 +1569,7 @@
     </testCase>
 
     <testCase name="c001_ininudge_old_ext" ref="dflowfm_default">
-      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c001_ininudge_old_ext</path>
+      <path version="2026-06-29T16:00:00">e02_dflowfm/f045_nudging/c001_ininudge_old_ext</path>
       <maxRunTime>60.0000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">
@@ -1581,7 +1581,7 @@
       </checks>
     </testCase>
 	<testCase name="c002_ininudge_ini" ref="dflowfm_default">
-      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c002_ininudge_ini</path>
+      <path version="2026-06-29T16:00:00">e02_dflowfm/f045_nudging/c002_ininudge_ini</path>
       <maxRunTime>60.0000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">
@@ -1593,7 +1593,7 @@
       </checks>
     </testCase>
 	<testCase name="c003_ininudge_new_ext" ref="dflowfm_default">
-      <path version="2026-06-29T13:37:00">e02_dflowfm/f045_nudging/c003_ininudge_new_ext</path>
+      <path version="2026-06-29T16:00:00">e02_dflowfm/f045_nudging/c003_ininudge_new_ext</path>
       <maxRunTime>60.0000000</maxRunTime>
       <checks>
         <file name="DFM_OUTPUT_ini_nudge/ini_nudge_map.nc" type="netCDF">


### PR DESCRIPTION
# What was done 
- bugfix: **First**, set_external_forcings() to do nudging at TStart (so temperature and salinity data are available from the external file). **Next**, call initialize_salinity_and_temperature_with_nudge_variables
- Add three testcases
 
# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated: e02_f045_c001, e02_f045_c002, e02_f045_c003
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9274