### PR TITLE
UNST-10103: Try to fix flaky horton tests

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delsam.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delsam.f90
@@ -40,7 +40,7 @@ contains
 !>               -1: do not prompt for confirmation, deallocate arrays, do not make copy
    subroutine DELSAM(JACONFIRM) ! SPvdP: need promptless delsam in orthogonalisenet
       use precision, only: dp
-      use M_SAMPLES, only: nsmax, ns, xs, ys, zs, ipsam, savesam
+      use M_SAMPLES, only: nsmax, ns, xs, ys, zs, ipsam, savesam, mxsam, mysam
       use m_polygon, only: npl, xpl, ypl, zpl
       use m_missing, only: dmiss, jins
       use geometry_module, only: dbpinpol
@@ -68,6 +68,8 @@ contains
                deallocate (ipsam)
             end if
          end if
+         mxsam = 0
+         mysam = 0
          return
       end if
 
@@ -89,6 +91,8 @@ contains
             ipsam(i) = 0
          end do
          NS = 0
+         mxsam = 0
+         mysam = 0
          return
       end if
       ! Else: check in polygon

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_obs_on_flowgeom.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_obs_on_flowgeom.f90
@@ -267,7 +267,6 @@ contains
       use m_sferic                 , only: jsferic, jasfer3D
       use fm_external_forcings_data, only: transformcoef
       use m_polygon                , only: npl, xpl, ypl, zpl
-      use m_samples                , only: mxsam, mysam 
       use precision                , only: dp
       use m_alloc
       
@@ -296,7 +295,7 @@ contains
       call realloc(wfxx, [3, numobs + nummovobs], keepexisting=.false., fill=0.0_dp)
             
       call triinterp2(xobs, yobs,dumout, numobs + nummovobs, jdla   ,xz(1:ndx2d), yz(1:ndx2d), dummyZ, ndx2d, dmiss, jsferic, 1   , &
-                                 jasfer3D, NPL, MXSAM, MYSAM, XPL, YPL, ZPL, transformcoef)
+                                 jasfer3D, NPL, 0, 0, XPL, YPL, ZPL, transformcoef)
       
        do i = n_start, n_end
          neighbour_nodes_obs  (:, i) = indxx(:, i)


### PR DESCRIPTION
# What was done 

There seems to be a bug with the reusing of the global data in 'm_samples' when a model uses this combination:
- Reading the bed level from a geotiff file
- Has observation stations

The two test cases in UNST-10103 have this combination. Details in the JIRA issue: https://issuetracker.deltares.nl/browse/UNST-10103

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
