### PR TITLE
UNST-10022: reuse pump capacity from rst

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -18215,6 +18215,7 @@ contains
                   istru = network%sts%pumpIndices(i)
                   pstru => network%sts%struct(istru)
                   pstru%pump%current_capacity = tmpvar(i)
+                  pstru%pump%capacity = tmpvar(i)
                end do
             end if
 

--- a/test/deltares_testbench/configs/dimr/dimr_dflowfm_full_scale_models_win64.xml
+++ b/test/deltares_testbench/configs/dimr/dimr_dflowfm_full_scale_models_win64.xml
@@ -259,7 +259,7 @@
             </checks>
         </testCase>		
         <testCase name="e02_f150_c31_pudong-1d" ref="dimr_default">
-            <path version="2025-10-21T11:11:05.095000">e02_dflowfm/f150_1d2d_acceptance_urban/c31_pudong-1d/dimr_model</path>
+            <path version="2026-07-06T08:39:17.950000">e02_dflowfm/f150_1d2d_acceptance_urban/c31_pudong-1d/dimr_model</path>
             <checks>
                 <file name="dflowfm/DFM_OUTPUT_FlowFM/FlowFM_map.nc" type="netCDF">
                     <parameters>


### PR DESCRIPTION
# What was done 

current_discharge seems only used for output, but discharge is what is used for computation. 
So initialized this also from RST file

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [x ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x ]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10022