### PR TITLE
UNST-9277 Testbench no longer fails when kernel writes unicode characters to stdout

### DIFF
--- a/test/deltares_testbench/src/suite/program.py
+++ b/test/deltares_testbench/src/suite/program.py
@@ -149,14 +149,14 @@ class Program:
 
             if completed_process.stderr:
                 prog_path = str(self.__program_config.path)
-                error_message = completed_process.stderr.decode().rstrip().replace("'", "")
+                error_message = completed_process.stderr.decode(errors="replace").rstrip().replace("'", "")
                 if self.__program_config.ignore_standard_error:
                     logger.debug(f"{prog_path} contained error message - {error_message}, but ignoring it")
                 else:
                     logger.warning(f"{prog_path} contained error message - {error_message}")
                     self.__error = subprocess.CalledProcessError(-1, self.__program_config.path, error_message)
         except Exception as e:
-            logger.exception(f"{repr(e)} Could not execute program: {e.filename}")
+            logger.exception(f"Could not execute program: {repr(e)}")
             self.__error = e
 
     def __handle_process_output(self, logger: ILogger, completed_process: subprocess.CompletedProcess) -> None:
@@ -177,7 +177,7 @@ class Program:
         logger.debug(f"Program output will be written to: {log_file}")
         file_logger = FileLogger(self.__settings.command_line_settings.log_level, unique_name, log_file)
         for line in completed_process.stdout.splitlines():
-            file_logger.debug(line.decode())
+            file_logger.debug(line.decode(errors="replace"))
 
     def __start_process(self, logger):
         execmd = self.__buildExeCommand__(logger)

--- a/test/deltares_testbench/src/utils/logging/file_logger.py
+++ b/test/deltares_testbench/src/utils/logging/file_logger.py
@@ -63,10 +63,10 @@ class FileLogger(ILogger):
         os.makedirs(log_folder, exist_ok=True)
 
         if os.path.isfile(self.__path):
-            handler = handlers.RotatingFileHandler(self.__path, backupCount=10)
+            handler = handlers.RotatingFileHandler(self.__path, backupCount=10, encoding="utf-8")
             handler.doRollover()
         else:
-            handler = handlers.RotatingFileHandler(self.__path, backupCount=10)
+            handler = handlers.RotatingFileHandler(self.__path, backupCount=10, encoding="utf-8")
 
         handler.setLevel(log_level)
         format_str = "%(asctime)s [%(levelname)-7s] : %(message)s"


### PR DESCRIPTION
# What was done 

This PR makes the TestBench more robust against garbage output that a kernel might write to stdout.

Thomas Pijls' recent changes in #1013 caused many testbench failures. After some digging I found that some junk values has been written to the dia file. An example from one of the tests:

```
** INFO   : Start initializing external forcings...
** WARNING: The inifieldfile is deprecated. Consider moving the content of inifields.ini to the external forcings file.
** WARNING: In [initial] block in file 'XÐªÿÝp@ƒ6âp@ÖHAìp@^ÐÜÿñp@JÕZ® öp@þOˆŒ  q@p0€;ÿq@&„òÖÿ	q@B7\ q@Ld›¼ÿq@’í`)ÿq@wÎ»²ÿq@¢ŠP "q@»W»õÿ'q@v‡´ÿ-q@PHG 2q@Shíãÿ3q@LuÊ 6q@°«h\ <q@LØ¸ÿAq@ê*ªV Fq@
¼ú Jq@¦Æö Pq@Ú1SÿUq@´òµÿYq@s‹+ ^q@ã¶Áÿcq@é–w…ÿiq@d‰ nq@‹^*z rq@ ¬xO xq@„9à  ~q@': operand value 'O' is deprecated. Consider replacing with 'override', 'overrideIfMissing', 'add', 'multiply', 'minimum', or 'maximum'.
** INFO   : Opened file : iniwatk.xyz
```

These log messages are also printed to the stdout, and the TestBench wasn't able to deal with this properly. TestBench uses `bytes.decode()` which by throws an exception when a unicode character is encountered. When using `error='replace'` the character is replaced by the unknown character symbol �. 

Another thing that went wrong is that the error handling assumed that the exception thrown in python always included a filename, which is only true for OSError-derived exceptions. This caused yet another failure that wasn't the actual issue.

# Downsides

There is a blessing in disguise here: if it weren't for the testbench failing we probably would have never noticed this issue. We might want to do some more explicit checking on what output is written to the stdout. Feel free to discuss.

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9277