### PR TITLE
UNST-9962: Remove deprecated .ini file warning

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -85,11 +85,6 @@ contains
          return
       end if
 
-      if (file_name(len_trim(file_name) - 3:) == '.ini') then
-         write (msgbuf, '(a)') 'The inifieldfile is deprecated. Consider moving the content of '//trim(file_name)//' to the external forcings file.'
-         call warn_flush()
-      end if
-
       res = .true.
 
       call tree_create(file_name, bnd_ptr)


### PR DESCRIPTION
# What was done 
- Remove deprecated .ini file warning
- Depending on the status of extforce transition in the GUI, this will be replaced by the more generic `call add_deprecated_keyword(deprecated_mdu_keywords, 'Geometry', ' IniFieldFile', DEPRECATED, 'Use ExtForceFileNew instead.')`

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9962