### PR TITLE
UNST-9690 Add cygwin to windows docker container. Remove some unneede…

### DIFF
--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
@@ -87,8 +87,8 @@ RUN Start-Process -FilePath 'C:\cygwin-setup-x86_64.exe' -Wait -NoNewWindow -Arg
     Remove-Item -Force C:\cygwin-setup-x86_64.exe; \
     Remove-Item -Recurse -Force C:\cygwin-packages
 
-# Cygwin's link.exe conflicts with the Intel ifort/ifx compiler. Rename it so the
-# Intel/MSVC linker is picked up instead (per PETSc Windows install instructions).
+# Cygwin's link.exe conflicts with the Intel ifort/ifx compiler. Rename it so the Intel/MSVC linker is
+# picked up instead (see https://petsc.org/main/install/windows/#native-microsoft-intel-windows-compilers).
 RUN if (Test-Path 'C:\cygwin64\bin\link.exe') { Move-Item 'C:\cygwin64\bin\link.exe' 'C:\cygwin64\bin\link-cygwin.exe' }
 
 # Add Cygwin to the PATH (appended so it does not shadow the explicitly installed tools).

--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
@@ -10,14 +10,11 @@ ADD vs_Community.exe C:/
 
 RUN (start /w vs_community.exe --passive --wait --noUpdateInstaller --norestart --nocache \
     --installPath "C:\\Program Files\\Microsoft Visual Studio\\17\\Community" \
-    --add Microsoft.VisualStudio.Workload.NativeDesktop;includeRecommended \
+    --add Microsoft.VisualStudio.Workload.NativeDesktop \
+    --add Microsoft.VisualStudio.Component.VC.Tools.x86.x64 \
     --add Microsoft.VisualStudio.Component.Windows11SDK.26100 \
     --add Microsoft.VisualStudio.Component.VC.ATLMFC \
     --add Microsoft.VisualStudio.Component.VC.CLI.Support \
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.10240 \
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.10586 \
-    --remove Microsoft.VisualStudio.Component.Windows10SDK.14393 \
-    --remove Microsoft.VisualStudio.Component.Windows81SDK \
     || IF "%ERRORLEVEL%"=="3010" EXIT 0)
 
 SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'Continue'; $verbosePreference='Continue';"]
@@ -44,15 +41,20 @@ RUN Remove-Item C:\\cmake-3.31.0-rc1-windows-x86_64.msi
 ENV ONEAPI_ROOT="C:\\Program Files (x86)\\Intel\\oneAPI\\"
 ENV VS2022INSTALLDIR="C:\\Program Files (x86)\\Microsoft Visual Studio\\2022\\Community\\"
 
-# Download and install git
-ADD Git-2.47.0-64-bit.exe C:\\Git-2.47.0-64-bit.exe
-RUN Start-Process -FilePath "C:\\Git-2.47.0-64-bit.exe" -ArgumentList "/SILENT" -Wait
-RUN Remove-Item C:\\Git-2.47.0-64-bit.exe
-RUN setx /M PATH $($Env:PATH + ';C:\\Program Files\\Git\\usr\\bin')
+# Add the Git that ships with Visual Studio to the PATH. The location is resolved
+# with vswhere (whose own path is stable across VS versions/editions) so the exact
+# VS install folder never needs to be hard-coded.
+RUN $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'; \
+    if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }; \
+    $gitCmd = & $vswhere -latest -products * -find '**\cmd\git.exe' | Select-Object -First 1; \
+    if (-not $gitCmd) { throw 'Could not locate git.exe in the Visual Studio installation.' }; \
+    $gitDir = Split-Path -Parent $gitCmd; \
+    Write-Host ('Adding Git to PATH: ' + $gitDir); \
+    setx /M PATH ($Env:PATH + ';' + $gitDir)
 
 # Install uv
 ENV UV_INSTALL_DIR="C:\Program Files\uv\install"
-RUN irm https://astral.sh/uv/0.11.11/install.ps1 | iex
+RUN irm https://astral.sh/uv/0.11.26/install.ps1 | iex
 
 ENV UV_PYTHON_INSTALL_DIR="C:\Program Files\uv\python" \
     UV_TOOL_DIR="C:\Program Files\uv\tools" \
@@ -62,10 +64,38 @@ ENV UV_PYTHON_INSTALL_DIR="C:\Program Files\uv\python" \
 # Install python and conan
 RUN setx /M PATH \"C:\Program Files\uv\bin;C:\Program Files\uv\install;$env:PATH\"
 RUN uv python install 3.12 --default
-RUN uv tool install 'conan ~= 2.28.1'
+RUN uv tool install 'conan ~= 2.30.0'
+
+ADD setup-x86_64.exe C:\\cygwin-setup-x86_64.exe
+# Install and clean up the package cache in a single layer. The cache uses very
+# long, URL-encoded directory names (e.g. https%3a%2f%2fmirrors.kernel.org%2f...)
+# which break the Windows container layer import (hcsshim::ImportLayer) if they
+# are ever committed to a layer, so they must never persist beyond this RUN.
+RUN Start-Process -FilePath 'C:\cygwin-setup-x86_64.exe' -Wait -NoNewWindow -ArgumentList \
+    '--quiet-mode', \
+    '--no-shortcuts', \
+    '--no-startmenu', \
+    '--no-desktop', \
+    '--no-admin', \
+    '--upgrade-also', \
+    '--root', 'C:\cygwin64', \
+    '--local-package-dir', 'C:\cygwin-packages', \
+    '--site', 'https://mirrors.kernel.org/sourceware/cygwin/', \
+    '--site', 'https://cygwin.mirror.constant.com/', \
+    '--only-site', \
+    '--packages', 'python3,make,git,cmake'; \
+    Remove-Item -Force C:\cygwin-setup-x86_64.exe; \
+    Remove-Item -Recurse -Force C:\cygwin-packages
+
+# Cygwin's link.exe conflicts with the Intel ifort/ifx compiler. Rename it so the
+# Intel/MSVC linker is picked up instead (per PETSc Windows install instructions).
+RUN if (Test-Path 'C:\cygwin64\bin\link.exe') { Move-Item 'C:\cygwin64\bin\link.exe' 'C:\cygwin64\bin\link-cygwin.exe' }
+
+# Add Cygwin to the PATH (appended so it does not shadow the explicitly installed tools).
+RUN setx /M PATH ($Env:PATH + ';C:\cygwin64\bin')
 
 # Copy the setup script into the container
 COPY set-env-vs2022.cmd C:\\set-env-vs2022.cmd
 
 # Set the default command to run the setup script
-CMD ["cmd", "/S", "/C", "C:\\set-env-vs2022.cmd"]
+CMD ["cmd", "/S", "/K", "C:\\set-env-vs2022.cmd"]

--- a/ci/dockerfiles/windows/set-env-vs2022.cmd
+++ b/ci/dockerfiles/windows/set-env-vs2022.cmd
@@ -1,3 +1,12 @@
 @echo off
+rem Recreate the 8.3 short names for the space-containing "Program Files" folders.
+rem PETSc's Windows configure (run from Cygwin) uses `cygpath -ms` to obtain a
+rem space-free path to the Intel oneAPI MPI/MKL libraries. Windows containers do
+rem not persist 8.3 metadata changes made to base-image folders at build time, so
+rem the short names must be (re)created at container startup instead.
+fsutil 8dot3name set C: 0 >nul 2>&1
+fsutil file setshortname "C:\Program Files" PROGRA~1 >nul 2>&1
+fsutil file setshortname "C:\Program Files (x86)" PROGRA~2 >nul 2>&1
+
 call "C:\\Program Files (x86)\\Intel\\oneAPI\\setvars.bat" --force
 call "C:\\Program Files\\Microsoft Visual Studio\\17\\Community\\Common7\\Tools\\VsDevCmd.bat" -arch=amd64 -host_arch=amd64


### PR DESCRIPTION
…d components and update uv and conan

- Added cygwin
- Removed includeRecommended from the Visual Studio install, explicitly install those parts that are necessary (reduce size docker container, total from 58.8GB to 50.6GB despite adding cygwin)
- Update uv and conan to latest versions
- Ensure that PROGRA~2 alias is available for C:\Program Files (x86), because cygwin cannot handle spaces in paths
- Remove separate git installer, use git from visual studio

# Issue link UNST-9690
