### PR TITLE
UNST-9889_support_relative_wind_for_atmospheric_stability

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flow_initimestep.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/flow_initimestep.f90
@@ -159,7 +159,7 @@ contains
          end if
 
          if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
-            call compute_air_water_interaction_most_fluxes(.false.)
+            call compute_air_water_interaction_most_fluxes(initialization=.false.)
          end if
 
          call calculate_wind_stresses(iresult)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
@@ -38,7 +38,7 @@ contains
 
    subroutine heatun(n, time_in_hours, nominal_solar_radiation)
       use precision, only: dp, comparereal, fp
-      use m_relative_wind, only: compute_surface_relative_wind
+      use m_relative_wind, only: compute_wind_relative_to_surface_scalar
       use physicalconsts, only: stf, celsius_to_kelvin, kelvin_to_celsius
       use m_physcoef, only: ag, rhomean, backgroundsalinity, backgroundwatertemperature, dalton, epshstem, stanton, secchi_depth, &
                             soiltempthick, BACKGROUND_AIR_PRESSURE, BACKGROUND_HUMIDITY, BACKGROUND_CLOUDINESS, surftempsmofac, &
@@ -104,7 +104,7 @@ contains
       net_solar_radiation_in_cell = 0.0_dp
       nominal_solar_radiation_in_cell = nominal_solar_radiation
       call getlink1(n, L)
-      call compute_surface_relative_wind(wx(L), wy(L), relativewind, ucx(ktop(n)), ucy(ktop(n)), wxL, wyL, wind_speed_in_cell)
+      call compute_wind_relative_to_surface_scalar(wx(L), wy(L), relativewind, ucx(ktop(n)), ucy(ktop(n)), wxL, wyL, wind_speed_in_cell)
 
       call getkbotktop(n, k_bot, k_top)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/heatun.f90
@@ -38,6 +38,7 @@ contains
 
    subroutine heatun(n, time_in_hours, nominal_solar_radiation)
       use precision, only: dp, comparereal, fp
+      use m_relative_wind, only: compute_surface_relative_wind
       use physicalconsts, only: stf, celsius_to_kelvin, kelvin_to_celsius
       use m_physcoef, only: ag, rhomean, backgroundsalinity, backgroundwatertemperature, dalton, epshstem, stanton, secchi_depth, &
                             soiltempthick, BACKGROUND_AIR_PRESSURE, BACKGROUND_HUMIDITY, BACKGROUND_CLOUDINESS, surftempsmofac, &
@@ -103,14 +104,7 @@ contains
       net_solar_radiation_in_cell = 0.0_dp
       nominal_solar_radiation_in_cell = nominal_solar_radiation
       call getlink1(n, L)
-      if (relativewind > 0.0_dp) then
-         wxL = wx(L) - relativewind * ucx(ktop(n))
-         wyL = wy(L) - relativewind * ucy(ktop(n))
-      else
-         wxL = wx(L)
-         wyL = wy(L)
-      end if
-      wind_speed_in_cell = sqrt(wxL * wxL + wyL * wyL)
+      call compute_surface_relative_wind(wx(L), wy(L), relativewind, ucx(ktop(n)), ucy(ktop(n)), wxL, wyL, wind_speed_in_cell)
 
       call getkbotktop(n, k_bot, k_top)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_relative_wind.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_relative_wind.f90
@@ -1,0 +1,114 @@
+!----- AGPL --------------------------------------------------------------------
+!
+!  Copyright (C)  Stichting Deltares, 2017-2026.
+!
+!  This file is part of Delft3D (D-Flow Flexible Mesh component).
+!
+!  Delft3D is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU Affero General Public License as
+!  published by the Free Software Foundation version 3.
+!
+!  Delft3D  is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU Affero General Public License for more details.
+!
+!  You should have received a copy of the GNU Affero General Public License
+!  along with Delft3D.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D",
+!  "D-Flow Flexible Mesh" and "Deltares" are registered trademarks of Stichting
+!  Deltares, and remain the property of Stichting Deltares. All rights reserved.
+!
+!-------------------------------------------------------------------------------
+
+!> Utilities for correcting wind velocity with the relative motion of the surface flow.
+module m_relative_wind
+
+   use precision, only: dp
+
+   implicit none
+
+   private
+
+   interface compute_surface_relative_wind
+      module procedure compute_surface_relative_wind_scalar
+      module procedure compute_surface_relative_wind_links
+   end interface compute_surface_relative_wind
+
+   public :: compute_surface_relative_wind
+   public :: compute_surface_relative_wind_on_link
+
+contains
+
+   !> Correct a single wind vector with the relative surface-flow contribution.
+   !!
+   !! corrected_wind = wind - relativewind * surface_velocity
+   !!
+   !! If `corrected_wind_speed` is provided, this routine also returns
+   !! `sqrt(corrected_wind_x**2 + corrected_wind_y**2)`.
+   subroutine compute_surface_relative_wind_scalar(wind_x, wind_y, relativewind, surface_u, surface_v, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
+      real(kind=dp), intent(in) :: wind_x, wind_y !< Input wind components in global x/y direction [m/s].
+      real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
+      real(kind=dp), intent(in) :: surface_u, surface_v !< Surface-flow components in global x/y direction [m/s].
+      real(kind=dp), intent(out) :: corrected_wind_x, corrected_wind_y !< Corrected wind components in global x/y direction [m/s].
+      real(kind=dp), intent(out), optional :: corrected_wind_speed !< Magnitude of corrected wind vector [m/s].
+
+      corrected_wind_x = wind_x
+      corrected_wind_y = wind_y
+
+      if (relativewind > 0.0_dp) then
+         corrected_wind_x = corrected_wind_x - relativewind * surface_u
+         corrected_wind_y = corrected_wind_y - relativewind * surface_v
+      end if
+
+      if (present(corrected_wind_speed)) then
+         corrected_wind_speed = sqrt(corrected_wind_x * corrected_wind_x + corrected_wind_y * corrected_wind_y)
+      end if
+   end subroutine compute_surface_relative_wind_scalar
+
+   !> Correct wind for one horizontal link using top-layer link velocity from flow state.
+   subroutine compute_surface_relative_wind_on_link(link, wind_x, wind_y, relativewind, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
+      use m_flowgeom, only: csu, snu
+      use m_flow, only: ltop, u1, v
+
+      integer, intent(in) :: link !< Horizontal link index.
+      real(kind=dp), intent(in) :: wind_x, wind_y !< Input wind components in global x/y direction [m/s].
+      real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
+      real(kind=dp), intent(out) :: corrected_wind_x, corrected_wind_y !< Corrected wind components in global x/y direction [m/s].
+      real(kind=dp), intent(out), optional :: corrected_wind_speed !< Magnitude of corrected wind vector [m/s].
+
+      real(kind=dp) :: uL, vL, uxL, uyL
+
+      uL = u1(ltop(link))
+      vL = v(ltop(link))
+      uxL = uL * csu(link) - vL * snu(link)
+      uyL = uL * snu(link) + vL * csu(link)
+
+      call compute_surface_relative_wind_scalar(wind_x, wind_y, relativewind, uxL, uyL, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
+   end subroutine compute_surface_relative_wind_on_link
+
+   !> Correct link-based wind vectors using top-layer link velocities from the flow state.
+   !!
+   !! This routine loops over all horizontal links and computes the local
+   !! correction by delegating each link to `compute_surface_relative_wind_on_link`.
+   subroutine compute_surface_relative_wind_links(wind_x, wind_y, relativewind, corrected_wind_x, corrected_wind_y)
+      use m_flowgeom, only: lnx
+
+      real(kind=dp), intent(in) :: wind_x(:), wind_y(:) !< Input wind components on links in global x/y direction [m/s].
+      real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
+      real(kind=dp), intent(out) :: corrected_wind_x(:), corrected_wind_y(:) !< Corrected wind components on links in global x/y direction [m/s].
+
+      integer :: L
+
+      do L = 1, lnx
+         call compute_surface_relative_wind_on_link(L, wind_x(L), wind_y(L), relativewind, corrected_wind_x(L), corrected_wind_y(L))
+      end do
+   end subroutine compute_surface_relative_wind_links
+
+end module m_relative_wind

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_relative_wind.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_relative_wind.f90
@@ -28,6 +28,9 @@
 !-------------------------------------------------------------------------------
 
 !> Utilities for correcting wind velocity with the relative motion of the surface flow.
+!!
+!! The public routines in this module are elemental, so they can be called
+!! for scalars and for conformable arrays with the same implementation.
 module m_relative_wind
 
    use precision, only: dp
@@ -36,23 +39,20 @@ module m_relative_wind
 
    private
 
-   interface compute_surface_relative_wind
-      module procedure compute_surface_relative_wind_scalar
-      module procedure compute_surface_relative_wind_links
-   end interface compute_surface_relative_wind
-
-   public :: compute_surface_relative_wind
-   public :: compute_surface_relative_wind_on_link
+   public :: compute_wind_relative_to_surface_scalar
+   public :: compute_wind_relative_to_surface_on_link
 
 contains
 
-   !> Correct a single wind vector with the relative surface-flow contribution.
+   !> Elemental correction of wind with the relative surface-flow contribution.
    !!
-   !! corrected_wind = wind - relativewind * surface_velocity
+   !! Applies
+   !! `corrected_wind = wind - relativewind * surface_velocity`
+   !! to one element (scalar call) or element-wise to conformable arrays.
    !!
-   !! If `corrected_wind_speed` is provided, this routine also returns
-   !! `sqrt(corrected_wind_x**2 + corrected_wind_y**2)`.
-   subroutine compute_surface_relative_wind_scalar(wind_x, wind_y, relativewind, surface_u, surface_v, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
+   !! If `corrected_wind_speed` is present, it returns
+   !! `sqrt(corrected_wind_x**2 + corrected_wind_y**2)` per element.
+   elemental subroutine compute_wind_relative_to_surface_scalar(wind_x, wind_y, relativewind, surface_u, surface_v, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
       real(kind=dp), intent(in) :: wind_x, wind_y !< Input wind components in global x/y direction [m/s].
       real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
       real(kind=dp), intent(in) :: surface_u, surface_v !< Surface-flow components in global x/y direction [m/s].
@@ -70,45 +70,31 @@ contains
       if (present(corrected_wind_speed)) then
          corrected_wind_speed = sqrt(corrected_wind_x * corrected_wind_x + corrected_wind_y * corrected_wind_y)
       end if
-   end subroutine compute_surface_relative_wind_scalar
+   end subroutine compute_wind_relative_to_surface_scalar
 
-   !> Correct wind for one horizontal link using top-layer link velocity from flow state.
-   subroutine compute_surface_relative_wind_on_link(link, wind_x, wind_y, relativewind, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
-      use m_flowgeom, only: csu, snu
-      use m_flow, only: ltop, u1, v
-
-      integer, intent(in) :: link !< Horizontal link index.
+   !> Elemental link-oriented wind correction using local link velocity components.
+   !!
+   !! This routine first rotates link-local velocity components (`link_u`, `link_v`)
+   !! to global coordinates using (`link_cos`, `link_sin`), then applies the same
+   !! relative-wind correction as `compute_wind_relative_to_surface_scalar`.
+   !!
+   !! Because the routine is elemental, it supports both:
+   !! - single-link scalar calls, and
+   !! - vectorized calls over conformable link arrays.
+   elemental subroutine compute_wind_relative_to_surface_on_link(wind_x, wind_y, relativewind, link_u, link_v, link_cos, link_sin, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
       real(kind=dp), intent(in) :: wind_x, wind_y !< Input wind components in global x/y direction [m/s].
       real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
+      real(kind=dp), intent(in) :: link_u, link_v !< Link-normal and link-tangential top-layer velocities [m/s].
+      real(kind=dp), intent(in) :: link_cos, link_sin !< Cosine and sine of link direction in global coordinates [-].
       real(kind=dp), intent(out) :: corrected_wind_x, corrected_wind_y !< Corrected wind components in global x/y direction [m/s].
       real(kind=dp), intent(out), optional :: corrected_wind_speed !< Magnitude of corrected wind vector [m/s].
 
-      real(kind=dp) :: uL, vL, uxL, uyL
+      real(kind=dp) :: uxL, uyL
 
-      uL = u1(ltop(link))
-      vL = v(ltop(link))
-      uxL = uL * csu(link) - vL * snu(link)
-      uyL = uL * snu(link) + vL * csu(link)
+      uxL = link_u * link_cos - link_v * link_sin
+      uyL = link_u * link_sin + link_v * link_cos
 
-      call compute_surface_relative_wind_scalar(wind_x, wind_y, relativewind, uxL, uyL, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
-   end subroutine compute_surface_relative_wind_on_link
-
-   !> Correct link-based wind vectors using top-layer link velocities from the flow state.
-   !!
-   !! This routine loops over all horizontal links and computes the local
-   !! correction by delegating each link to `compute_surface_relative_wind_on_link`.
-   subroutine compute_surface_relative_wind_links(wind_x, wind_y, relativewind, corrected_wind_x, corrected_wind_y)
-      use m_flowgeom, only: lnx
-
-      real(kind=dp), intent(in) :: wind_x(:), wind_y(:) !< Input wind components on links in global x/y direction [m/s].
-      real(kind=dp), intent(in) :: relativewind !< Weight factor for relative-wind correction [-].
-      real(kind=dp), intent(out) :: corrected_wind_x(:), corrected_wind_y(:) !< Corrected wind components on links in global x/y direction [m/s].
-
-      integer :: L
-
-      do L = 1, lnx
-         call compute_surface_relative_wind_on_link(L, wind_x(L), wind_y(L), relativewind, corrected_wind_x(L), corrected_wind_y(L))
-      end do
-   end subroutine compute_surface_relative_wind_links
+      call compute_wind_relative_to_surface_scalar(wind_x, wind_y, relativewind, uxL, uyL, corrected_wind_x, corrected_wind_y, corrected_wind_speed)
+   end subroutine compute_wind_relative_to_surface_on_link
 
 end module m_relative_wind

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
@@ -42,11 +42,11 @@ contains
 
    subroutine setwindstress()
       use precision, only: dp
-      use m_relative_wind, only: compute_surface_relative_wind_on_link
+      use m_relative_wind, only: compute_wind_relative_to_surface_on_link
       use m_setcdwcoefficient, only: setcdwcoefficient
       use m_flowgeom, only: ln, lnx, snu, csu
       use m_flow, only: map_write_settings, rho_water_in_wind_stress, RHO_MEAN, wdsu, ktop, rho, wdsu_x, wdsu_y, rhomean, &
-               viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw
+               viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw, ltop, u1, v
       use m_wind, only: windxav, windyav, jawindstressgiven, jastresstowind, wx, wy, rhoair, cdb, relativewind, jaspacevarcharn, wcharnock, cdwcof, ja_airdensity, ja_computed_airdensity, air_density
       use m_fm_icecover, only: fm_ice_drag_effect, ice_modify_winddrag, ICE_WINDDRAG_NONE, ice_area_fraction
       use m_flowparameters, only: air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
@@ -120,7 +120,7 @@ contains
 
                    wxL = wx(L)
                    wyL = wy(L)
-                   call compute_surface_relative_wind_on_link(L, wxL, wyL, relativewind, wxL, wyL, uwi)
+                   call compute_wind_relative_to_surface_on_link(wxL, wyL, relativewind, u1(ltop(L)), v(ltop(L)), csu(L), snu(L), wxL, wyL, uwi)
                    if (jaspacevarcharn == 1) then
                       cdb(1) = wcharnock(L)
                    end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
@@ -42,17 +42,18 @@ contains
 
    subroutine setwindstress()
       use precision, only: dp
+      use m_relative_wind, only: compute_surface_relative_wind_on_link
       use m_setcdwcoefficient, only: setcdwcoefficient
       use m_flowgeom, only: ln, lnx, snu, csu
       use m_flow, only: map_write_settings, rho_water_in_wind_stress, RHO_MEAN, wdsu, ktop, rho, wdsu_x, wdsu_y, rhomean, &
-                        viskinair, ag, vonkarw, u1, ltop, v, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw
+               viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw
       use m_wind, only: windxav, windyav, jawindstressgiven, jastresstowind, wx, wy, rhoair, cdb, relativewind, jaspacevarcharn, wcharnock, cdwcof, ja_airdensity, ja_computed_airdensity, air_density
       use m_fm_icecover, only: fm_ice_drag_effect, ice_modify_winddrag, ICE_WINDDRAG_NONE, ice_area_fraction
       use m_flowparameters, only: air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
       use m_atmospheric_stability, only: get_wind_stress
       use m_flowgeom_interpolate, only: node_to_link_vector
 
-      real(kind=dp) :: uwi, cdw, tuwi, roro, wxL, wyL, uL, vL, uxL, uyL, ust, ust2, tau, z0w, roa, row
+      real(kind=dp) :: uwi, cdw, tuwi, roro, wxL, wyL, ust, ust2, tau, z0w, roa, row
       real(kind=dp) :: local_ice_area_fraction
       real(kind=dp), allocatable :: wind_stress_x_node(:), wind_stress_y_node(:)
       integer :: L, numwav, k
@@ -119,15 +120,7 @@ contains
 
                    wxL = wx(L)
                    wyL = wy(L)
-                   if (relativewind > 0.0_dp) then
-                      uL = relativewind * U1(Ltop(L))
-                      vL = relativewind * v(Ltop(L))
-                      uxL = uL * csu(L) - vL * snu(L)
-                      uyL = uL * snu(L) + vL * csu(L)
-                      wxL = wxL - uxL
-                      wyL = wyL - uyL
-                   end if
-                   uwi = sqrt(wxL * wxL + wyL * wyL)
+                   call compute_surface_relative_wind_on_link(L, wxL, wyL, relativewind, wxL, wyL, uwi)
                    if (jaspacevarcharn == 1) then
                       cdb(1) = wcharnock(L)
                    end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -330,10 +330,12 @@ contains
    !> compute fluxes based on Monin-Obukhov Stability Theory
    module subroutine compute_air_water_interaction_most_fluxes(initialization)
       use precision, only: dp
-      use m_flowgeom, only: ndx
+      use m_flowgeom, only: ndx, lnx
       use m_get_surface_temperature, only: get_surface_temperature
       use m_flowgeom_interpolate, only: link_to_node_vector, link_to_node_scalar
       use m_atmospheric_stability, only: compute_scales_and_fluxes, t_options
+      use m_relative_wind, only: compute_surface_relative_wind
+      use m_wind, only: relativewind
       use physicalconsts, only: celsius_to_kelvin
       use m_flowparameters, only: atmospheric_stability_function, ATMOSPHERIC_STABILITY_FUNCTION_ECMWF, &
                                   free_convection, FREE_CONVECTION_ON, salinity_reduction_factor_saturation_humidity
@@ -343,6 +345,7 @@ contains
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature
       real(kind=dp), dimension(:), allocatable, save :: windx, windy, charnock
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature_kelvin, air_temperature_kelvin, dew_point_temperature_kelvin
+      real(kind=dp), dimension(lnx) :: windx_link, windy_link
       type(t_options) :: atm_stability_options
 
 
@@ -355,9 +358,9 @@ contains
          allocate(air_temperature_kelvin(ndx))
          allocate(dew_point_temperature_kelvin(ndx))
       end if
-      
 
-      call link_to_node_vector(wx, wy, windx, windy, ndx)
+      call compute_surface_relative_wind(wx, wy, relativewind, windx_link, windy_link)
+      call link_to_node_vector(windx_link, windy_link, windx, windy, ndx)
       call link_to_node_scalar(wcharnock, charnock, ndx)
 
       call get_surface_temperature(surface_temperature, initialization)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -330,12 +330,13 @@ contains
    !> compute fluxes based on Monin-Obukhov Stability Theory
    module subroutine compute_air_water_interaction_most_fluxes(initialization)
       use precision, only: dp
-      use m_flowgeom, only: ndx, lnx
+      use m_flowgeom, only: ndx, lnx, csu, snu
       use m_get_surface_temperature, only: get_surface_temperature
       use m_flowgeom_interpolate, only: link_to_node_vector, link_to_node_scalar
       use m_atmospheric_stability, only: compute_scales_and_fluxes, t_options
-      use m_relative_wind, only: compute_surface_relative_wind
+      use m_relative_wind, only: compute_wind_relative_to_surface_on_link
       use m_wind, only: relativewind
+      use m_flow, only: ltop, u1, v
       use physicalconsts, only: celsius_to_kelvin
       use m_flowparameters, only: atmospheric_stability_function, ATMOSPHERIC_STABILITY_FUNCTION_ECMWF, &
                                   free_convection, FREE_CONVECTION_ON, salinity_reduction_factor_saturation_humidity
@@ -359,7 +360,8 @@ contains
          allocate(dew_point_temperature_kelvin(ndx))
       end if
 
-      call compute_surface_relative_wind(wx, wy, relativewind, windx_link, windy_link)
+      call compute_wind_relative_to_surface_on_link(wx(1:lnx), wy(1:lnx), relativewind, u1(ltop(1:lnx)), v(ltop(1:lnx)), &
+                               csu(1:lnx), snu(1:lnx), windx_link, windy_link)
       call link_to_node_vector(windx_link, windy_link, windx, windy, ndx)
       call link_to_node_scalar(wcharnock, charnock, ndx)
 


### PR DESCRIPTION
# What was done 
- create m_relative_wind.f90 containing procedures for computing relative corrected wind velocity components and wind speed 
- implement the procedure in routine compute_air_water_interaction_most_fluxes() in set_external_forcings_update.
- use the procedures in setwindstress() and heatun() 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable; tests have been done locally, with relativewind = 0 and 1, the results are compared to an existing setup generated earlier before relativewind is supported (practically relativewind=0); when relativewind = 0, results are identical with the existing one; when relativewind = 1, results are different; see the two figures below. Further tests will be done by user.

When RelativeWind = 0:
<img width="702" height="628" alt="20260702_wldiff_relwind_0 0" src="https://github.com/user-attachments/assets/c60bd67a-93a1-4244-acc5-f583ea1d082d" />

When RelativeWind = 1:
<img width="702" height="628" alt="20260702_wldiff_relwind_1 0" src="https://github.com/user-attachments/assets/33109674-723b-4c7d-8551-806bb997e0ca" />


# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9889