### PR TITLE
UNST-9887: rearrange nudging of temperature and salinity

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flow_initimestep.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flow_initimestep.f90
@@ -159,7 +159,7 @@ contains
          end if
 
          if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
-            call compute_air_water_interaction_most_fluxes()
+            call compute_air_water_interaction_most_fluxes(.false.)
          end if
 
          call calculate_wind_stresses(iresult)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_temperature.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_temperature.f90
@@ -28,18 +28,32 @@
 !-------------------------------------------------------------------------------
 
 module m_get_surface_temperature
+   use precision_basics, only: dp
+   use m_flowgeom, only: ndx
+   use m_get_kbot_ktop, only: getkbotktop
+   
    implicit none
 
    public :: get_surface_temperature
 
-contains
+   contains
 
+   !> Returns the surface-layer temperature for all horizontal cells.
+   subroutine get_surface_temperature(surface_temperature, initialization)
+      real(kind=dp), intent(out) :: surface_temperature(ndx)   
+      logical, intent(in) :: initialization !< initialization phase
+      
+      if (initialization) then
+         call get_surface_temperature_from_tem1(surface_temperature)
+      else
+         call get_surface_temperature_from_constituents(surface_temperature)
+      end if
+      
+   end subroutine get_surface_temperature
+   
    !> Returns the surface-layer temperature from constituents(itemp,:) for all horizontal cells.
-   subroutine get_surface_temperature(surface_temperature)
-      use precision_basics, only: dp
+   subroutine get_surface_temperature_from_constituents(surface_temperature)
       use m_transport, only: constituents, itemp
-      use m_flowgeom, only: ndx
-      use m_get_kbot_ktop, only: getkbotktop
 
       real(kind=dp), intent(out) :: surface_temperature(ndx)
 
@@ -49,6 +63,20 @@ contains
          call getkbotktop(n, kb, kt)
          surface_temperature(n) = constituents(itemp, kt)
       end do
-   end subroutine get_surface_temperature
+   end subroutine get_surface_temperature_from_constituents
+
+   !> Returns the surface-layer temperature from tem1 for all horizontal cells.
+   subroutine get_surface_temperature_from_tem1(surface_temperature)
+      use m_flow, only: tem1
+
+      real(kind=dp), intent(out) :: surface_temperature(ndx)
+
+      integer :: n, kb, kt
+
+      do n = 1, ndx
+         call getkbotktop(n, kb, kt)
+         surface_temperature(n) = tem1(kt)
+      end do
+   end subroutine get_surface_temperature_from_tem1
 
 end module m_get_surface_temperature

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
@@ -33,8 +33,6 @@ module m_flow_flowinit
    use m_statisticsini, only: statisticsini
    use m_setzminmax, only: setzminmax
    use m_flow_settidepotential, only: flow_settidepotential
-   use m_set_saltem_nudge, only: set_saltem_nudge
-   use m_set_nudgerate, only: set_nudgerate
    use m_setvelocityfield, only: setvelocityfield
    use m_setupwslopes, only: setupwslopes
    use m_setstruclink, only: setstruclink
@@ -283,8 +281,6 @@ contains
          call qnerror('Error occurred when setting external forcings.', ' ', ' ')
          return
       end if
-
-      call initialize_salinity_and_temperature_with_nudge_variables()
 
       if (jasal > OFF) then
          call fill_constituents_with_salinity()
@@ -1572,26 +1568,6 @@ contains
       end if
 
    end subroutine initialize_salinity_temperature_on_boundary
-
-!> initialize salinity and temperature with nudge variables
-   subroutine initialize_salinity_and_temperature_with_nudge_variables()
-      use m_flowparameters, only: janudge, jainiwithnudge
-      use m_nudge
-
-      implicit none
-
-      if (janudge == ON) then ! and here last actions on sal/tem nudging, before we set rho
-         call set_nudgerate()
-         if (jainiwithnudge > OFF) then
-            call set_saltem_nudge()
-            if (jainiwithnudge == 2) then
-               janudge = OFF
-               deallocate (nudge_temperature, nudge_salinity, nudge_rate, nudge_time)
-            end if
-         end if
-      end if
-
-   end subroutine initialize_salinity_and_temperature_with_nudge_variables
 
 !> fill_constituents_with_salinity
    subroutine fill_constituents_with_salinity()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -71,7 +71,8 @@ module fm_external_forcings
    end interface
 
    interface
-      module subroutine compute_air_water_interaction_most_fluxes()
+      module subroutine compute_air_water_interaction_most_fluxes(initialization)
+         logical, intent(in) :: initialization !< initialization phase
       end subroutine compute_air_water_interaction_most_fluxes
    end interface
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -147,8 +147,16 @@ contains
          return
       end if
       
+      ! Update nudging temperature (and salinity)
+      if (item_nudge_temperature /= ec_undef_int .and. janudge > 0) then
+         success = success .and. ec_gettimespacevalue(ecInstancePtr, item_nudge_temperature, irefdate, tzone, tunit, time_in_seconds)
+      end if
+      if (initialization) then
+         call initialize_salinity_and_temperature_with_nudge_variables()
+      end if
+
       if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
-         call compute_air_water_interaction_most_fluxes()
+         call compute_air_water_interaction_most_fluxes(initialization)
       end if
 
       if (update_wind_stress_each_time_step == 0) then ! Update wind in set_external_forcing (each user timestep)
@@ -293,16 +301,34 @@ contains
          call update_bubblescreen_discharge_wrapper()
       end if
 
-      ! Update nudging temperature (and salinity)
-      if (item_nudge_temperature /= ec_undef_int .and. janudge > 0) then
-         success = success .and. ec_gettimespacevalue(ecInstancePtr, item_nudge_temperature, irefdate, tzone, tunit, time_in_seconds)
-      end if
-
       iresult = DFM_NOERR
 
    end subroutine set_external_forcings
 
-   module subroutine compute_air_water_interaction_most_fluxes()
+   !> initialize salinity and temperature with nudge variables
+   subroutine initialize_salinity_and_temperature_with_nudge_variables()
+      use m_flowparameters, only: janudge, jainiwithnudge
+      use m_set_nudgerate, only: set_nudgerate
+      use m_set_saltem_nudge, only: set_saltem_nudge
+      use m_nudge, only: nudge_temperature, nudge_salinity, nudge_rate, nudge_time
+
+      implicit none
+
+      if (janudge == 1) then ! and here last actions on sal/tem nudging, before we set rho
+         call set_nudgerate()
+         if (jainiwithnudge > 0) then
+            call set_saltem_nudge()
+            if (jainiwithnudge == 2) then
+               janudge = 0
+               deallocate (nudge_temperature, nudge_salinity, nudge_rate, nudge_time)
+            end if
+         end if
+      end if
+
+   end subroutine initialize_salinity_and_temperature_with_nudge_variables
+
+   !> compute fluxes based on Monin-Obukhov Stability Theory
+   module subroutine compute_air_water_interaction_most_fluxes(initialization)
       use precision, only: dp
       use m_flowgeom, only: ndx
       use m_get_surface_temperature, only: get_surface_temperature
@@ -312,10 +338,13 @@ contains
       use m_flowparameters, only: atmospheric_stability_function, ATMOSPHERIC_STABILITY_FUNCTION_ECMWF, &
                                   free_convection, FREE_CONVECTION_ON, salinity_reduction_factor_saturation_humidity
 
+      logical, intent(in) :: initialization !< initialization phase
+      
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature
       real(kind=dp), dimension(:), allocatable, save :: windx, windy, charnock
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature_kelvin, air_temperature_kelvin, dew_point_temperature_kelvin
       type(t_options) :: atm_stability_options
+
 
       if (.not. allocated(windx)) then
          allocate(windx(ndx))
@@ -331,7 +360,7 @@ contains
       call link_to_node_vector(wx, wy, windx, windy, ndx)
       call link_to_node_scalar(wcharnock, charnock, ndx)
 
-      call get_surface_temperature(surface_temperature)
+      call get_surface_temperature(surface_temperature, initialization)
       surface_temperature_kelvin = celsius_to_kelvin(surface_temperature)
       air_temperature_kelvin = celsius_to_kelvin(air_temperature)
       dew_point_temperature_kelvin = celsius_to_kelvin(dew_point_temperature)


### PR DESCRIPTION
# What was done 
These modifications are required as consequence of UNST-9274, as initial (surface) temperature is required for the atm stability module; hence the nudging of temperature should be done before calling atm stability module:

- move 'update nudging temperature and salinity' in fm_external_forcings_update() to a line above the line for calling compute flux of MOST 
- move initialize_salinity_and_temperature_with_nudge_variables from flow_flowinit() to fm_external_forcings_update(), to the line just after 'update nudging temperature and salinity'
- extend compute_air_water_interaction_most_fluxes() with INITIALIZATION_PHASE as input argument
- extend get_surface_temperature() with INITIALIZATION_PHASE as input argument and an option, depending on INITIALIZATION_PHASE, whether to compute surface temperature from tem1 or from constituents(itemp,:)

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9887