### PR TITLE
DEVOPSDSC-985 (fix-up): Restore printing of kill flag and build id in function query_trigger

### DIFF
--- a/ci/github/cancel_teamcity_builds.sh
+++ b/ci/github/cancel_teamcity_builds.sh
@@ -226,6 +226,8 @@ function query_trigger() {
     exit 1
     ;;
   esac
+
+  printf "%s\t%s\n" "${kill_em_all}" "${build_id}"
 }
 
 function cancel_all_builds() {


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSDSC-985