### PR TITLE
UNST-9888_add_extra_output_to_his_file

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
@@ -1518,6 +1518,42 @@ contains
                              'Wrihis_wind', 'windy', 'velocity of air on flow element center, y-component', 'northward_wind', &
                              'm s-1', UNC_LOC_STATION, nc_attributes=atts(1:1), &
                              nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_WINDSTRESSX, &
+                             'Wrihis_windstress', 'windstressx', 'wind stress on flow element center, x-component', 'surface_downward_x_stress', &
+                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+                    nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_WINDSTRESSX_SFERIC, &
+                             'Wrihis_windstress', 'windstressx', 'wind stress on flow element center, x-component', 'surface_downward_eastward_stress', &
+                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+                    nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_WINDSTRESSY, &
+                             'Wrihis_windstress', 'windstressy', 'wind stress on flow element center, y-component', 'surface_downward_y_stress', &
+                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+                    nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_WINDSTRESSY_SFERIC, &
+                             'Wrihis_windstress', 'windstressy', 'wind stress on flow element center, y-component', 'surface_downward_northward_stress', &
+                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+                    nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_WSTAR, &
+                    'Wrihis_windstress', 'w_star', 'Free convective velocity scale', '', &
+              'm s-1', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+              nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_OBUKHOV_LENGTH, &
+                    'Wrihis_windstress', 'obukhov_length', 'Obukhov length', '', &
+              'm', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+              nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_MOMENTUM, &
+                    'Wrihis_windstress', 'C_D', 'Bulk transfer coefficient of momentum flux', '', &
+              '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+              nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_SENSIBLE_HEAT, &
+                    'Wrihis_windstress', 'C_H', 'Bulk transfer coefficient of sensible heat flux', '', &
+              '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+              nc_dim_ids=station_nc_dims_2D)
+      call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_LATENT_HEAT, &
+                    'Wrihis_windstress', 'C_E', 'Bulk transfer coefficient of latent heat flux', '', &
+              '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+              nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_RAIN, &
                              'Wrihis_rain', 'rain', 'precipitation depth per time unit', 'lwe_precipitation_rate', &
                              'mm day-1', UNC_LOC_STATION, nc_attributes=atts(1:1), description='Write precipitation to his-file', &
@@ -2306,6 +2342,7 @@ contains
       use processes_input, only: num_wq_user_outputs => noout_user
       use m_dad, only: dad_included, dadpar
       use m_laterals, only: numlatsg, qplat, qplatAve, qLatRealAve, qLatReal
+      use m_flowparameters, only: air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
       use m_sferic, only: jsferic
       use m_wind, only: air_pressure_available, jawind, jarain, ja_airdensity, ja_computed_airdensity, cloudiness, relative_humidity
       use m_dambreak_breach, only: n_db_signals
@@ -2755,6 +2792,24 @@ contains
             end if
          end if
 
+         if (jawind > 0 .and. his_write_settings%windstress > 0) then
+            if (jsferic == 0) then
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WINDSTRESSX), valobs(:, IPNT_windstressx))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WINDSTRESSY), valobs(:, IPNT_windstressy))
+            else
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WINDSTRESSX_SFERIC), valobs(:, IPNT_windstressx))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WINDSTRESSY_SFERIC), valobs(:, IPNT_windstressy))
+            end if
+         end if
+         
+         if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+            call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WSTAR), valobs(:, IPNT_wstar))
+            call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_OBUKHOV_LENGTH), valobs(:, IPNT_obukhov_length))
+            call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_TRANSFER_COEFF_MOMENTUM), valobs(:, IPNT_TRANSFER_COEFF_MOMENTUM))
+            call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_TRANSFER_COEFF_SENSIBLE_HEAT), valobs(:, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT))
+            call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_TRANSFER_COEFF_LATENT_HEAT), valobs(:, IPNT_TRANSFER_COEFF_LATENT_HEAT))
+         end if
+
          if (jarain > 0 .and. his_write_settings%rain > 0) then
             call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_RAIN), valobs(:, IPNT_rain))
          end if
@@ -2769,8 +2824,14 @@ contains
          end if
 
          ! Write heat flux model statistical output
-         if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-            if (his_write_settings%heatflux > 0) then
+         if (his_write_settings%heatflux > 0) then
+            if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QSUN), valobs(:, IPNT_QSUN))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QEVA), valobs(:, IPNT_QEVA))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QCON), valobs(:, IPNT_QCON))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QLONG), valobs(:, IPNT_QLON))
+               call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QTOT), valobs(:, IPNT_QTOT))
+            elseif (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
                call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WIND), valobs(:, IPNT_WIND))
                call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_TAIR), valobs(:, IPNT_TAIR))
 
@@ -2787,7 +2848,7 @@ contains
                   call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QFREVA), valobs(:, IPNT_QFRE))
                   call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QFRCON), valobs(:, IPNT_QFRC))
                end if
-
+               
                call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_QTOT), valobs(:, IPNT_QTOT))
             end if
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
@@ -1543,15 +1543,15 @@ contains
               'm', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_MOMENTUM, &
-                    'Wrihis_windstress', 'C_D', 'Bulk transfer coefficient of momentum flux', '', &
+                    'Wrihis_windstress', 'c_d', 'Bulk transfer coefficient of momentum flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_SENSIBLE_HEAT, &
-                    'Wrihis_windstress', 'C_H', 'Bulk transfer coefficient of sensible heat flux', '', &
+                    'Wrihis_windstress', 'c_h', 'Bulk transfer coefficient of sensible heat flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_LATENT_HEAT, &
-                    'Wrihis_windstress', 'C_E', 'Bulk transfer coefficient of latent heat flux', '', &
+                    'Wrihis_windstress', 'c_e', 'Bulk transfer coefficient of latent heat flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_RAIN, &

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
@@ -1535,23 +1535,23 @@ contains
                     'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
                     nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_WSTAR, &
-                    'Wrihis_windstress', 'w_star', 'Free convective velocity scale', '', &
+                    'Wrihis_bulk_exchange_coefficients', 'w_star', 'Free convective velocity scale', '', &
               'm s-1', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_OBUKHOV_LENGTH, &
-                    'Wrihis_windstress', 'obukhov_length', 'Obukhov length', '', &
+                    'Wrihis_bulk_exchange_coefficients', 'obukhov_length', 'Obukhov length', 'atmosphere_obukhov_length', &
               'm', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_MOMENTUM, &
-                    'Wrihis_windstress', 'c_d', 'Bulk transfer coefficient of momentum flux', '', &
+                    'Wrihis_bulk_exchange_coefficients', 'c_d', 'Bulk transfer coefficient of momentum flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_SENSIBLE_HEAT, &
-                    'Wrihis_windstress', 'c_h', 'Bulk transfer coefficient of sensible heat flux', '', &
+                    'Wrihis_bulk_exchange_coefficients', 'c_h', 'Bulk transfer coefficient of sensible heat flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_TRANSFER_COEFF_LATENT_HEAT, &
-                    'Wrihis_windstress', 'c_e', 'Bulk transfer coefficient of latent heat flux', '', &
+                    'Wrihis_bulk_exchange_coefficients', 'c_e', 'Bulk transfer coefficient of latent heat flux', '', &
               '-', UNC_LOC_STATION, nc_attributes=atts(1:1), &
               nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_RAIN, &
@@ -2802,7 +2802,7 @@ contains
             end if
          end if
          
-         if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+         if (his_write_settings%bulk_exchange_coeff > 0 .and. air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
             call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_WSTAR), valobs(:, IPNT_wstar))
             call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_OBUKHOV_LENGTH), valobs(:, IPNT_obukhov_length))
             call add_stat_output_items(output_set, output_config_set%configs(IDX_HIS_TRANSFER_COEFF_MOMENTUM), valobs(:, IPNT_TRANSFER_COEFF_MOMENTUM))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -348,6 +348,11 @@ module m_flow ! flow arrays-999
    real(kind=dp), allocatable :: wdsu(:) !< windstress/rhow u point  (m2/s2)
    real(kind=dp), allocatable, target :: wdsu_x(:) !< windstress u point  (N/m2) x-component
    real(kind=dp), allocatable, target :: wdsu_y(:) !< windstress u point  (N/m2) y-component
+   real(kind=dp), allocatable, target :: w_star(:) !< [m/s] free convective velocity scale at cell centers
+   real(kind=dp), allocatable, target :: obukhov_length(:) !< [m] Obukhov length at cell centers
+   real(kind=dp), allocatable, target :: transfer_coeff_momentum(:) !< [-] bulk transfer coefficient for momentum flux at cell centers
+   real(kind=dp), allocatable, target :: transfer_coeff_sensible_heat(:) !< [-] bulk transfer coefficient for sensible heat flux at cell centers
+   real(kind=dp), allocatable, target :: transfer_coeff_latent_heat(:) !< [-] bulk transfer coefficient for latent heat flux at cell centers
    real(kind=dp), allocatable :: wavmubnd(:) !< wave-induced mass flux (on open boundaries)
    integer :: number_steps_limited_visc_flux_links = 0 !< number of steps with limited viscosity/flux on links
    integer, parameter :: MAX_PRINTS_LIMITED_VISC_FLUX_LINKS = 10 !< number of messages in dia file on limited viscosity/flux links

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -1,4 +1,4 @@
-!----- AGPL --------------------------------------------------------------------
+﻿!----- AGPL --------------------------------------------------------------------
 !
 !  Copyright (C)  Stichting Deltares, 2017-2026.
 !
@@ -64,7 +64,7 @@ module m_flow ! flow arrays-999
    integer :: numtopsig = 0 !< number of top layers in sigma
    integer :: janumtopsiguniform = 1 !< specified nr of top layers in sigma is same everywhere
 
-   integer, allocatable :: ndkx_to_ndx(:)  ! Maps NDKX → NDX
+   integer, allocatable, dimension(:) :: ndkx_to_ndx  ! Maps NDKX â†’ NDX
 
    real(kind=dp) :: Tsigma = 100 !< relaxation period; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
 
@@ -88,25 +88,25 @@ module m_flow ! flow arrays-999
    real(kind=dp) :: dztop = -999.0_dp !< if specified, dz of top layer, kmx = computed, if not, dz = (ztop-zbot)/kmx
    real(kind=dp) :: zlaybot = -999.0_dp !< if specified, first zlayer starts from zlaybot, if not, it starts from the lowest bed point
    real(kind=dp) :: zlaytop = -999.0_dp !< if specified, highest zlayer ends at zlaytop, if not, it ends at the initial water level
-   real(kind=dp), allocatable :: aak(:) !< coefficient vertical mom exchange of kmx layers
-   real(kind=dp), allocatable :: bbk(:) !< coefficient vertical mom exchange of kmx layers
-   real(kind=dp), allocatable :: cck(:) !< coefficient vertical mom exchange of kmx layers
-   real(kind=dp), allocatable :: ddk(:) !< coefficient vertical mom exchange of kmx layers
-   real(kind=dp), allocatable :: eek(:) !< coefficient vertical mom exchange of kmx layers
-   real(kind=dp), allocatable :: uuk(:) !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: aak !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: bbk !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: cck !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: ddk !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: eek !< coefficient vertical mom exchange of kmx layers
+   real(kind=dp), allocatable, dimension(:) :: uuk !< coefficient vertical mom exchange of kmx layers
 
-   real(kind=dp), allocatable :: laycof(:) !< coefficients for sigma layer
+   real(kind=dp), allocatable, dimension(:) :: laycof !< coefficients for sigma layer
    !    1: Percentages of the layers, user defined, laycof(kmx)
    !    2: Stretching level, and two coefficients for layers growth, laycof(3)
    !
-   real(kind=dp), allocatable :: dzslay(:, :) ! the normalized thickness of layer, dim = (: , maxlaydefs)
+   real(kind=dp), allocatable, dimension(:, :) :: dzslay ! the normalized thickness of layer, dim = (: , maxlaydefs)
 
    !real(kind=dp), allocatable     :: dzu(:)           !< vertical layer size at layer centre    at u-velocity points (m) 1:kmx Local
    !real(kind=dp), allocatable     :: dzw(:)           !< vertical layer size at layer interface at u-velocity points (m) 1:kmx Local
    !< 1:kmx: bottom interface not included
 
-   real(kind=dp), allocatable, target :: zws(:) !< [m] z levels  (m) of interfaces (w-points) at cell centres (s-points) (m)    (1:ndkx) {"shape": ["ndkx"]}
-   real(kind=dp), allocatable :: zws0(:) !< z levels  (m) of interfaces (w-points) at cell centres (s-points) (m)    (1:ndkx), be
+   real(kind=dp), allocatable, target, dimension(:) :: zws !< [m] z levels  (m) of interfaces (w-points) at cell centres (s-points) (m)    (1:ndkx) {"shape": ["ndkx"]}
+   real(kind=dp), allocatable, dimension(:) :: zws0 !< z levels  (m) of interfaces (w-points) at cell centres (s-points) (m)    (1:ndkx), be
 
                                                         !!
                                                         !!-------------------------------------  zws(2) = interface(2), zws (ktop(ndx) ) == s1(ndx)
@@ -124,120 +124,120 @@ module m_flow ! flow arrays-999
                                                         !!-------------------------------------  zws(0) = interface(0) = bl
                                                         !!
 
-   real(kind=dp), allocatable, target :: zcs(:) !< z levels at layer mid-points, only for nudging
+   real(kind=dp), allocatable, target, dimension(:) :: zcs !< z levels at layer mid-points, only for nudging
 
    !< [m] waterlevel    (m ) at start of timestep {"location": "face", "shape": ["ndx"]}
-   integer, allocatable, target :: kbot(:) !< [-] layer-compressed bottom layer cell number: for each of ndx horizontal cells, we have indices to bot and top ndxk cells {"location": "face", "shape": ["ndx"]}
-   integer, allocatable, target :: ktop(:) !< [-] layer-compressed top layer cell number: for each of ndx horizontal cells, we have indices to bot and top ndxk cells {"location": "face", "shape": ["ndx"]}
-   integer, allocatable :: ktop0(:) !< store of ktop
-   integer, allocatable :: kmxn(:) !< Maximum number of active vertical cells per horizontal base cell n (cell_index_2d). The maximum is decided upon initialization, depends on many keywords and can be smaller than kmx.
-   integer, allocatable, target :: Lbot(:) !< [-] layer-compressed bottom layer edge number: for each of lnx horizontal links, we have indices to bot and top lnxk links {"location": "edge", "shape": ["lnx"]}
-   integer, allocatable, target :: Ltop(:) !< [-] layer-compressed top layer edge number: for each of lnx horizontal links, we have indices to bot and top lnxk links {"location": "edge", "shape": ["lnx"]}
-   integer, allocatable :: kmxL(:) !< max nr of vertical links per base link L
-   integer, allocatable :: kbotc(:) !< as kbot, for cornerpoints
-   integer, allocatable :: kmxc(:) !< as kmxn, for cornerpoints
+   integer, allocatable, target, dimension(:) :: kbot !< [-] layer-compressed bottom layer cell number: for each of ndx horizontal cells, we have indices to bot and top ndxk cells {"location": "face", "shape": ["ndx"]}
+   integer, allocatable, target, dimension(:) :: ktop !< [-] layer-compressed top layer cell number: for each of ndx horizontal cells, we have indices to bot and top ndxk cells {"location": "face", "shape": ["ndx"]}
+   integer, allocatable, dimension(:) :: ktop0 !< store of ktop
+   integer, allocatable, dimension(:) :: kmxn !< Maximum number of active vertical cells per horizontal base cell n (cell_index_2d). The maximum is decided upon initialization, depends on many keywords and can be smaller than kmx.
+   integer, allocatable, target, dimension(:) :: Lbot !< [-] layer-compressed bottom layer edge number: for each of lnx horizontal links, we have indices to bot and top lnxk links {"location": "edge", "shape": ["lnx"]}
+   integer, allocatable, target, dimension(:) :: Ltop !< [-] layer-compressed top layer edge number: for each of lnx horizontal links, we have indices to bot and top lnxk links {"location": "edge", "shape": ["lnx"]}
+   integer, allocatable, dimension(:) :: kmxL !< max nr of vertical links per base link L
+   integer, allocatable, dimension(:) :: kbotc !< as kbot, for cornerpoints
+   integer, allocatable, dimension(:) :: kmxc !< as kmxn, for cornerpoints
 
    integer :: mxlaydefs = 4 !< max nr of layering definitions
-   integer, allocatable :: laydefnr(:) !< dim = (ndx), pointer to laydef, if positive to unique laydef, otherwise interpolate in 1,2, and 3
-   integer, allocatable :: laytyp(:) !< dim = (mxlaydefs), 1 = sigma, 2 = z
-   integer, allocatable :: laymx(:) !< dim = (mxlaydefs), max nr of layers
-   integer, allocatable :: nrlayn(:) !< dim = (ndx), max nr of layers
-   integer, allocatable :: nlaybn(:) !< dim = (ndx), bed lay nr
-   real(kind=dp), allocatable :: zslay(:, :) !< dim = (: , maxlaydefs) z or s coordinate,
-   real(kind=dp), allocatable :: wflaynod(:, :) !< dim = (3 , ndx) weight factors to flownodes indlaynod
-   integer, allocatable :: indlaynod(:, :) !< dim = (3 , ndx)
-   real(kind=dp), allocatable :: dkx(:) !< dim = ndx, sigma level of interface height; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
-   real(kind=dp), allocatable :: sdkx(:) !< dim = ndx, sum of ..; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
+   integer, allocatable, dimension(:) :: laydefnr !< dim = (ndx), pointer to laydef, if positive to unique laydef, otherwise interpolate in 1,2, and 3
+   integer, allocatable, dimension(:) :: laytyp !< dim = (mxlaydefs), 1 = sigma, 2 = z
+   integer, allocatable, dimension(:) :: laymx !< dim = (mxlaydefs), max nr of layers
+   integer, allocatable, dimension(:) :: nrlayn !< dim = (ndx), max nr of layers
+   integer, allocatable, dimension(:) :: nlaybn !< dim = (ndx), bed lay nr
+   real(kind=dp), allocatable, dimension(:, :) :: zslay !< dim = (: , maxlaydefs) z or s coordinate,
+   real(kind=dp), allocatable, dimension(:, :) :: wflaynod !< dim = (3 , ndx) weight factors to flownodes indlaynod
+   integer, allocatable, dimension(:, :) :: indlaynod !< dim = (3 , ndx)
+   real(kind=dp), allocatable, dimension(:) :: dkx !< dim = ndx, sigma level of interface height; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
+   real(kind=dp), allocatable, dimension(:) :: sdkx !< dim = ndx, sum of ..; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
 
-   real(kind=dp), allocatable :: asig(:) !< alfa of sigma at nodes, 1d0=full sigma, 0d0=full z, 0.5d0=fifty/fifty; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
-   real(kind=dp), allocatable :: ustb(:) !< ustar at Lbot, dim=Lnx,
-   real(kind=dp), allocatable :: ustw(:) !< ustar at Ltop, dim=Lnx
-   real(kind=dp), allocatable :: ustbc(:) !< ustar at bed at netnodes, dim=numk
+   real(kind=dp), allocatable, dimension(:) :: asig !< alfa of sigma at nodes, 1d0=full sigma, 0d0=full z, 0.5d0=fifty/fifty; only used in density controlled sigma-layers (layertype == LAYTP_DENS_SIGMA)
+   real(kind=dp), allocatable, dimension(:) :: ustb !< ustar at Lbot, dim=Lnx,
+   real(kind=dp), allocatable, dimension(:) :: ustw !< ustar at Ltop, dim=Lnx
+   real(kind=dp), allocatable, dimension(:) :: ustbc !< ustar at bed at netnodes, dim=numk
 
    integer :: nfixed, nsigma
 
    ! flow arrays
 
    ! node related, dim = ndx
-   real(kind=dp), allocatable, target :: s0(:) !< [m] waterlevel    (m ) at start of timestep {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable, target :: s1(:) !< [m] waterlevel    (m ) at end   of timestep {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable, target :: s1max(:) !< [m] maximum waterlevel (m ) at end   of timestep for Fourier output {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable :: s00(:) !< waterlevel    (m ) for checking iteration in nonlin
-   real(kind=dp), allocatable, target :: a0(:) !< [m2] storage area at start of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
-   real(kind=dp), allocatable, target :: a1(:) !< [m2] storage area at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
-   real(kind=dp), allocatable, target :: vol1(:) !< [m3] total volume at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
-   real(kind=dp), allocatable, target :: vol0(:) !< [m3] total volume at start of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
-   real(kind=dp), allocatable, target :: vol1_f(:) !< [m3] flow volume volume at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
-   real(kind=dp), allocatable :: sq(:) !< total  influx (m3/s) at water level point
-   real(kind=dp), allocatable :: sqa(:) !< total  out! flux (m3/s) at s point, u1 based, non-conservative for iadvec == 38
-   real(kind=dp), allocatable, target :: hs(:) !< [m] waterdepth at cell centre = s1 - bl  (m) {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable :: cfs(:) !< dimensionless friction coefficient sag/C in cell centre
-   real(kind=dp), allocatable :: volerror(:) !< volume error
+   real(kind=dp), allocatable, target, dimension(:) :: s0 !< [m] waterlevel    (m ) at start of timestep {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: s1 !< [m] waterlevel    (m ) at end   of timestep {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: s1max !< [m] maximum waterlevel (m ) at end   of timestep for Fourier output {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, dimension(:) :: s00 !< waterlevel    (m ) for checking iteration in nonlin
+   real(kind=dp), allocatable, target, dimension(:) :: a0 !< [m2] storage area at start of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
+   real(kind=dp), allocatable, target, dimension(:) :: a1 !< [m2] storage area at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
+   real(kind=dp), allocatable, target, dimension(:) :: vol1 !< [m3] total volume at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
+   real(kind=dp), allocatable, target, dimension(:) :: vol0 !< [m3] total volume at start of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
+   real(kind=dp), allocatable, target, dimension(:) :: vol1_f !< [m3] flow volume volume at end of timestep {"location": "face", "shape": ["ndkx"]}; in 2D models ndkx=ndx
+   real(kind=dp), allocatable, dimension(:) :: sq !< total  influx (m3/s) at water level point
+   real(kind=dp), allocatable, dimension(:) :: sqa !< total  out! flux (m3/s) at s point, u1 based, non-conservative for iadvec == 38
+   real(kind=dp), allocatable, target, dimension(:) :: hs !< [m] waterdepth at cell centre = s1 - bl  (m) {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, dimension(:) :: cfs !< dimensionless friction coefficient sag/C in cell centre
+   real(kind=dp), allocatable, dimension(:) :: volerror !< volume error
 
-   real(kind=dp), allocatable :: voldhu(:) !< node volume based on downwind hu
+   real(kind=dp), allocatable, dimension(:) :: voldhu !< node volume based on downwind hu
 
-   real(kind=dp), allocatable :: s1m(:) !< waterlevel   pressurized nonlin minus part
-   real(kind=dp), allocatable :: a1m(:) !< surface area pressurized nonlin minus part
+   real(kind=dp), allocatable, dimension(:) :: s1m !< waterlevel   pressurized nonlin minus part
+   real(kind=dp), allocatable, dimension(:) :: a1m !< surface area pressurized nonlin minus part
 
-   real(kind=dp), allocatable :: negativeDepths(:) !< Number of negative depths during output interval at nodes.
-   real(kind=dp), allocatable :: negativeDepths_cum(:) !< Cumulative number of negative depths at nodes.
-   real(kind=dp), allocatable :: noIterations(:) !< Number of no iteration locations during output interval at nodes.
-   real(kind=dp), allocatable :: noIterations_cum(:) !< Cumulative number of no iteration locations at nodes.
-   real(kind=dp), allocatable :: limitingTimestepEstimation(:) !< Number of times during the output interval the conditions in a node is limiting the time step
-   real(kind=dp), allocatable :: limitingTimestepEstimation_cum(:) !< Cumulative number of times the conditions in a node is limiting the time step.
+   real(kind=dp), allocatable, dimension(:) :: negativeDepths !< Number of negative depths during output interval at nodes.
+   real(kind=dp), allocatable, dimension(:) :: negativeDepths_cum !< Cumulative number of negative depths at nodes.
+   real(kind=dp), allocatable, dimension(:) :: noIterations !< Number of no iteration locations during output interval at nodes.
+   real(kind=dp), allocatable, dimension(:) :: noIterations_cum !< Cumulative number of no iteration locations at nodes.
+   real(kind=dp), allocatable, dimension(:) :: limitingTimestepEstimation !< Number of times during the output interval the conditions in a node is limiting the time step
+   real(kind=dp), allocatable, dimension(:) :: limitingTimestepEstimation_cum !< Cumulative number of times the conditions in a node is limiting the time step.
    !< Note: this doubles with variable numlimdt(:), which contains the same cumulative count, under a different MDU option.
    !< Note: these variables are real(kind=dp) (in stead of integers) because post processing is
    !<       based on real(kind=dp) variables.
-   real(kind=dp), allocatable :: flowCourantNumber(:) !< Courant number
+   real(kind=dp), allocatable, dimension(:) :: flowCourantNumber !< Courant number
 
-   real(kind=dp), allocatable :: volau(:) !< trial, au based cell volume (m3)
-   real(kind=dp), allocatable, target :: ucx(:) !< [m/s] cell center velocity, global x-dir (m/s) {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: ucy(:) !< [m/s] cell center velocity, global y-dir (m/s) {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: ucz(:) !< [m/s] cell center velocity, global z-dir (m/s) {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: ucxq(:) !< cell center velocity, q based  global x-dir (m/s)
-   real(kind=dp), allocatable, target :: ucyq(:) !< cell center velocity, q based  global y-dir (m/s)
-   real(kind=dp), allocatable :: uqcx(:) !< cell center incoming momentum, global x-dir (m4/s2), only for iadvec = 1
-   real(kind=dp), allocatable :: uqcy(:) !< cell center incoming momentum, global y-dir (m4/s2), only for iadvec = 1
-   real(kind=dp), allocatable, target :: ucmag(:) !< [m/s] cell center velocity magnitude {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable :: uc1D(:) !< [m/s] 1D cell center velocities
-   real(kind=dp), allocatable :: alpha_mom_1D(:) !< [-] ratio of incoming momentum versus initial estimate of outgoing momentum
-   real(kind=dp), allocatable :: alpha_ene_1D(:) !< [-] ratio of incoming energy versus initial estimate of outgoing energy
-   real(kind=dp), allocatable :: cfli(:) !< sum of incoming courants (    ) = sum( Dt*Qj/Vi)
-   real(kind=dp), allocatable :: dvxc(:) !< cell center stress term, global x-dir (m3/s2)
-   real(kind=dp), allocatable :: dvyc(:) !< cell center stress term, global y-dir (m3/s2)
-   real(kind=dp), allocatable :: squ(:) !< cell center outgoing flux (m3/s)
-   real(kind=dp), allocatable :: sqi(:) !< cell center incoming flux (m3/s)
-   real(kind=dp), allocatable :: squ2D(:) !< cell center outgoing 2D flux (m3/s)
-   real(kind=dp), allocatable :: sqwave(:) !< cell center outgoing flux, including gravity wave velocity (m3/s) (for explicit time-step)
-   real(kind=dp), allocatable :: squcor(:) !< cell center outgoing flux with some corrections to exclude structure links (if enabled)
-   real(kind=dp), allocatable :: hus(:) !< hu averaged at 3D cell
-   real(kind=dp), allocatable :: workx(:) !< Work array
-   real(kind=dp), allocatable :: worky(:) !< Work array
-   real(kind=dp), allocatable :: work0(:, :) !< Work array
-   real(kind=dp), allocatable :: work1(:, :) !< Work array
-   real(kind=dp), allocatable, target :: ucx_mor(:) !< [m/s] cell center velocity for sedmor, global x-dir (m/s) {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: ucy_mor(:) !< [m/s] cell center velocity for sedmor, global y-dir (m/s) {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, dimension(:) :: volau !< trial, au based cell volume (m3)
+   real(kind=dp), allocatable, target, dimension(:) :: ucx !< [m/s] cell center velocity, global x-dir (m/s) {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: ucy !< [m/s] cell center velocity, global y-dir (m/s) {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: ucz !< [m/s] cell center velocity, global z-dir (m/s) {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: ucxq !< cell center velocity, q based  global x-dir (m/s)
+   real(kind=dp), allocatable, target, dimension(:) :: ucyq !< cell center velocity, q based  global y-dir (m/s)
+   real(kind=dp), allocatable, dimension(:) :: uqcx !< cell center incoming momentum, global x-dir (m4/s2), only for iadvec = 1
+   real(kind=dp), allocatable, dimension(:) :: uqcy !< cell center incoming momentum, global y-dir (m4/s2), only for iadvec = 1
+   real(kind=dp), allocatable, target, dimension(:) :: ucmag !< [m/s] cell center velocity magnitude {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, dimension(:) :: uc1D !< [m/s] 1D cell center velocities
+   real(kind=dp), allocatable, dimension(:) :: alpha_mom_1D !< [-] ratio of incoming momentum versus initial estimate of outgoing momentum
+   real(kind=dp), allocatable, dimension(:) :: alpha_ene_1D !< [-] ratio of incoming energy versus initial estimate of outgoing energy
+   real(kind=dp), allocatable, dimension(:) :: cfli !< sum of incoming courants (    ) = sum( Dt*Qj/Vi)
+   real(kind=dp), allocatable, dimension(:) :: dvxc !< cell center stress term, global x-dir (m3/s2)
+   real(kind=dp), allocatable, dimension(:) :: dvyc !< cell center stress term, global y-dir (m3/s2)
+   real(kind=dp), allocatable, dimension(:) :: squ !< cell center outgoing flux (m3/s)
+   real(kind=dp), allocatable, dimension(:) :: sqi !< cell center incoming flux (m3/s)
+   real(kind=dp), allocatable, dimension(:) :: squ2D !< cell center outgoing 2D flux (m3/s)
+   real(kind=dp), allocatable, dimension(:) :: sqwave !< cell center outgoing flux, including gravity wave velocity (m3/s) (for explicit time-step)
+   real(kind=dp), allocatable, dimension(:) :: squcor !< cell center outgoing flux with some corrections to exclude structure links (if enabled)
+   real(kind=dp), allocatable, dimension(:) :: hus !< hu averaged at 3D cell
+   real(kind=dp), allocatable, dimension(:) :: workx !< Work array
+   real(kind=dp), allocatable, dimension(:) :: worky !< Work array
+   real(kind=dp), allocatable, dimension(:, :) :: work0 !< Work array
+   real(kind=dp), allocatable, dimension(:, :) :: work1 !< Work array
+   real(kind=dp), allocatable, target, dimension(:) :: ucx_mor !< [m/s] cell center velocity for sedmor, global x-dir (m/s) {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: ucy_mor !< [m/s] cell center velocity for sedmor, global y-dir (m/s) {"location": "face", "shape": ["ndkx"]}
 
-   real(kind=dp), allocatable :: dsadx(:) !< cell center sa gradient, (ppt/m)
-   real(kind=dp), allocatable :: dsady(:) !< cell center sa gradient, (ppt/m)
+   real(kind=dp), allocatable, dimension(:) :: dsadx !< cell center sa gradient, (ppt/m)
+   real(kind=dp), allocatable, dimension(:) :: dsady !< cell center sa gradient, (ppt/m)
 
    ! node related, dim = ndxi
-   real(kind=dp), allocatable, target :: freeboard(:) !< [m] For output purposes: freeboard at cell center, only for 1D
-   real(kind=dp), allocatable, target :: hsOnGround(:) !< [m] For output purposes: waterdepth above ground level, only for 1D
-   real(kind=dp), allocatable, target :: volOnGround(:) !< [m3] For output purposes: volume above ground level, only for 1D
-   real(kind=dp), allocatable :: qCur1d2d(:) !< [m3/s] total 1d2d net inflow, current discharge
-   real(kind=dp), allocatable :: vTot1d2d(:) !< [m3] total 1d2d net inflow, cumulative volume
-   real(kind=dp), allocatable :: qCurLat(:) !< [m3/s] total lateral net inflow, current discharge
-   real(kind=dp), allocatable :: vTotLat(:) !< [m3] total lateral net inflow, cumulative volume
+   real(kind=dp), allocatable, target, dimension(:) :: freeboard !< [m] For output purposes: freeboard at cell center, only for 1D
+   real(kind=dp), allocatable, target, dimension(:) :: hsOnGround !< [m] For output purposes: waterdepth above ground level, only for 1D
+   real(kind=dp), allocatable, target, dimension(:) :: volOnGround !< [m3] For output purposes: volume above ground level, only for 1D
+   real(kind=dp), allocatable, dimension(:) :: qCur1d2d !< [m3/s] total 1d2d net inflow, current discharge
+   real(kind=dp), allocatable, dimension(:) :: vTot1d2d !< [m3] total 1d2d net inflow, cumulative volume
+   real(kind=dp), allocatable, dimension(:) :: qCurLat !< [m3/s] total lateral net inflow, current discharge
+   real(kind=dp), allocatable, dimension(:) :: vTotLat !< [m3] total lateral net inflow, cumulative volume
 
    ! link related, dim = lnx
-   real(kind=dp), allocatable :: s1Gradient(:) !< [1] For output purposes: water level gradient on flow links
+   real(kind=dp), allocatable, dimension(:) :: s1Gradient !< [1] For output purposes: water level gradient on flow links
 
    ! Secondary Flow
-   real(kind=dp), allocatable :: ducxdx(:) !< cell center gradient of x-velocity in x-dir,    (1/s)
-   real(kind=dp), allocatable :: ducxdy(:) !< cell center gradient of x-velocity in y-dir,    (1/s)
-   real(kind=dp), allocatable :: ducydx(:) !< cell center gradient of y-velocity in x-dir,    (1/s)
-   real(kind=dp), allocatable :: ducydy(:) !< cell center gradient of y-velocity in y-dir,    (1/s)
+   real(kind=dp), allocatable, dimension(:) :: ducxdx !< cell center gradient of x-velocity in x-dir,    (1/s)
+   real(kind=dp), allocatable, dimension(:) :: ducxdy !< cell center gradient of x-velocity in y-dir,    (1/s)
+   real(kind=dp), allocatable, dimension(:) :: ducydx !< cell center gradient of y-velocity in x-dir,    (1/s)
+   real(kind=dp), allocatable, dimension(:) :: ducydy !< cell center gradient of y-velocity in y-dir,    (1/s)
 ! real(kind=dp), allocatable, target     :: dsdx   (:)   !< cell center gradient of waterlevel in x-dir,    ( )
 ! real(kind=dp), allocatable, target     :: dsdy   (:)   !< cell center gradient of waterlevel in y-dir,    ( )
 ! real(kind=dp), allocatable, target     :: dvdx   (:)   !< cell center gradient of y-velocity in x-dir,    (1/s)
@@ -268,123 +268,123 @@ module m_flow ! flow arrays-999
    real(kind=dp), dimension(:), allocatable :: dsalL ! the flux of salinity    on flow linkes for anti-creep
    real(kind=dp), dimension(:), allocatable :: dtemL ! the flux of temperature on flow nodes  for anti-creep
 
-   real(kind=dp), allocatable, target :: sa0(:) !< [1e-3] salinity (ppt) at start of timestep {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: sa1(:) !< [1e-3] salinity (ppt) at end   of timestep {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: satop(:) !< [1e-3] salinity (ppt) help in initialise , deallocated {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable, target :: sabot(:) !< [1e-3] salinity (ppt) help in initialise , deallocated {"location": "face", "shape": ["ndx"]}
-   real(kind=dp), allocatable :: supq(:) !< summed upwind salinity fluxes (ppt*m3/s)
-   real(kind=dp), allocatable :: qsho(:) !< higher order part of upwind salinity    fluxes (ppt*m3/s) (dim=lnkx)
-   real(kind=dp), allocatable, target :: tem0(:) !< [degC] water temperature at end of timestep {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable, target :: tem1(:) !< [degC] water temperature at end of timestep {"location": "face", "shape": ["ndkx"]}
-   real(kind=dp), allocatable :: qtho(:) !< higher order part of upwind temperature fluxes (ppt*m3/s) (dim=lnkx)
+   real(kind=dp), allocatable, target, dimension(:) :: sa0 !< [1e-3] salinity (ppt) at start of timestep {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: sa1 !< [1e-3] salinity (ppt) at end   of timestep {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: satop !< [1e-3] salinity (ppt) help in initialise , deallocated {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: sabot !< [1e-3] salinity (ppt) help in initialise , deallocated {"location": "face", "shape": ["ndx"]}
+   real(kind=dp), allocatable, dimension(:) :: supq !< summed upwind salinity fluxes (ppt*m3/s)
+   real(kind=dp), allocatable, dimension(:) :: qsho !< higher order part of upwind salinity    fluxes (ppt*m3/s) (dim=lnkx)
+   real(kind=dp), allocatable, target, dimension(:) :: tem0 !< [degC] water temperature at end of timestep {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: tem1 !< [degC] water temperature at end of timestep {"location": "face", "shape": ["ndkx"]}
+   real(kind=dp), allocatable, dimension(:) :: qtho !< higher order part of upwind temperature fluxes (ppt*m3/s) (dim=lnkx)
 
-   real(kind=dp), allocatable :: sam0(:) !< salinity mass       (pptm3) at start of timestep  ! remove later
-   real(kind=dp), allocatable :: sam1(:) !< salinity mass       (pptm3) at end   of timestep  ! remove later
-   real(kind=dp), allocatable :: same(:) !< salinity mass error (pptm3) at end   of timestep  ! remove later
+   real(kind=dp), allocatable, dimension(:) :: sam0 !< salinity mass       (pptm3) at start of timestep  ! remove later
+   real(kind=dp), allocatable, dimension(:) :: sam1 !< salinity mass       (pptm3) at end   of timestep  ! remove later
+   real(kind=dp), allocatable, dimension(:) :: same !< salinity mass error (pptm3) at end   of timestep  ! remove later
 
-   real(kind=dp), allocatable :: ww1(:) !< vertical velocity (m/s) end of timestep
-   real(kind=dp), allocatable :: qw(:) !< vertical flux through interface (m3/s)
-   real(kind=dp), allocatable :: tidep(:, :) !< tidal potential (m2/s2)
-   real(kind=dp), allocatable :: tidef(:) !< tidal force (m/s2)
-   real(kind=dp), allocatable :: s1init(:) !< initial water level, for correction in SAL
+   real(kind=dp), allocatable, dimension(:) :: ww1 !< vertical velocity (m/s) end of timestep
+   real(kind=dp), allocatable, dimension(:) :: qw !< vertical flux through interface (m3/s)
+   real(kind=dp), allocatable, dimension(:, :) :: tidep !< tidal potential (m2/s2)
+   real(kind=dp), allocatable, dimension(:) :: tidef !< tidal force (m/s2)
+   real(kind=dp), allocatable, dimension(:) :: s1init !< initial water level, for correction in SAL
 
-   real(kind=dp), allocatable :: vih(:) !< horizontal eddy viscosity in cell center (m2/s)
-   real(kind=dp), allocatable :: qin(:) !< rain, evap, qlat and src netto inloop (m3/s)
+   real(kind=dp), allocatable, dimension(:) :: vih !< horizontal eddy viscosity in cell center (m2/s)
+   real(kind=dp), allocatable, dimension(:) :: qin !< rain, evap, qlat and src netto inloop (m3/s)
 
    real(kind=dp) :: errmas !< (cumulative) mass   error ()
 
 ! link related, dim = lnkx
-   real(kind=dp), allocatable, target :: u0(:) !< flow velocity (m/s)  at start of timestep
-   real(kind=dp), allocatable, target :: u1(:) !< [m/s]  flow velocity (m/s)  at   end of timestep {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable, target :: u_to_umain(:) !< [-]  Factor for translating general velocity to the flow velocity in the main channel at end of timestep (1d) {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable, target :: q1(:) !< [m3/s] discharge     (m3/s) at   end of timestep n, used as q0 in timestep n+1, statement q0 = q1 is out of code, saves 1 array {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable, target :: q1_main(:) !< [m3/s] discharge     (m3/s) in main channel at {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable :: qa(:) !< discharge (m3/s) used in advection, qa=au(n)*u1(n+1) instead of
-   real(kind=dp), allocatable :: map_fixed_weir_energy_loss(:) !< fixed weir energy loss at end of timestep {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable :: cflj(:) !< courant nr link j to downwind volume i (    ) = Dt*Qj/Vi
-   real(kind=dp), allocatable :: tetaj(:) !< 1-1/sum(upwind incoming courants)      (    )
-   real(kind=dp), allocatable, target :: au(:) !< [m2] flow area     (m2)   at u point {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable, target :: au_nostrucs(:) !< [m2] flow area     (m2)   at u point {"location": "edge", "shape": ["lnkx"]}
-   real(kind=dp), allocatable :: ucxu(:) !< upwind link ucx (m/s)
-   real(kind=dp), allocatable :: ucyu(:) !< upwind link ucy (m/s)
-   real(kind=dp), allocatable :: au1D(:, :) !< [m2] cross-sectional area at begin and end of 1D link (only relevant for Pure1D)
-   real(kind=dp), allocatable :: wu1D(:, :) !< [m] surface width at begin and end of 1D link (only relevant for Pure1D)
-   real(kind=dp), allocatable :: sar1D(:, :) !< [m2] surface area of first and second half of 1D link (only relevant for Pure1D)
-   real(kind=dp), allocatable :: volu1D(:) !< [m3] volume of 1D link (only relevant for Pure1D)
-   real(kind=dp), allocatable :: u1Du(:) !< [m/s] upwind 1D link velocity (only relevant for Pure1D)
-   real(kind=dp), allocatable :: q1D(:, :) !< [m3/s] discharge at begin and end of 1D link (only relevant for Pure1D)
-   integer, allocatable :: isnbnod(:, :) !< sign of left/right node follows your dir in jaPure1D assumptions, -1 or 1 for Ja1D nodes
-   integer, allocatable :: isnblin(:, :) !< sign of left/right link follows your dir in jaPure1D assumptions, -1 or 1 for Ja1D nodes
-   real(kind=dp), allocatable :: advi(:) !< advection implicit part (1/s)
-   real(kind=dp), allocatable :: adve(:) !< advection explicit part (m/s2)
-   real(kind=dp), allocatable :: adve0(:) !< advection explicit part (m/s2) prevstep
-   real(kind=dp), allocatable, target :: hu(:) !< [m] upwind waterheight at u-point; for 3D layers the distance from the top of layer to the bed (m) {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable :: huvli(:) !< inverse alfa weighted waterheight at u-point (m) (volume representative)
-   real(kind=dp), allocatable :: v(:) !< tangential velocity in u point (m/s)
-   real(kind=dp), allocatable :: suu(:) !< stress u dir (m/s2)
-   real(kind=dp), allocatable :: cfuhi(:) !< g/(hCC) u point (1/m)
-   real(kind=dp), allocatable, target :: frcu(:) !< [TODO] friction coefficient set by initial fields {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable :: frcu_mor(:) !< friction coefficient in morphologically active region set by initial fields {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable :: frcu_bkp(:) !< Backup of friction coefficient set by initial fields {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable :: cfclval(:) !< array for calibration factor for friction coefficients
-   real(kind=dp), allocatable :: cftrt(:, :) !< array for friction coefficients due to trachytopes
-   real(kind=dp), allocatable, target :: cftrtfac(:) !< array for optional multiplication factor for trachytopes's returned roughness values
+   real(kind=dp), allocatable, target, dimension(:) :: u0 !< flow velocity (m/s)  at start of timestep
+   real(kind=dp), allocatable, target, dimension(:) :: u1 !< [m/s]  flow velocity (m/s)  at   end of timestep {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: u_to_umain !< [-]  Factor for translating general velocity to the flow velocity in the main channel at end of timestep (1d) {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: q1 !< [m3/s] discharge     (m3/s) at   end of timestep n, used as q0 in timestep n+1, statement q0 = q1 is out of code, saves 1 array {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: q1_main !< [m3/s] discharge     (m3/s) in main channel at {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, dimension(:) :: qa !< discharge (m3/s) used in advection, qa=au(n)*u1(n+1) instead of
+   real(kind=dp), allocatable, dimension(:) :: map_fixed_weir_energy_loss !< fixed weir energy loss at end of timestep {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, dimension(:) :: cflj !< courant nr link j to downwind volume i (    ) = Dt*Qj/Vi
+   real(kind=dp), allocatable, dimension(:) :: tetaj !< 1-1/sum(upwind incoming courants)      (    )
+   real(kind=dp), allocatable, target, dimension(:) :: au !< [m2] flow area     (m2)   at u point {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: au_nostrucs !< [m2] flow area     (m2)   at u point {"location": "edge", "shape": ["lnkx"]}
+   real(kind=dp), allocatable, dimension(:) :: ucxu !< upwind link ucx (m/s)
+   real(kind=dp), allocatable, dimension(:) :: ucyu !< upwind link ucy (m/s)
+   real(kind=dp), allocatable, dimension(:, :) :: au1D !< [m2] cross-sectional area at begin and end of 1D link (only relevant for Pure1D)
+   real(kind=dp), allocatable, dimension(:, :) :: wu1D !< [m] surface width at begin and end of 1D link (only relevant for Pure1D)
+   real(kind=dp), allocatable, dimension(:, :) :: sar1D !< [m2] surface area of first and second half of 1D link (only relevant for Pure1D)
+   real(kind=dp), allocatable, dimension(:) :: volu1D !< [m3] volume of 1D link (only relevant for Pure1D)
+   real(kind=dp), allocatable, dimension(:) :: u1Du !< [m/s] upwind 1D link velocity (only relevant for Pure1D)
+   real(kind=dp), allocatable, dimension(:, :) :: q1D !< [m3/s] discharge at begin and end of 1D link (only relevant for Pure1D)
+   integer, allocatable, dimension(:, :) :: isnbnod !< sign of left/right node follows your dir in jaPure1D assumptions, -1 or 1 for Ja1D nodes
+   integer, allocatable, dimension(:, :) :: isnblin !< sign of left/right link follows your dir in jaPure1D assumptions, -1 or 1 for Ja1D nodes
+   real(kind=dp), allocatable, dimension(:) :: advi !< advection implicit part (1/s)
+   real(kind=dp), allocatable, dimension(:) :: adve !< advection explicit part (m/s2)
+   real(kind=dp), allocatable, dimension(:) :: adve0 !< advection explicit part (m/s2) prevstep
+   real(kind=dp), allocatable, target, dimension(:) :: hu !< [m] upwind waterheight at u-point; for 3D layers the distance from the top of layer to the bed (m) {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, dimension(:) :: huvli !< inverse alfa weighted waterheight at u-point (m) (volume representative)
+   real(kind=dp), allocatable, dimension(:) :: v !< tangential velocity in u point (m/s)
+   real(kind=dp), allocatable, dimension(:) :: suu !< stress u dir (m/s2)
+   real(kind=dp), allocatable, dimension(:) :: cfuhi !< g/(hCC) u point (1/m)
+   real(kind=dp), allocatable, target, dimension(:) :: frcu !< [TODO] friction coefficient set by initial fields {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, dimension(:) :: frcu_mor !< friction coefficient in morphologically active region set by initial fields {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, dimension(:) :: frcu_bkp !< Backup of friction coefficient set by initial fields {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, dimension(:) :: cfclval !< array for calibration factor for friction coefficients
+   real(kind=dp), allocatable, dimension(:, :) :: cftrt !< array for friction coefficients due to trachytopes
+   real(kind=dp), allocatable, target, dimension(:) :: cftrtfac !< array for optional multiplication factor for trachytopes's returned roughness values
    integer :: jacftrtfac !< Whether or not (1/0) a multiplication factor field was specified for trachytopes's Chezy roughness values.
-   real(kind=dp), allocatable :: czu(:) !< array for chezy friction at flow links {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable, target :: frculin(:) !< friction coefficient set by initial fields ( todo mag later ook single real worden)
-   integer, allocatable :: ifrcutp(:) !< friction coefficient type   initial fields ( todo mag later ook single real worden)
-   real(kind=dp), allocatable, target :: Cdwusp(:) !< Wind friction coefficient at u point set by initial fields ( todo mag later ook single real worden)
-   real(kind=dp), allocatable :: wind_speed_factor(:) !< wind speed multiplication factor
-   real(kind=dp), allocatable :: solar_radiation_factor(:) !< solar radiation multiplication factor
-   real(kind=dp), allocatable :: z0ucur(:) !< current related roughness, moved from waves, always needed
-   real(kind=dp), allocatable :: z0urou(:) !< current and wave related roughness
+   real(kind=dp), allocatable, dimension(:) :: czu !< array for chezy friction at flow links {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: frculin !< friction coefficient set by initial fields ( todo mag later ook single real worden)
+   integer, allocatable, dimension(:) :: ifrcutp !< friction coefficient type   initial fields ( todo mag later ook single real worden)
+   real(kind=dp), allocatable, target, dimension(:) :: Cdwusp !< Wind friction coefficient at u point set by initial fields ( todo mag later ook single real worden)
+   real(kind=dp), allocatable, dimension(:) :: wind_speed_factor !< wind speed multiplication factor
+   real(kind=dp), allocatable, dimension(:) :: solar_radiation_factor !< solar radiation multiplication factor
+   real(kind=dp), allocatable, dimension(:) :: z0ucur !< current related roughness, moved from waves, always needed
+   real(kind=dp), allocatable, dimension(:) :: z0urou !< current and wave related roughness
 
-   real(kind=dp), allocatable :: frcuroofs(:) !< temp
+   real(kind=dp), allocatable, dimension(:) :: frcuroofs !< temp
 
-   real(kind=dp), allocatable, target :: frcInternalTides2D(:) !< internal tides friction coefficient gamma, tau/rho = - gamma u.grad h grad h
+   real(kind=dp), allocatable, target, dimension(:) :: frcInternalTides2D !< internal tides friction coefficient gamma, tau/rho = - gamma u.grad h grad h
 
-   real(kind=dp), allocatable :: wavfu(:) !< wave force u point
-   real(kind=dp), allocatable :: wavfv(:) !< wave force u point
-   real(kind=dp), allocatable :: wdsu(:) !< windstress/rhow u point  (m2/s2)
-   real(kind=dp), allocatable, target :: wdsu_x(:) !< windstress u point  (N/m2) x-component
-   real(kind=dp), allocatable, target :: wdsu_y(:) !< windstress u point  (N/m2) y-component
-   real(kind=dp), allocatable, target :: w_star(:) !< [m/s] free convective velocity scale at cell centers
-   real(kind=dp), allocatable, target :: obukhov_length(:) !< [m] Obukhov length at cell centers
-   real(kind=dp), allocatable, target :: transfer_coeff_momentum(:) !< [-] bulk transfer coefficient for momentum flux at cell centers
-   real(kind=dp), allocatable, target :: transfer_coeff_sensible_heat(:) !< [-] bulk transfer coefficient for sensible heat flux at cell centers
-   real(kind=dp), allocatable, target :: transfer_coeff_latent_heat(:) !< [-] bulk transfer coefficient for latent heat flux at cell centers
-   real(kind=dp), allocatable :: wavmubnd(:) !< wave-induced mass flux (on open boundaries)
+   real(kind=dp), allocatable, dimension(:) :: wavfu !< wave force u point
+   real(kind=dp), allocatable, dimension(:) :: wavfv !< wave force u point
+   real(kind=dp), allocatable, dimension(:) :: wdsu !< windstress/rhow u point  (m2/s2)
+   real(kind=dp), allocatable, target, dimension(:) :: wdsu_x !< windstress u point  (N/m2) x-component
+   real(kind=dp), allocatable, target, dimension(:) :: wdsu_y !< windstress u point  (N/m2) y-component
+   real(kind=dp), allocatable, target, dimension(:) :: w_star !< [m/s] free convective velocity scale at cell centers
+   real(kind=dp), allocatable, target, dimension(:) :: obukhov_length !< [m] Obukhov length at cell centers
+   real(kind=dp), allocatable, target, dimension(:) :: transfer_coeff_momentum !< [-] bulk transfer coefficient for momentum flux at cell centers
+   real(kind=dp), allocatable, target, dimension(:) :: transfer_coeff_sensible_heat !< [-] bulk transfer coefficient for sensible heat flux at cell centers
+   real(kind=dp), allocatable, target, dimension(:) :: transfer_coeff_latent_heat !< [-] bulk transfer coefficient for latent heat flux at cell centers
+   real(kind=dp), allocatable, dimension(:) :: wavmubnd !< wave-induced mass flux (on open boundaries)
    integer :: number_steps_limited_visc_flux_links = 0 !< number of steps with limited viscosity/flux on links
    integer, parameter :: MAX_PRINTS_LIMITED_VISC_FLUX_LINKS = 10 !< number of messages in dia file on limited viscosity/flux links
-   real(kind=dp), allocatable :: vicLu(:) !< horizontal eddy viscosity coefficient at u point (m2/s)  (limited only if ja_timestep_auto_visc==0)
-   real(kind=dp), allocatable :: viu(:) !< horizontal eddy viscosity coefficient at u point (m2/s), modeled part of viscosity = vicLu - viusp
-   real(kind=dp), allocatable, target :: viusp(:) !< [m2/s] user defined spatial eddy viscosity coefficient at u point (m2/s) {"location": "edge", "shape": ["lnx"]}
-   real(kind=dp), allocatable, target :: diusp(:) !< [m2/s] user defined spatial eddy diffusivity coefficient at u point (m2/s) {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, dimension(:) :: vicLu !< horizontal eddy viscosity coefficient at u point (m2/s)  (limited only if ja_timestep_auto_visc==0)
+   real(kind=dp), allocatable, dimension(:) :: viu !< horizontal eddy viscosity coefficient at u point (m2/s), modeled part of viscosity = vicLu - viusp
+   real(kind=dp), allocatable, target, dimension(:) :: viusp !< [m2/s] user defined spatial eddy viscosity coefficient at u point (m2/s) {"location": "edge", "shape": ["lnx"]}
+   real(kind=dp), allocatable, target, dimension(:) :: diusp !< [m2/s] user defined spatial eddy diffusivity coefficient at u point (m2/s) {"location": "edge", "shape": ["lnx"]}
    !< so in transport, total diffusivity = viu*sigdifi + diusp
-   real(kind=dp), allocatable :: fcori(:) !< spatially variable fcorio coeff at u point (1/s)
-   real(kind=dp), allocatable :: fvcoro(:) !< 3D adamsbashford u point (m/s2)
+   real(kind=dp), allocatable, dimension(:) :: fcori !< spatially variable fcorio coeff at u point (1/s)
+   real(kind=dp), allocatable, dimension(:) :: fvcoro !< 3D adamsbashford u point (m/s2)
 
-   real(kind=dp), allocatable :: plotlin(:) !< for plotting on u points
-   integer, allocatable :: numlimdt(:) !< nr of times this point was the timestep limiting point
+   real(kind=dp), allocatable, dimension(:) :: plotlin !< for plotting on u points
+   integer, allocatable, dimension(:) :: numlimdt !< nr of times this point was the timestep limiting point
    integer :: numlimdt_baorg = 0 !< nr of times limiting > numlimdt_baorg, keep org ba
    real(kind=dp) :: baorgfracmin = 0 !< ba = max(cutarea, ba*baorgfracmin)
 
-   real(kind=dp), allocatable :: zn2rn(:) !< weight from zn to rn, flownode to netnode
+   real(kind=dp), allocatable, dimension(:) :: zn2rn !< weight from zn to rn, flownode to netnode
 
-   real(kind=dp), allocatable, target :: tausx(:) ! vector components shear stress
-   real(kind=dp), allocatable, target :: tausy(:)
-   real(kind=dp), allocatable, target :: taubxu(:) !< Maximal bed shear stress
-   real(kind=dp), allocatable, target :: taubu(:) !< Mean bed shear stress
-   real(kind=dp), allocatable :: q1waq(:) !< Cumulative q1 within current waq-timestep
-   real(kind=dp), allocatable :: qwwaq(:) !< Cumulative qw within current waq-timestep
+   real(kind=dp), allocatable, target, dimension(:) :: tausx ! vector components shear stress
+   real(kind=dp), allocatable, target, dimension(:) :: tausy
+   real(kind=dp), allocatable, target, dimension(:) :: taubxu !< Maximal bed shear stress
+   real(kind=dp), allocatable, target, dimension(:) :: taubu !< Mean bed shear stress
+   real(kind=dp), allocatable, dimension(:) :: q1waq !< Cumulative q1 within current waq-timestep
+   real(kind=dp), allocatable, dimension(:) :: qwwaq !< Cumulative qw within current waq-timestep
 
    ! solving related, dim = ndx for 2D, otherwise ndx*kmxd
-   real(kind=dp), allocatable :: fu(:) !< main diag (lnx)
-   real(kind=dp), allocatable :: ru(:) !< rhs       (lnx)
-   real(kind=dp), allocatable :: bb(:) !< main diag (ndx)
-   real(kind=dp), allocatable :: dd(:) !< rhs       (ndx)
+   real(kind=dp), allocatable, dimension(:) :: fu !< main diag (lnx)
+   real(kind=dp), allocatable, dimension(:) :: ru !< rhs       (lnx)
+   real(kind=dp), allocatable, dimension(:) :: bb !< main diag (ndx)
+   real(kind=dp), allocatable, dimension(:) :: dd !< rhs       (ndx)
 
-   integer, allocatable :: struclink(:)
+   integer, allocatable, dimension(:) :: struclink
 
    ! basis
    real(kind=dp) :: vol0tot !< Total volume start of timestep            (m3)
@@ -452,7 +452,7 @@ module m_flow ! flow arrays-999
    real(kind=dp), dimension(2) :: voutextcum !< Total outflow to  Qext (1D and 2D)        (m3) "
 
    real(kind=dp) :: DissInternalTides !< Total Internal Tides Dissipation (J/s)
-   real(kind=dp), allocatable :: DissInternalTidesPerArea(:) !< Internal tides dissipation / area (J/(m^2 s))
+   real(kind=dp), allocatable, dimension(:) :: DissInternalTidesPerArea !< Internal tides dissipation / area (J/(m^2 s))
    real(kind=dp) :: GravInput !< Total Gravitational Input (incl. SAL) (J/s)
    real(kind=dp) :: SALInput !< Total SAL Input (J/s)
    real(kind=dp) :: SALInput2 !< Total SAL Input (J/s), different formulation

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -477,6 +477,7 @@ module m_flowparameters
       integer :: bubblescreens = 1 !< Write bubble screen parameters to his file, 0: no, 1: yes
       integer :: tur = 1 !< Write k, eps and vicww to his file, 0: no, 1: yes
       integer :: wind = 1 !< Write wind velocities to his file, 0: no, 1: yes
+      integer :: windstress = 1 !< Write wind stress to his file, 0: no, 1: yes
       integer :: rain = 1 !< Write precipitation intensity (depth per time) to this file, 0: no, 1: yes
       integer :: infilt = 1 !< Write infiltration rate to this file, 0: no, 1: yes
       integer :: tem = 1 !< Write temperature to his file, 0: no, 1: yes

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -478,6 +478,7 @@ module m_flowparameters
       integer :: tur = 1 !< Write k, eps and vicww to his file, 0: no, 1: yes
       integer :: wind = 1 !< Write wind velocities to his file, 0: no, 1: yes
       integer :: windstress = 1 !< Write wind stress to his file, 0: no, 1: yes
+      integer :: bulk_exchange_coeff = 1 !< Write bulk exchange coefficients to his file, 0: no, 1: yes
       integer :: rain = 1 !< Write precipitation intensity (depth per time) to this file, 0: no, 1: yes
       integer :: infilt = 1 !< Write infiltration rate to this file, 0: no, 1: yes
       integer :: tem = 1 !< Write temperature to his file, 0: no, 1: yes

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_outputconfig.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_outputconfig.f90
@@ -244,6 +244,15 @@ module m_output_config
    integer, public :: IDX_HIS_WINDX_SFERIC
    integer, public :: IDX_HIS_WINDY
    integer, public :: IDX_HIS_WINDY_SFERIC
+   integer, public :: IDX_HIS_WINDSTRESSX
+   integer, public :: IDX_HIS_WINDSTRESSX_SFERIC
+   integer, public :: IDX_HIS_WINDSTRESSY
+   integer, public :: IDX_HIS_WINDSTRESSY_SFERIC
+   integer, public :: IDX_HIS_WSTAR
+   integer, public :: IDX_HIS_OBUKHOV_LENGTH
+   integer, public :: IDX_HIS_TRANSFER_COEFF_MOMENTUM
+   integer, public :: IDX_HIS_TRANSFER_COEFF_SENSIBLE_HEAT
+   integer, public :: IDX_HIS_TRANSFER_COEFF_LATENT_HEAT
    integer, public :: IDX_HIS_RAIN
    integer, public :: IDX_HIS_INFILTRATION_CAP
    integer, public :: IDX_HIS_INFILTRATION_INFILTRATION_ACTUAL

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1850,6 +1850,7 @@ contains
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_structure_longculvert', his_write_settings%long_culvert, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_turbulence', his_write_settings%tur, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_wind', his_write_settings%wind, success)
+      call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_windstress', his_write_settings%windstress, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_rain', his_write_settings%rain, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_infiltration', his_write_settings%infilt, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_airdensity', his_write_settings%airdensity, success)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1851,6 +1851,7 @@ contains
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_turbulence', his_write_settings%tur, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_wind', his_write_settings%wind, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_windstress', his_write_settings%windstress, success)
+      call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_bulk_exchange_coefficients', his_write_settings%bulk_exchange_coeff, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_rain', his_write_settings%rain, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_infiltration', his_write_settings%infilt, success)
       call read_output_parameter_toggle(md_ptr, 'output', 'Wrihis_airdensity', his_write_settings%airdensity, success)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -38,8 +38,9 @@ module m_atmospheric_stability
    public :: get_z0_momentum
    public :: get_z0_heat
    public :: get_z0_humidity
-   public :: get_monin_obukhov_length
+   public :: get_obukhov_length
    public :: get_richardson_number
+   public :: get_bulk_exchange_diagnostics
    
    real(kind=dp), parameter :: HEIGHT_WIND_VELOCITY = 10.0_dp ! sensor height for wind velocity [m]
    real(kind=dp), parameter :: HEIGHT_TEMPERATURE = 2.0_dp ! sensor height for temperature [m]
@@ -73,11 +74,14 @@ module m_atmospheric_stability
       real(kind=dp) :: t_star = 0.0_dp                 !< Temperature scale [K].
       real(kind=dp) :: q_star = 0.0_dp                 !< Humidity scale [kg/kg].
       real(kind=dp) :: w_star = 0.0_dp                 !< Free convective velocity scale [m/s].
-      real(kind=dp) :: monin_obukhov_length = 0.0_dp   !< Obukhov length [m].
+      real(kind=dp) :: obukhov_length = 0.0_dp         !< Obukhov length [m].
       real(kind=dp) :: richardson_number = 0.0_dp      !< Bulk Richardson number [-].
       real(kind=dp) :: z0_momentum = 0.0_dp            !< Momentum roughness [m].
       real(kind=dp) :: z0_heat = 0.0_dp                !< Heat roughness [m].
       real(kind=dp) :: z0_humidity = 0.0_dp            !< Humidity roughness [m].
+      real(kind=dp) :: C_D = 0.0_dp                    !< Bulk transfer coefficient of momentum flux [-]
+      real(kind=dp) :: C_H = 0.0_dp                    !< Bulk transfer coefficient of sensible heat flux [-]
+      real(kind=dp) :: C_E = 0.0_dp                    !< Bulk transfer coefficient of latent heat flux [-]
    end type t_scales
 
    !> Fluxes data type.
@@ -126,6 +130,7 @@ contains
       real(kind=dp) :: heat_profile_correction, humidity_profile_correction
       real(kind=dp) :: convective_velocity_scale
       real(kind=dp) :: inverse_obukhov_length
+      real(kind=dp) :: denom_d, denom_h, denom_e
       integer :: iteration
       integer, parameter :: MINIMUM_ITERATION = 5
       integer, parameter :: MAXIMUM_ITERATION = 50
@@ -245,11 +250,18 @@ contains
       result%t_star = t_star
       result%q_star = q_star
       result%w_star = convective_velocity_scale
-      result%monin_obukhov_length = obukhov_length
+      result%obukhov_length = obukhov_length
       result%richardson_number = richardson_number
       result%z0_momentum = z0_momentum
       result%z0_heat = z0_heat
       result%z0_humidity = z0_humidity
+      
+      denom_d = max(wind_velocity_magnitude, SMALL_NUMBER)
+      denom_h = max(abs(delta_temperature), SMALL_NUMBER)
+      denom_e = max(abs(delta_specific_humidity), SMALL_NUMBER)
+      result%C_D = (u_star / denom_d)**2
+      result%C_H = abs((u_star / denom_d)*(t_star / denom_h))
+      result%C_E = abs((u_star / denom_d)*(q_star / denom_e))
    end function compute_scaling_parameters
 
    !> Compute arrays of scaling parameters and bulk surface fluxes.
@@ -423,6 +435,78 @@ contains
       end do
    end subroutine get_q_star
 
+   !> Return w* array [m/s] from module-stored scaling parameters.
+   subroutine get_w_star(w_star)
+      real(kind=dp), allocatable, intent(out) :: w_star(:)
+      integer :: index
+      integer :: number_of_elements
+
+      if (.not. allocated(scaling_parameters)) then
+         error stop 'get_w_star: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+      end if
+
+      number_of_elements = size(scaling_parameters)
+      allocate(w_star(number_of_elements))
+
+      do index = 1, number_of_elements
+         w_star(index) = scaling_parameters(index)%w_star
+      end do
+   end subroutine get_w_star
+
+   !> Return bulk transfer coefficient of momentum flux [-] from module-stored scaling parameters.
+   subroutine get_transfer_coeff_momentum(C_D)
+      real(kind=dp), allocatable, intent(out) :: C_D(:)
+      integer :: index
+      integer :: number_of_elements
+
+      if (.not. allocated(scaling_parameters)) then
+         error stop 'get_transfer_coeff_momentum: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+      end if
+
+      number_of_elements = size(scaling_parameters)
+      allocate(C_D(number_of_elements))
+
+      do index = 1, number_of_elements
+         C_D(index) = scaling_parameters(index)%C_D
+      end do
+   end subroutine get_transfer_coeff_momentum
+
+   !> Return bulk transfer coefficient of sensible heat flux [-] from module-stored scaling parameters.
+   subroutine get_transfer_coeff_sensible_heat(C_H)
+      real(kind=dp), allocatable, intent(out) :: C_H(:)
+      integer :: index
+      integer :: number_of_elements
+
+      if (.not. allocated(scaling_parameters)) then
+         error stop 'get_transfer_coeff_sensible_heat: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+      end if
+
+      number_of_elements = size(scaling_parameters)
+      allocate(C_H(number_of_elements))
+
+      do index = 1, number_of_elements
+         C_H(index) = scaling_parameters(index)%C_H
+      end do
+   end subroutine get_transfer_coeff_sensible_heat
+
+   !> Return bulk transfer coefficient of latent heat flux [-] from module-stored scaling parameters.
+   subroutine get_transfer_coeff_latent_heat(C_E )
+      real(kind=dp), allocatable, intent(out) :: C_E(:)
+      integer :: index
+      integer :: number_of_elements
+
+      if (.not. allocated(scaling_parameters)) then
+         error stop 'get_transfer_coeff_latent_heat: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+      end if
+
+      number_of_elements = size(scaling_parameters)
+      allocate(C_E(number_of_elements))
+
+      do index = 1, number_of_elements
+         C_E(index) = scaling_parameters(index)%C_E
+      end do
+   end subroutine get_transfer_coeff_latent_heat
+
    !> Return momentum roughness length array [m] from module-stored scaling parameters.
    subroutine get_z0_momentum(z0_momentum)
       real(kind=dp), allocatable, intent(out) :: z0_momentum(:)
@@ -478,22 +562,22 @@ contains
    end subroutine get_z0_humidity
 
    !> Return Obukhov length array [m] from module-stored scaling parameters.
-   subroutine get_monin_obukhov_length(monin_obukhov_length)
-      real(kind=dp), allocatable, intent(out) :: monin_obukhov_length(:)
+   subroutine get_obukhov_length(obukhov_length)
+      real(kind=dp), allocatable, intent(out) :: obukhov_length(:)
       integer :: index
       integer :: number_of_elements
 
       if (.not. allocated(scaling_parameters)) then
-         error stop 'get_monin_obukhov_length: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+         error stop 'get_obukhov_length: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
       end if
 
       number_of_elements = size(scaling_parameters)
-      allocate(monin_obukhov_length(number_of_elements))
+      allocate(obukhov_length(number_of_elements))
 
       do index = 1, number_of_elements
-         monin_obukhov_length(index) = scaling_parameters(index)%monin_obukhov_length
+         obukhov_length(index) = scaling_parameters(index)%obukhov_length
       end do
-   end subroutine get_monin_obukhov_length
+   end subroutine get_obukhov_length
 
    !> Return bulk Richardson number array [-] from module-stored scaling parameters.
    subroutine get_richardson_number(richardson_number)
@@ -512,6 +596,36 @@ contains
          richardson_number(index) = scaling_parameters(index)%richardson_number
       end do
    end subroutine get_richardson_number
+
+   !> Return a batch of atmospheric-stability diagnostics from module-stored scaling parameters.
+   subroutine get_bulk_exchange_diagnostics(w_star, obukhov_length, C_D, C_H, C_E)
+      real(kind=dp), allocatable, intent(out) :: w_star(:)
+      real(kind=dp), allocatable, intent(out) :: obukhov_length(:)
+      real(kind=dp), allocatable, intent(out) :: C_D(:)
+      real(kind=dp), allocatable, intent(out) :: C_H(:)
+      real(kind=dp), allocatable, intent(out) :: C_E(:)
+      integer :: index
+      integer :: number_of_elements
+
+      if (.not. allocated(scaling_parameters)) then
+         error stop 'get_bulk_exchange_diagnostics: module scaling parameters are not available. Call compute_scales_and_fluxes first.'
+      end if
+
+      number_of_elements = size(scaling_parameters)
+      allocate(w_star(number_of_elements))
+      allocate(obukhov_length(number_of_elements))
+      allocate(C_D(number_of_elements))
+      allocate(C_H(number_of_elements))
+      allocate(C_E(number_of_elements))
+
+      do index = 1, number_of_elements
+         w_star(index) = scaling_parameters(index)%w_star
+         obukhov_length(index) = scaling_parameters(index)%obukhov_length
+         C_D(index) = scaling_parameters(index)%C_D
+         C_H(index) = scaling_parameters(index)%C_H
+         C_E(index) = scaling_parameters(index)%C_E
+      end do
+   end subroutine get_bulk_exchange_diagnostics
 
    !> Compute roughness lengths following an ECMWF-style parameterization.
    pure subroutine compute_roughness_lengths(u_star, charnock, z0_momentum, z0_heat, z0_humidity)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -6,9 +6,9 @@ module m_atmospheric_stability
 !! by updating roughness lengths and stability corrections (psi functions) until convergence. 
 !! From these, surface fluxes are derived via:
 !!
-!!   tau   = rho_air * u_star^2 = rho_air * C_D * |U| * U
-!!   Qh    = rho_air * Cp * u_star * t_star = rho_air * C_H * C_P * (T_air - T_surface) * U
-!!   Qe    = rho_air * Lv * u_star * q_star = rho_air * L_V * C_E * (q_air - q_surface) * U
+!!   tau   = rho_air * u_star^2 = rho_air * c_d * |U| * U
+!!   Qh    = rho_air * Cp * u_star * t_star = rho_air * c_h * C_P * (T_air - T_surface) * U
+!!   Qe    = rho_air * Lv * u_star * q_star = rho_air * L_V * c_e * (q_air - q_surface) * U
 !!
 !! Inputs required:
 !!   - Wind velocity components (u, v)
@@ -20,6 +20,7 @@ module m_atmospheric_stability
    use precision, only: dp
    use m_sferic, only: pi
    use m_physcoef, only: vonkarw
+   use m_flowparameters, only: EPS8
    
    implicit none(type, external)
    
@@ -41,6 +42,10 @@ module m_atmospheric_stability
    public :: get_obukhov_length
    public :: get_richardson_number
    public :: get_bulk_exchange_diagnostics
+   public :: get_w_star
+   public :: get_transfer_coeff_momentum
+   public :: get_transfer_coeff_sensible_heat
+   public :: get_transfer_coeff_latent_heat
    
    real(kind=dp), parameter :: HEIGHT_WIND_VELOCITY = 10.0_dp ! sensor height for wind velocity [m]
    real(kind=dp), parameter :: HEIGHT_TEMPERATURE = 2.0_dp ! sensor height for temperature [m]
@@ -58,7 +63,6 @@ module m_atmospheric_stability
    real(kind=dp), parameter :: CONST_E0 = 611.21_dp ! water vapour saturation pressure over water (Pa) at triple point temperature (Tt) [Pa]
    real(kind=dp), parameter :: CONST_TT = 273.16_dp ! triple point temperature [K]
    real(kind=dp), parameter :: OBUKHOV_LENGTH_LIMIT = 1.0e4_dp ! limit of Obukhov length to prevent numerical issues [m]
-   real(kind=dp), parameter :: SMALL_NUMBER = 1.0e-8_dp
    
    !> Optional switches controlling physical parameterizations.
    !! Enable terms only when they are needed for the target conditions.
@@ -79,9 +83,9 @@ module m_atmospheric_stability
       real(kind=dp) :: z0_momentum = 0.0_dp            !< Momentum roughness [m].
       real(kind=dp) :: z0_heat = 0.0_dp                !< Heat roughness [m].
       real(kind=dp) :: z0_humidity = 0.0_dp            !< Humidity roughness [m].
-      real(kind=dp) :: C_D = 0.0_dp                    !< Bulk transfer coefficient of momentum flux [-]
-      real(kind=dp) :: C_H = 0.0_dp                    !< Bulk transfer coefficient of sensible heat flux [-]
-      real(kind=dp) :: C_E = 0.0_dp                    !< Bulk transfer coefficient of latent heat flux [-]
+      real(kind=dp) :: c_d = 0.0_dp                    !< Bulk transfer coefficient of momentum flux [-]
+      real(kind=dp) :: c_h = 0.0_dp                    !< Bulk transfer coefficient of sensible heat flux [-]
+      real(kind=dp) :: c_e = 0.0_dp                    !< Bulk transfer coefficient of latent heat flux [-]
    end type t_scales
 
    !> Fluxes data type.
@@ -186,7 +190,7 @@ contains
                               salt_saturation_humidity_reduction_factor)
 
              log_denominator_momentum = log(HEIGHT_WIND_VELOCITY) - log(z0_momentum) - psi_momentum
-             log_denominator_momentum = sign(max(abs(log_denominator_momentum), SMALL_NUMBER), log_denominator_momentum)
+             log_denominator_momentum = sign(max(abs(log_denominator_momentum), EPS8), log_denominator_momentum)
              log_denominator_heat = log(HEIGHT_WIND_VELOCITY) - log(z0_heat) - psi_heat
 
              obukhov_length = (HEIGHT_WIND_VELOCITY / richardson_number) * log_denominator_heat / log_denominator_momentum**2
@@ -225,17 +229,17 @@ contains
             log_denominator_humidity = log(HEIGHT_HUMIDITY) - log(z0_humidity)
          end if
          
-         log_denominator_momentum = sign(max(abs(log_denominator_momentum), SMALL_NUMBER), log_denominator_momentum)
-         log_denominator_heat = sign(max(abs(log_denominator_heat), SMALL_NUMBER), log_denominator_heat)
-         log_denominator_humidity = sign(max(abs(log_denominator_humidity), SMALL_NUMBER), log_denominator_humidity)
+         log_denominator_momentum = sign(max(abs(log_denominator_momentum), EPS8), log_denominator_momentum)
+         log_denominator_heat = sign(max(abs(log_denominator_heat), EPS8), log_denominator_heat)
+         log_denominator_humidity = sign(max(abs(log_denominator_humidity), EPS8), log_denominator_humidity)
 
          result%u_star = vonkarw * delta_wind_speed / log_denominator_momentum
          result%t_star = vonkarw * delta_temperature / log_denominator_heat
          result%q_star = vonkarw * delta_specific_humidity / log_denominator_humidity
 
-         convergence_error = sqrt(((result%u_star - u_star)/max(abs(u_star), SMALL_NUMBER))**2 + &
-                             ((result%t_star - t_star)/max(abs(t_star), SMALL_NUMBER))**2 + &
-                             ((result%q_star - q_star)/max(abs(q_star), SMALL_NUMBER))**2)
+         convergence_error = sqrt(((result%u_star - u_star)/max(abs(u_star), EPS8))**2 + &
+                             ((result%t_star - t_star)/max(abs(t_star), EPS8))**2 + &
+                             ((result%q_star - q_star)/max(abs(q_star), EPS8))**2)
 
          u_star = result%u_star
          t_star = result%t_star
@@ -256,12 +260,12 @@ contains
       result%z0_heat = z0_heat
       result%z0_humidity = z0_humidity
       
-      denom_d = max(wind_velocity_magnitude, SMALL_NUMBER)
-      denom_h = max(abs(delta_temperature), SMALL_NUMBER)
-      denom_e = max(abs(delta_specific_humidity), SMALL_NUMBER)
-      result%C_D = (u_star / denom_d)**2
-      result%C_H = abs((u_star / denom_d)*(t_star / denom_h))
-      result%C_E = abs((u_star / denom_d)*(q_star / denom_e))
+      denom_d = max(wind_velocity_magnitude, EPS8)
+      denom_h = max(abs(delta_temperature), EPS8)
+      denom_e = max(abs(delta_specific_humidity), EPS8)
+      result%c_d = (u_star / denom_d)**2
+      result%c_h = abs((u_star / denom_d)*(t_star / denom_h))
+      result%c_e = abs((u_star / denom_d)*(q_star / denom_e))
    end function compute_scaling_parameters
 
    !> Compute arrays of scaling parameters and bulk surface fluxes.
@@ -326,8 +330,8 @@ contains
 
    !> Return wind-stress component arrays from module-stored fluxes.
    subroutine get_wind_stress(wind_stress_x, wind_stress_y)
-      real(kind=dp), allocatable, intent(out) :: wind_stress_x(:)
-      real(kind=dp), allocatable, intent(out) :: wind_stress_y(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: wind_stress_x !< Wind-stress x-component [N/m^2].
+      real(kind=dp), allocatable, dimension(:), intent(out) :: wind_stress_y !< Wind-stress y-component [N/m^2].
       integer :: index
       integer :: number_of_elements
 
@@ -347,7 +351,7 @@ contains
 
    !> Return latent heat flux array [W/m^2] from module-stored fluxes.
    subroutine get_latent_heat_flux(heat_flux)
-      real(kind=dp), allocatable, intent(out) :: heat_flux(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: heat_flux !< Latent heat flux [W/m^2].
       integer :: index
       integer :: number_of_elements
 
@@ -365,7 +369,7 @@ contains
 
    !> Return sensible heat flux array [W/m^2] from module-stored fluxes.
    subroutine get_sensible_heat_flux(heat_flux)
-      real(kind=dp), allocatable, intent(out) :: heat_flux(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: heat_flux !< Sensible heat flux [W/m^2].
       integer :: index
       integer :: number_of_elements
 
@@ -383,7 +387,7 @@ contains
 
    !> Return u* array [m/s] from module-stored scaling parameters.
    subroutine get_u_star(u_star)
-      real(kind=dp), allocatable, intent(out) :: u_star(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: u_star !< Friction velocity u* [m/s].
       integer :: index
       integer :: number_of_elements
 
@@ -401,7 +405,7 @@ contains
 
    !> Return t* array [K] from module-stored scaling parameters.
    subroutine get_t_star(t_star)
-      real(kind=dp), allocatable, intent(out) :: t_star(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: t_star !< Temperature scale t* [K].
       integer :: index
       integer :: number_of_elements
 
@@ -419,7 +423,7 @@ contains
 
    !> Return q* array [kg/kg] from module-stored scaling parameters.
    subroutine get_q_star(q_star)
-      real(kind=dp), allocatable, intent(out) :: q_star(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: q_star !< Humidity scale q* [kg/kg].
       integer :: index
       integer :: number_of_elements
 
@@ -437,7 +441,7 @@ contains
 
    !> Return w* array [m/s] from module-stored scaling parameters.
    subroutine get_w_star(w_star)
-      real(kind=dp), allocatable, intent(out) :: w_star(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: w_star !< Convective velocity scale w* [m/s].
       integer :: index
       integer :: number_of_elements
 
@@ -454,8 +458,8 @@ contains
    end subroutine get_w_star
 
    !> Return bulk transfer coefficient of momentum flux [-] from module-stored scaling parameters.
-   subroutine get_transfer_coeff_momentum(C_D)
-      real(kind=dp), allocatable, intent(out) :: C_D(:)
+   subroutine get_transfer_coeff_momentum(c_d)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_d !< Bulk momentum transfer coefficient [-].
       integer :: index
       integer :: number_of_elements
 
@@ -464,16 +468,16 @@ contains
       end if
 
       number_of_elements = size(scaling_parameters)
-      allocate(C_D(number_of_elements))
+      allocate(c_d(number_of_elements))
 
       do index = 1, number_of_elements
-         C_D(index) = scaling_parameters(index)%C_D
+         c_d(index) = scaling_parameters(index)%c_d
       end do
    end subroutine get_transfer_coeff_momentum
 
    !> Return bulk transfer coefficient of sensible heat flux [-] from module-stored scaling parameters.
-   subroutine get_transfer_coeff_sensible_heat(C_H)
-      real(kind=dp), allocatable, intent(out) :: C_H(:)
+   subroutine get_transfer_coeff_sensible_heat(c_h)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_h !< Bulk sensible-heat transfer coefficient [-].
       integer :: index
       integer :: number_of_elements
 
@@ -482,16 +486,16 @@ contains
       end if
 
       number_of_elements = size(scaling_parameters)
-      allocate(C_H(number_of_elements))
+      allocate(c_h(number_of_elements))
 
       do index = 1, number_of_elements
-         C_H(index) = scaling_parameters(index)%C_H
+         c_h(index) = scaling_parameters(index)%c_h
       end do
    end subroutine get_transfer_coeff_sensible_heat
 
    !> Return bulk transfer coefficient of latent heat flux [-] from module-stored scaling parameters.
-   subroutine get_transfer_coeff_latent_heat(C_E )
-      real(kind=dp), allocatable, intent(out) :: C_E(:)
+   subroutine get_transfer_coeff_latent_heat(c_e)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_e !< Bulk latent-heat transfer coefficient [-].
       integer :: index
       integer :: number_of_elements
 
@@ -500,16 +504,16 @@ contains
       end if
 
       number_of_elements = size(scaling_parameters)
-      allocate(C_E(number_of_elements))
+      allocate(c_e(number_of_elements))
 
       do index = 1, number_of_elements
-         C_E(index) = scaling_parameters(index)%C_E
+         c_e(index) = scaling_parameters(index)%c_e
       end do
    end subroutine get_transfer_coeff_latent_heat
 
    !> Return momentum roughness length array [m] from module-stored scaling parameters.
    subroutine get_z0_momentum(z0_momentum)
-      real(kind=dp), allocatable, intent(out) :: z0_momentum(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: z0_momentum !< Momentum roughness length [m].
       integer :: index
       integer :: number_of_elements
 
@@ -527,7 +531,7 @@ contains
 
    !> Return heat roughness length array [m] from module-stored scaling parameters.
    subroutine get_z0_heat(z0_heat)
-      real(kind=dp), allocatable, intent(out) :: z0_heat(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: z0_heat !< Heat roughness length [m].
       integer :: index
       integer :: number_of_elements
 
@@ -545,7 +549,7 @@ contains
 
    !> Return humidity roughness length array [m] from module-stored scaling parameters.
    subroutine get_z0_humidity(z0_humidity)
-      real(kind=dp), allocatable, intent(out) :: z0_humidity(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: z0_humidity !< Humidity roughness length [m].
       integer :: index
       integer :: number_of_elements
 
@@ -563,7 +567,7 @@ contains
 
    !> Return Obukhov length array [m] from module-stored scaling parameters.
    subroutine get_obukhov_length(obukhov_length)
-      real(kind=dp), allocatable, intent(out) :: obukhov_length(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: obukhov_length !< Obukhov length [m].
       integer :: index
       integer :: number_of_elements
 
@@ -581,7 +585,7 @@ contains
 
    !> Return bulk Richardson number array [-] from module-stored scaling parameters.
    subroutine get_richardson_number(richardson_number)
-      real(kind=dp), allocatable, intent(out) :: richardson_number(:)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: richardson_number !< Bulk Richardson number [-].
       integer :: index
       integer :: number_of_elements
 
@@ -598,12 +602,12 @@ contains
    end subroutine get_richardson_number
 
    !> Return a batch of atmospheric-stability diagnostics from module-stored scaling parameters.
-   subroutine get_bulk_exchange_diagnostics(w_star, obukhov_length, C_D, C_H, C_E)
-      real(kind=dp), allocatable, intent(out) :: w_star(:)
-      real(kind=dp), allocatable, intent(out) :: obukhov_length(:)
-      real(kind=dp), allocatable, intent(out) :: C_D(:)
-      real(kind=dp), allocatable, intent(out) :: C_H(:)
-      real(kind=dp), allocatable, intent(out) :: C_E(:)
+   subroutine get_bulk_exchange_diagnostics(w_star, obukhov_length, c_d, c_h, c_e)
+      real(kind=dp), allocatable, dimension(:), intent(out) :: w_star !< Convective velocity scale w* [m/s].
+      real(kind=dp), allocatable, dimension(:), intent(out) :: obukhov_length !< Obukhov length [m].
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_d !< Bulk momentum transfer coefficient [-].
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_h !< Bulk sensible-heat transfer coefficient [-].
+      real(kind=dp), allocatable, dimension(:), intent(out) :: c_e !< Bulk latent-heat transfer coefficient [-].
       integer :: index
       integer :: number_of_elements
 
@@ -614,16 +618,16 @@ contains
       number_of_elements = size(scaling_parameters)
       allocate(w_star(number_of_elements))
       allocate(obukhov_length(number_of_elements))
-      allocate(C_D(number_of_elements))
-      allocate(C_H(number_of_elements))
-      allocate(C_E(number_of_elements))
+      allocate(c_d(number_of_elements))
+      allocate(c_h(number_of_elements))
+      allocate(c_e(number_of_elements))
 
       do index = 1, number_of_elements
          w_star(index) = scaling_parameters(index)%w_star
          obukhov_length(index) = scaling_parameters(index)%obukhov_length
-         C_D(index) = scaling_parameters(index)%C_D
-         C_H(index) = scaling_parameters(index)%C_H
-         C_E(index) = scaling_parameters(index)%C_E
+         c_d(index) = scaling_parameters(index)%c_d
+         c_h(index) = scaling_parameters(index)%c_h
+         c_e(index) = scaling_parameters(index)%c_e
       end do
    end subroutine get_bulk_exchange_diagnostics
 
@@ -636,7 +640,7 @@ contains
       real(kind=dp), parameter :: ALPHA_Q = 0.62_dp ! roughness length coefficient for humidity
       real(kind=dp) :: inverse_u_star
 
-      inverse_u_star = 1.0_dp / sign(max(abs(u_star), SMALL_NUMBER), u_star)
+      inverse_u_star = 1.0_dp / sign(max(abs(u_star), EPS8), u_star)
       z0_momentum = ALPHA_M*CONST_NU_AIR*inverse_u_star + charnock*u_star*u_star/CONST_GRAVITY
       z0_heat = ALPHA_H*CONST_NU_AIR*inverse_u_star
       z0_humidity = ALPHA_Q*CONST_NU_AIR*inverse_u_star

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
@@ -46,7 +46,7 @@ contains
       use m_setcdwcoefficient, only: setcdwcoefficient
       use m_flowgeom, only: ln, lnx, snu, csu
       use m_flow, only: map_write_settings, rho_water_in_wind_stress, RHO_MEAN, wdsu, ktop, rho, wdsu_x, wdsu_y, rhomean, &
-                        viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw, ltop, u1, v, dmiss, &
+                        viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw, ltop, u1, v, &
                         w_star, obukhov_length, transfer_coeff_momentum, transfer_coeff_sensible_heat, transfer_coeff_latent_heat
       use m_wind, only: windxav, windyav, jawindstressgiven, jastresstowind, wx, wy, rhoair, cdb, relativewind, jaspacevarcharn, wcharnock, cdwcof, ja_airdensity, ja_computed_airdensity, air_density
       use m_fm_icecover, only: fm_ice_drag_effect, ice_modify_winddrag, ICE_WINDDRAG_NONE, ice_area_fraction
@@ -57,36 +57,15 @@ contains
       real(kind=dp) :: uwi, cdw, tuwi, roro, wxL, wyL, ust, ust2, tau, z0w, roa, row
       real(kind=dp) :: local_ice_area_fraction
       real(kind=dp), allocatable :: wind_stress_x_node(:), wind_stress_y_node(:)
-      real(kind=dp), allocatable :: w_star_node(:), obukhov_length_node(:), c_d_node(:), c_h_node(:), c_e_node(:)
       integer :: L, numwav, k
 
       windxav = 0.0_dp
       windyav = 0.0_dp
 
-      if (allocated(w_star)) then
-         w_star = dmiss
-         obukhov_length = dmiss
-         transfer_coeff_momentum = dmiss
-         transfer_coeff_sensible_heat = dmiss
-         transfer_coeff_latent_heat = dmiss
-      end if
-
       if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
          call get_wind_stress(wind_stress_x_node, wind_stress_y_node)
-         call get_bulk_exchange_diagnostics(w_star_node, obukhov_length_node, c_d_node, c_h_node, c_e_node)
-
-         if (allocated(w_star)) then
-            deallocate (w_star)
-            deallocate (obukhov_length)
-            deallocate (transfer_coeff_momentum)
-            deallocate (transfer_coeff_sensible_heat)
-            deallocate (transfer_coeff_latent_heat)
-         end if
-         call move_alloc(w_star_node, w_star)
-         call move_alloc(obukhov_length_node, obukhov_length)
-         call move_alloc(c_d_node, transfer_coeff_momentum)
-         call move_alloc(c_h_node, transfer_coeff_sensible_heat)
-         call move_alloc(c_e_node, transfer_coeff_latent_heat)
+         call get_bulk_exchange_diagnostics(w_star, obukhov_length, transfer_coeff_momentum, &
+                                            transfer_coeff_sensible_heat, transfer_coeff_latent_heat)
 
          call node_to_link_vector(wind_stress_x_node, wind_stress_y_node, wdsu_x, wdsu_y, lnx)
          do L = 1, lnx

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
@@ -46,121 +46,146 @@ contains
       use m_setcdwcoefficient, only: setcdwcoefficient
       use m_flowgeom, only: ln, lnx, snu, csu
       use m_flow, only: map_write_settings, rho_water_in_wind_stress, RHO_MEAN, wdsu, ktop, rho, wdsu_x, wdsu_y, rhomean, &
-               viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw, ltop, u1, v
+                        viskinair, ag, vonkarw, temperature_model, TEMPERATURE_MODEL_COMPOSITE, kmx, ustw, ltop, u1, v, dmiss, &
+                        w_star, obukhov_length, transfer_coeff_momentum, transfer_coeff_sensible_heat, transfer_coeff_latent_heat
       use m_wind, only: windxav, windyav, jawindstressgiven, jastresstowind, wx, wy, rhoair, cdb, relativewind, jaspacevarcharn, wcharnock, cdwcof, ja_airdensity, ja_computed_airdensity, air_density
       use m_fm_icecover, only: fm_ice_drag_effect, ice_modify_winddrag, ICE_WINDDRAG_NONE, ice_area_fraction
       use m_flowparameters, only: air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
-      use m_atmospheric_stability, only: get_wind_stress
+      use m_atmospheric_stability, only: get_wind_stress, get_bulk_exchange_diagnostics
       use m_flowgeom_interpolate, only: node_to_link_vector
 
       real(kind=dp) :: uwi, cdw, tuwi, roro, wxL, wyL, ust, ust2, tau, z0w, roa, row
       real(kind=dp) :: local_ice_area_fraction
       real(kind=dp), allocatable :: wind_stress_x_node(:), wind_stress_y_node(:)
+      real(kind=dp), allocatable :: w_star_node(:), obukhov_length_node(:), c_d_node(:), c_h_node(:), c_e_node(:)
       integer :: L, numwav, k
 
       windxav = 0.0_dp
       windyav = 0.0_dp
 
+      if (allocated(w_star)) then
+         w_star = dmiss
+         obukhov_length = dmiss
+         transfer_coeff_momentum = dmiss
+         transfer_coeff_sensible_heat = dmiss
+         transfer_coeff_latent_heat = dmiss
+      end if
+
       if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
-          call get_wind_stress(wind_stress_x_node, wind_stress_y_node)
-          call node_to_link_vector(wind_stress_x_node, wind_stress_y_node, wdsu_x, wdsu_y, lnx)
-            do L = 1, lnx
-                if (rho_water_in_wind_stress /= RHO_MEAN) then
-                    k = ln(2, L)
-                    wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rho(ktop(k))
-                else
-                    wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rhomean
-                end if
-            end do
+         call get_wind_stress(wind_stress_x_node, wind_stress_y_node)
+         call get_bulk_exchange_diagnostics(w_star_node, obukhov_length_node, c_d_node, c_h_node, c_e_node)
+
+         if (allocated(w_star)) then
+            deallocate (w_star)
+            deallocate (obukhov_length)
+            deallocate (transfer_coeff_momentum)
+            deallocate (transfer_coeff_sensible_heat)
+            deallocate (transfer_coeff_latent_heat)
+         end if
+         call move_alloc(w_star_node, w_star)
+         call move_alloc(obukhov_length_node, obukhov_length)
+         call move_alloc(c_d_node, transfer_coeff_momentum)
+         call move_alloc(c_h_node, transfer_coeff_sensible_heat)
+         call move_alloc(c_e_node, transfer_coeff_latent_heat)
+
+         call node_to_link_vector(wind_stress_x_node, wind_stress_y_node, wdsu_x, wdsu_y, lnx)
+         do L = 1, lnx
+            if (rho_water_in_wind_stress /= RHO_MEAN) then
+               k = ln(2, L)
+               wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rho(ktop(k))
+            else
+               wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rhomean
+            end if
+         end do
 
       else
-          if (jawindstressgiven > 0) then
+         if (jawindstressgiven > 0) then
 
-             if (jastresstowind == 0) then ! stress directly
-                if (map_write_settings%wind > 0) then
-                   wx = 0.0_dp
-                   wy = 0.0_dp
-                end if
-                do L = 1, lnx
-                   if (rho_water_in_wind_stress /= RHO_MEAN) then
-                      k = ln(2, L)
-                      wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rho(ktop(k))
-                   else
-                      wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rhomean
-                   end if
-                end do
-             else ! first reconstruct wx, wy
+            if (jastresstowind == 0) then ! stress directly
+               if (map_write_settings%wind > 0) then
+                  wx = 0.0_dp
+                  wy = 0.0_dp
+               end if
+               do L = 1, lnx
+                  if (rho_water_in_wind_stress /= RHO_MEAN) then
+                     k = ln(2, L)
+                     wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rho(ktop(k))
+                  else
+                     wdsu(L) = (wdsu_x(L) * csu(L) + wdsu_y(L) * snu(L)) / rhomean
+                  end if
+               end do
+            else ! first reconstruct wx, wy
 
-                do L = 1, lnx
-                   tau = sqrt(wdsu_x(L) * wdsu_x(L) + wdsu_y(L) * wdsu_y(L))
-                   if (tau > 0) then
-                      ust2 = tau / rhoair
-                      ust = sqrt(ust2)
-                      z0w = cdb(2) * viskinair / ust + cdb(1) * ust2 / ag
-                      uwi = log(10.0_dp / (z0w)) * ust / vonkarw
-                      wx(L) = uwi * wdsu_x(L) / tau
-                      wy(L) = uwi * wdsu_y(L) / tau
-                   else
-                      wx(L) = 0.0_dp
-                      wy(L) = 0.0_dp
-                   end if
-                end do
+               do L = 1, lnx
+                  tau = sqrt(wdsu_x(L) * wdsu_x(L) + wdsu_y(L) * wdsu_y(L))
+                  if (tau > 0) then
+                     ust2 = tau / rhoair
+                     ust = sqrt(ust2)
+                     z0w = cdb(2) * viskinair / ust + cdb(1) * ust2 / ag
+                     uwi = log(10.0_dp / (z0w)) * ust / vonkarw
+                     wx(L) = uwi * wdsu_x(L) / tau
+                     wy(L) = uwi * wdsu_y(L) / tau
+                  else
+                     wx(L) = 0.0_dp
+                     wy(L) = 0.0_dp
+                  end if
+               end do
 
-             end if
+            end if
 
-          end if
+         end if
 
-          if (jawindstressgiven == 0 .or. jastresstowind == 1) then
-             roa = rhoair
-             row = rhomean
-             wdsu = 0.0_dp
-             numwav = 0
-             do L = 1, lnx
-                if (wx(L) /= 0.0_dp .or. wy(L) /= 0.0_dp .or. relativewind > 0) then ! only if some wind
+         if (jawindstressgiven == 0 .or. jastresstowind == 1) then
+            roa = rhoair
+            row = rhomean
+            wdsu = 0.0_dp
+            wdsu_x = 0.0_dp
+            wdsu_y = 0.0_dp
+            numwav = 0
+            do L = 1, lnx
+               if (wx(L) /= 0.0_dp .or. wy(L) /= 0.0_dp .or. relativewind > 0) then ! only if some wind
 
-                   wxL = wx(L)
-                   wyL = wy(L)
-                   call compute_wind_relative_to_surface_on_link(wxL, wyL, relativewind, u1(ltop(L)), v(ltop(L)), csu(L), snu(L), wxL, wyL, uwi)
-                   if (jaspacevarcharn == 1) then
-                      cdb(1) = wcharnock(L)
-                   end if
-                   call setcdwcoefficient(uwi, cdw, L)
-                   if (ice_modify_winddrag /= ICE_WINDDRAG_NONE) then
-                      local_ice_area_fraction = 0.5_dp * (ice_area_fraction(ln(1, L)) + ice_area_fraction(ln(2, L)))
-                      cdw = fm_ice_drag_effect(local_ice_area_fraction, cdw)
-                   end if
-                   if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-                      cdwcof(L) = cdw
-                   end if
-                   if (rho_water_in_wind_stress /= RHO_MEAN) then
-                      k = ln(2, L)
-                      row = rho(ktop(k))
-                   end if
-                   if (ja_airdensity + ja_computed_airdensity > 0) then
-                      k = ln(2, L)
-                      roa = air_density(k)
-                   end if
-                   tuwi = roa * cdw * uwi
-                   if (map_write_settings%windstress > 0) then
-                      wdsu_x(L) = tuwi * wxL
-                      wdsu_y(L) = tuwi * wyL
-                   end if
-                   if (kmx > 0) then
-                      roro = roa / row
-                      ustw(L) = sqrt(roro * cdw) * uwi
-                   end if
-                   wdsu(L) = tuwi * (wxL * csu(L) + wyL * snu(L)) / row
-                   windxav = windxav + wxL
-                   windyav = windyav + wyL
-                   numwav = numwav + 1
+                  wxL = wx(L)
+                  wyL = wy(L)
+                  call compute_wind_relative_to_surface_on_link(wxL, wyL, relativewind, u1(ltop(L)), v(ltop(L)), csu(L), snu(L), wxL, wyL, uwi)
+                  if (jaspacevarcharn == 1) then
+                     cdb(1) = wcharnock(L)
+                  end if
+                  call setcdwcoefficient(uwi, cdw, L)
+                  if (ice_modify_winddrag /= ICE_WINDDRAG_NONE) then
+                     local_ice_area_fraction = 0.5_dp * (ice_area_fraction(ln(1, L)) + ice_area_fraction(ln(2, L)))
+                     cdw = fm_ice_drag_effect(local_ice_area_fraction, cdw)
+                  end if
+                  if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
+                     cdwcof(L) = cdw
+                  end if
+                  if (rho_water_in_wind_stress /= RHO_MEAN) then
+                     k = ln(2, L)
+                     row = rho(ktop(k))
+                  end if
+                  if (ja_airdensity + ja_computed_airdensity > 0) then
+                     k = ln(2, L)
+                     roa = air_density(k)
+                  end if
+                  tuwi = roa * cdw * uwi
+                  wdsu_x(L) = tuwi * wxL
+                  wdsu_y(L) = tuwi * wyL
+                  if (kmx > 0) then
+                     roro = roa / row
+                     ustw(L) = sqrt(roro * cdw) * uwi
+                  end if
+                  wdsu(L) = tuwi * (wxL * csu(L) + wyL * snu(L)) / row
+                  windxav = windxav + wxL
+                  windyav = windyav + wyL
+                  numwav = numwav + 1
 
-                end if
-             end do
-             if (numwav > 0) then
-                windxav = windxav / numwav
-                windyav = windyav / numwav
-             end if
-          end if
+               end if
+            end do
+            if (numwav > 0) then
+               windxav = windxav / numwav
+               windyav = windyav / numwav
+            end if
+         end if
       end if
    end subroutine setwindstress
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
@@ -437,7 +437,7 @@ contains
                   end if
                end do
 
-               if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+               if (his_write_settings%bulk_exchange_coeff > 0 .and. air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
                   valobs(i, IPNT_wstar) = dmiss
                   valobs(i, IPNT_obukhov_length) = dmiss
                   valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = dmiss

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
@@ -51,13 +51,16 @@ contains
                         potential_density, apply_thermobaricity, in_situ_density, squ, sqi, iturbulencemodel, vicwws, difwws, &
                         drhodz, brunt_vaisala_coefficient, idensform, jarichardsononoutput, richs, hu, vicwwu, turkin1, tureps1, &
                         rich, infiltrationmodel, dfm_hyd_infilt_const, dfm_hyd_infilt_horton, &
-                        infiltcap, infilt, qsunmap, qevamap, qconmap, qlongmap, qfrevamap, qfrconmap, qtotmap, &
-                        use_density
+                        infiltcap, infilt, qsunmap, qevamap, qconmap, qlongmap, qfrevamap, qfrconmap, qtotmap, wdsu_x, wdsu_y, &
+                        use_density, w_star, obukhov_length, transfer_coeff_momentum, transfer_coeff_sensible_heat, transfer_coeff_latent_heat
+      use m_flowparameters, only: air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
       use m_flowtimes, only: handle_extra
       use m_transport, only: constituents, isalt, itemp, itra1, ised1
       use m_flowgeom, only: ndx, lnx, bl, nd, ln, wcl, bob, ba
       use m_observations_data, only: valobs, numobs, nummovobs, kobs, lobs, ipnt_s1, ipnt_hs, ipnt_bl, ipnt_cmx, cmxobs, &
-                                     ipnt_wx, ipnt_wy, ipnt_patm, ipnt_waver, ipnt_waveh, ipnt_wavet, ipnt_waved, ipnt_wavel, ipnt_waveu, ipnt_taux, &
+                                     ipnt_wx, ipnt_wy, ipnt_windstressx, ipnt_windstressy, ipnt_wstar, ipnt_obukhov_length, &
+                                     ipnt_transfer_coeff_momentum, ipnt_transfer_coeff_sensible_heat, ipnt_transfer_coeff_latent_heat, &
+                                     ipnt_patm, ipnt_waver, ipnt_waveh, ipnt_wavet, ipnt_waved, ipnt_wavel, ipnt_waveu, ipnt_taux, &
                                      ipnt_tauy, ival_sbcx1, ival_sbcxn, ipnt_sbcx1, ival_sbcy1, ival_sbcyn, ipnt_sbcy1, ival_sscx1, ival_sscxn, &
                                      ipnt_sscx1, ival_sscy1, ival_sscyn, ipnt_sscy1, ival_sbwx1, ival_sbwxn, ipnt_sbwx1, ival_sbwy1, ival_sbwyn, &
                                      ipnt_sbwy1, ival_sswx1, ival_sswxn, ipnt_sswx1, ival_sswy1, ival_sswyn, ipnt_sswy1, ipnt_taub, ival_bodsed1, &
@@ -333,6 +336,10 @@ contains
             if (jawind > 0) then
                valobs(i, IPNT_wx) = 0.0_dp
                valobs(i, IPNT_wy) = 0.0_dp
+               if (his_write_settings%windstress > 0) then
+                  valobs(i, IPNT_windstressx) = 0.0_dp
+                  valobs(i, IPNT_windstressy) = 0.0_dp
+               end if
                do LL = 1, nd(k)%lnx
                   LLL = abs(nd(k)%ln(LL))
                   k1 = ln(1, LLL)
@@ -343,7 +350,27 @@ contains
                   end if
                   valobs(i, IPNT_wx) = valobs(i, IPNT_wx) + wx(LLL) * wcL(k3, LLL)
                   valobs(i, IPNT_wy) = valobs(i, IPNT_wy) + wy(LLL) * wcL(k3, LLL)
+                  if (his_write_settings%windstress > 0) then
+                     valobs(i, IPNT_windstressx) = valobs(i, IPNT_windstressx) + wdsu_x(LLL) * wcL(k3, LLL)
+                     valobs(i, IPNT_windstressy) = valobs(i, IPNT_windstressy) + wdsu_y(LLL) * wcL(k3, LLL)
+                  end if
                end do
+
+               if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+                  if (allocated(w_star)) then
+                     valobs(i, IPNT_wstar) = w_star(k)
+                     valobs(i, IPNT_obukhov_length) = obukhov_length(k)
+                     valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = transfer_coeff_momentum(k)
+                     valobs(i, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT) = transfer_coeff_sensible_heat(k)
+                     valobs(i, IPNT_TRANSFER_COEFF_LATENT_HEAT) = transfer_coeff_latent_heat(k)
+                  else
+                     valobs(i, IPNT_wstar) = dmiss
+                     valobs(i, IPNT_obukhov_length) = dmiss
+                     valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = dmiss
+                     valobs(i, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT) = dmiss
+                     valobs(i, IPNT_TRANSFER_COEFF_LATENT_HEAT) = dmiss
+                  end if
+               end if
             end if
             if (air_pressure_available .and. allocated(air_pressure)) then
                valobs(i, IPNT_PATM) = air_pressure(k)
@@ -642,29 +669,37 @@ contains
             end if
 
 !        Heatflux
-            if (temperature_model /= TEMPERATURE_MODEL_NONE .and. his_write_settings%heatflux > 0) then
-               call getlink1(k, LL)
-               if (jawind > 0) then
-                  valobs(i, IPNT_WIND) = sqrt(wx(LL) * wx(LL) + wy(LL) * wy(LL))
-               end if
-
-               if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then ! also heat modelling involved
-                  valobs(i, IPNT_TAIR) = air_temperature(k)
-                  valobs(i, IPNT_QTOT) = Qtotmap(k)
-               end if
-
-               if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-                  if (allocated(relative_humidity) .and. allocated(cloudiness)) then
-                     valobs(i, IPNT_RHUM) = relative_humidity(k)
-                     valobs(i, IPNT_CLOU) = cloudiness(k)
-                  end if
-
+            if (his_write_settings%heatflux > 0) then
+               if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
                   valobs(i, IPNT_QSUN) = Qsunmap(k)
                   valobs(i, IPNT_QEVA) = Qevamap(k)
                   valobs(i, IPNT_QCON) = Qconmap(k)
                   valobs(i, IPNT_QLON) = Qlongmap(k)
-                  valobs(i, IPNT_QFRE) = Qfrevamap(k)
-                  valobs(i, IPNT_QFRC) = Qfrconmap(k)
+                  valobs(i, IPNT_QTOT) = Qtotmap(k)                   
+               else if (temperature_model /= TEMPERATURE_MODEL_NONE) then
+                  call getlink1(k, LL)
+                  if (jawind > 0) then
+                     valobs(i, IPNT_WIND) = sqrt(wx(LL) * wx(LL) + wy(LL) * wy(LL))
+                  end if
+               
+                  if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then ! also heat modelling involved
+                     valobs(i, IPNT_TAIR) = air_temperature(k)
+                     valobs(i, IPNT_QTOT) = Qtotmap(k)
+                  end if
+               
+                  if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
+                     if (allocated(relative_humidity) .and. allocated(cloudiness)) then
+                        valobs(i, IPNT_RHUM) = relative_humidity(k)
+                        valobs(i, IPNT_CLOU) = cloudiness(k)
+                     end if
+               
+                     valobs(i, IPNT_QSUN) = Qsunmap(k)
+                     valobs(i, IPNT_QEVA) = Qevamap(k)
+                     valobs(i, IPNT_QCON) = Qconmap(k)
+                     valobs(i, IPNT_QLON) = Qlongmap(k)
+                     valobs(i, IPNT_QFRE) = Qfrevamap(k)
+                     valobs(i, IPNT_QFRC) = Qfrconmap(k)
+                  end if
                end if
             end if
          else

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fill_valobs.f90
@@ -438,18 +438,17 @@ contains
                end do
 
                if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+                  valobs(i, IPNT_wstar) = dmiss
+                  valobs(i, IPNT_obukhov_length) = dmiss
+                  valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = dmiss
+                  valobs(i, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT) = dmiss
+                  valobs(i, IPNT_TRANSFER_COEFF_LATENT_HEAT) = dmiss
                   if (allocated(w_star)) then
                      valobs(i, IPNT_wstar) = w_star(k)
                      valobs(i, IPNT_obukhov_length) = obukhov_length(k)
                      valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = transfer_coeff_momentum(k)
                      valobs(i, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT) = transfer_coeff_sensible_heat(k)
                      valobs(i, IPNT_TRANSFER_COEFF_LATENT_HEAT) = transfer_coeff_latent_heat(k)
-                  else
-                     valobs(i, IPNT_wstar) = dmiss
-                     valobs(i, IPNT_obukhov_length) = dmiss
-                     valobs(i, IPNT_TRANSFER_COEFF_MOMENTUM) = dmiss
-                     valobs(i, IPNT_TRANSFER_COEFF_SENSIBLE_HEAT) = dmiss
-                     valobs(i, IPNT_TRANSFER_COEFF_LATENT_HEAT) = dmiss
                   end if
                end if
             end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations.f90
@@ -235,7 +235,7 @@ contains
          IVAL_WINDSTRESSX = next_index(i)
          IVAL_WINDSTRESSY = next_index(i)
       end if
-      if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+      if (his_write_settings%bulk_exchange_coeff > 0 .and. air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
          IVAL_WSTAR = next_index(i)
          IVAL_OBUKHOV_LENGTH = next_index(i)
          IVAL_TRANSFER_COEFF_MOMENTUM = next_index(i)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations.f90
@@ -81,7 +81,7 @@ contains
 !! which is being reduced in parallel runs
    subroutine init_valobs_pointers()
       use m_flowparameters, only: jawave, his_write_settings, temperature_model, TEMPERATURE_MODEL_NONE, TEMPERATURE_MODEL_EXCESS, &
-                                  TEMPERATURE_MODEL_COMPOSITE, jased, jasal
+                                  TEMPERATURE_MODEL_COMPOSITE, jased, jasal, air_water_interaction_model, AIR_WATER_INTERACTION_MODEL_MOST
       use m_flow, only: iturbulencemodel, idensform, kmx, apply_thermobaricity, use_density
       use m_transport, only: ITRA1, ITRAN, ISED1, ISEDN
       use m_fm_wq_processes, only: noout, numwqbots
@@ -104,6 +104,13 @@ contains
       IVAL_CMX = 0
       IVAL_WX = 0
       IVAL_WY = 0
+      IVAL_WINDSTRESSX = 0
+      IVAL_WINDSTRESSY = 0
+      IVAL_WSTAR = 0
+      IVAL_OBUKHOV_LENGTH = 0
+      IVAL_TRANSFER_COEFF_MOMENTUM = 0
+      IVAL_TRANSFER_COEFF_SENSIBLE_HEAT = 0
+      IVAL_TRANSFER_COEFF_LATENT_HEAT = 0
       IVAL_PATM = 0
       IVAL_WAVEH = 0
       IVAL_WAVET = 0
@@ -224,6 +231,17 @@ contains
          IVAL_WX = next_index(i)
          IVAL_WY = next_index(i)
       end if
+      if (jawind > 0 .and. his_write_settings%windstress > 0) then
+         IVAL_WINDSTRESSX = next_index(i)
+         IVAL_WINDSTRESSY = next_index(i)
+      end if
+      if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+         IVAL_WSTAR = next_index(i)
+         IVAL_OBUKHOV_LENGTH = next_index(i)
+         IVAL_TRANSFER_COEFF_MOMENTUM = next_index(i)
+         IVAL_TRANSFER_COEFF_SENSIBLE_HEAT = next_index(i)
+         IVAL_TRANSFER_COEFF_LATENT_HEAT = next_index(i)
+      end if
       if (air_pressure_available) then
          IVAL_PATM = next_index(i)
       end if
@@ -239,24 +257,33 @@ contains
          IVAL_TAUX = next_index(i)
          IVAL_TAUY = next_index(i)
       end if
-      if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-         IVAL_TAIR = next_index(i)
-      end if
       if (jawind > 0) then
          IVAL_WIND = next_index(i)
       end if
-      if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-         IVAL_RHUM = next_index(i)
-         IVAL_CLOU = next_index(i)
-         IVAL_QSUN = next_index(i)
-         IVAL_QEVA = next_index(i)
-         IVAL_QCON = next_index(i)
-         IVAL_QLON = next_index(i)
-         IVAL_QFRE = next_index(i)
-         IVAL_QFRC = next_index(i)
-      end if
-      if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
-         IVAL_QTOT = next_index(i)
+      ! heat flux
+      if (air_water_interaction_model == AIR_WATER_INTERACTION_MODEL_MOST) then
+            IVAL_QSUN = next_index(i)
+            IVAL_QEVA = next_index(i)
+            IVAL_QCON = next_index(i)
+            IVAL_QLON = next_index(i)
+            IVAL_QTOT = next_index(i)
+      else          
+         if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
+            IVAL_TAIR = next_index(i)
+         end if
+         if (temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
+            IVAL_RHUM = next_index(i)
+            IVAL_CLOU = next_index(i)
+            IVAL_QSUN = next_index(i)
+            IVAL_QEVA = next_index(i)
+            IVAL_QCON = next_index(i)
+            IVAL_QLON = next_index(i)
+            IVAL_QFRE = next_index(i)
+            IVAL_QFRC = next_index(i)
+         end if
+         if (temperature_model == TEMPERATURE_MODEL_EXCESS .or. temperature_model == TEMPERATURE_MODEL_COMPOSITE) then
+            IVAL_QTOT = next_index(i)
+         end if
       end if
       call set_value_indices_for_ice(i)
       if (his_write_settings%rain > 0) then
@@ -448,6 +475,13 @@ contains
       IPNT_SED = ivalpoint(IVAL_SED, kmx, nlyrs)
       IPNT_WX = ivalpoint(IVAL_WX, kmx, nlyrs)
       IPNT_WY = ivalpoint(IVAL_WY, kmx, nlyrs)
+      IPNT_WINDSTRESSX = ivalpoint(IVAL_WINDSTRESSX, kmx, nlyrs)
+      IPNT_WINDSTRESSY = ivalpoint(IVAL_WINDSTRESSY, kmx, nlyrs)
+      IPNT_WSTAR = ivalpoint(IVAL_WSTAR, kmx, nlyrs)
+      IPNT_OBUKHOV_LENGTH = ivalpoint(IVAL_OBUKHOV_LENGTH, kmx, nlyrs)
+      IPNT_TRANSFER_COEFF_MOMENTUM = ivalpoint(IVAL_TRANSFER_COEFF_MOMENTUM, kmx, nlyrs)
+      IPNT_TRANSFER_COEFF_SENSIBLE_HEAT = ivalpoint(IVAL_TRANSFER_COEFF_SENSIBLE_HEAT, kmx, nlyrs)
+      IPNT_TRANSFER_COEFF_LATENT_HEAT = ivalpoint(IVAL_TRANSFER_COEFF_LATENT_HEAT, kmx, nlyrs)
       IPNT_PATM = ivalpoint(IVAL_PATM, kmx, nlyrs)
       IPNT_WAVEH = ivalpoint(IVAL_WAVEH, kmx, nlyrs)
       IPNT_WAVET = ivalpoint(IVAL_WAVET, kmx, nlyrs)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations_data.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_observations_data.f90
@@ -73,6 +73,13 @@ module m_observations_data
    integer :: IVAL_CMX
    integer :: IVAL_WX
    integer :: IVAL_WY
+   integer :: IVAL_WINDSTRESSX
+   integer :: IVAL_WINDSTRESSY
+   integer :: IVAL_WSTAR
+   integer :: IVAL_OBUKHOV_LENGTH
+   integer :: IVAL_TRANSFER_COEFF_MOMENTUM
+   integer :: IVAL_TRANSFER_COEFF_SENSIBLE_HEAT
+   integer :: IVAL_TRANSFER_COEFF_LATENT_HEAT
    integer :: IVAL_PATM
    integer :: IVAL_RAIN
    integer :: IVAL_INFILTCAP
@@ -196,6 +203,13 @@ module m_observations_data
    integer :: IPNT_CMX
    integer :: IPNT_WX
    integer :: IPNT_WY
+   integer :: IPNT_WINDSTRESSX
+   integer :: IPNT_WINDSTRESSY
+   integer :: IPNT_WSTAR
+   integer :: IPNT_OBUKHOV_LENGTH
+   integer :: IPNT_TRANSFER_COEFF_MOMENTUM
+   integer :: IPNT_TRANSFER_COEFF_SENSIBLE_HEAT
+   integer :: IPNT_TRANSFER_COEFF_LATENT_HEAT
    integer :: IPNT_RAIN
    integer :: IPNT_INFILTCAP
    integer :: IPNT_INFILTACT

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
@@ -9,14 +9,14 @@ contains
 
    !$f90tw TESTCODE(TEST, test_atmospheric_stability, test_compute_scales_and_fluxes_moninobukhov_true, test_compute_scales_and_fluxes_moninobukhov_true,
    subroutine test_compute_scales_and_fluxes_moninobukhov_true() bind(C)
-      real(kind=dp), allocatable :: wind_velocity_u(:), wind_velocity_v(:), air_temperature(:), dew_point_temperature(:), &
-                                    air_pressure(:), charnock(:), surface_temperature(:)
-      type(t_scales), allocatable :: scaling_parameter_array(:)
-      type(t_fluxes), allocatable :: flux_array(:)
-      real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
-      real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
-      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
+      real(kind=dp), allocatable, dimension(:) :: wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
+                                    air_pressure, charnock, surface_temperature
+      type(t_scales), allocatable, dimension(:) :: scaling_parameter_array
+      type(t_fluxes), allocatable, dimension(:) :: flux_array
+      real(kind=dp), allocatable, dimension(:) :: wind_stress_u, wind_stress_v
+      real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
+      real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
+                                    obukhov_length, richardson_number, c_d, c_h, c_e
       type(t_options) :: options
       
       options%include_stability = .true.
@@ -103,14 +103,14 @@ contains
 
    !$f90tw TESTCODE(TEST, test_atmospheric_stability, test_compute_scales_and_fluxes_moninobukhov_false, test_compute_scales_and_fluxes_moninobukhov_false,
    subroutine test_compute_scales_and_fluxes_moninobukhov_false() bind(C)
-      real(kind=dp), allocatable :: wind_velocity_u(:), wind_velocity_v(:), air_temperature(:), dew_point_temperature(:), &
-                                    air_pressure(:), charnock(:), surface_temperature(:)
-      type(t_scales), allocatable :: scaling_parameter_array(:)
-      type(t_fluxes), allocatable :: flux_array(:)
-      real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
-      real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
-      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
+      real(kind=dp), allocatable, dimension(:) :: wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
+                                    air_pressure, charnock, surface_temperature
+      type(t_scales), allocatable, dimension(:) :: scaling_parameter_array
+      type(t_fluxes), allocatable, dimension(:) :: flux_array
+      real(kind=dp), allocatable, dimension(:) :: wind_stress_u, wind_stress_v
+      real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
+      real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
+                                    obukhov_length, richardson_number, c_d, c_h, c_e
       real(kind=dp) :: tolerance = 1e-5_dp
       type(t_options) :: options
       
@@ -198,14 +198,14 @@ contains
 
    !$f90tw TESTCODE(TEST, test_atmospheric_stability, test_compute_scales_and_fluxes_moninobukhov_free_convection, test_compute_scales_and_fluxes_moninobukhov_free_convection,
    subroutine test_compute_scales_and_fluxes_moninobukhov_free_convection() bind(C)
-      real(kind=dp), allocatable :: wind_velocity_u(:), wind_velocity_v(:), air_temperature(:), dew_point_temperature(:), &
-                                    air_pressure(:), charnock(:), surface_temperature(:)
-      type(t_scales), allocatable :: scaling_parameter_array(:)
-      type(t_fluxes), allocatable :: flux_array(:)
-      real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
-      real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
-      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
+      real(kind=dp), allocatable, dimension(:) :: wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
+                                    air_pressure, charnock, surface_temperature
+      type(t_scales), allocatable, dimension(:) :: scaling_parameter_array
+      type(t_fluxes), allocatable, dimension(:) :: flux_array
+      real(kind=dp), allocatable, dimension(:) :: wind_stress_u, wind_stress_v
+      real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
+      real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
+                                    obukhov_length, richardson_number, c_d, c_h, c_e
       type(t_options) :: options
       
       options%include_stability = .true.

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
@@ -15,8 +15,8 @@ contains
       type(t_fluxes), allocatable :: flux_array(:)
       real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
       real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
-      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    obukhov_length(:), richardson_number(:)
+      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
+                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
       type(t_options) :: options
       
       options%include_stability = .true.
@@ -42,6 +42,10 @@ contains
       call get_wind_stress(wind_stress_u, wind_stress_v)
       call get_latent_heat_flux(latent_heat_flux)
       call get_sensible_heat_flux(sensible_heat_flux)
+      call get_w_star(w_star)
+      call get_transfer_coeff_momentum(c_d)
+      call get_transfer_coeff_sensible_heat(c_h)
+      call get_transfer_coeff_latent_heat(c_e)
 
       call f90_expect_near(u_star(1), 0.483570419681275_dp, 1e-5_dp, "u_star(1) does not match expected value.")
       call f90_expect_near(t_star(1), -0.017773509539055_dp, 1e-7_dp, "t_star(1) does not match expected value.")
@@ -55,6 +59,10 @@ contains
       call f90_expect_near(wind_stress_v(1), 0.20706103307367529_dp, 1e-9_dp, "wind_stress_v(1) does not match expected value.")
       call f90_expect_near(latent_heat_flux(1), -105.25243274353112_dp, 1e-9_dp, "latent_heat_flux(1) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(1), -9.0742363226028786_dp, 1e-9_dp, "sensible_heat_flux(1) does not match expected value.")
+      call f90_expect_near(w_star(1), 0.0_dp, 1e-9_dp, "w_star(1) does not match expected value.")
+      call f90_expect_near(c_d(1), 0.0018059530743435596_dp, 1e-9_dp, "c_d(1) does not match expected value.")
+      call f90_expect_near(c_h(1), 0.0012616656967239196_dp, 1e-9_dp, "c_h(1) does not match expected value.")
+      call f90_expect_near(c_e(1), 0.0013040850160151948_dp, 1e-9_dp, "c_e(1) does not match expected value.")
             
       call f90_expect_near(u_star(2), 0.021983450898111_dp, 1e-5_dp, "u_star(2) does not match expected value.")
       call f90_expect_near(t_star(2), -0.063781380223977_dp, 1e-5_dp, "t_star(2) does not match expected value.")
@@ -68,6 +76,10 @@ contains
       call f90_expect_near(wind_stress_v(2), -0.00056730769523640964_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
       call f90_expect_near(latent_heat_flux(2), -9.9282858337395812_dp, 1e-9_dp, "latent_heat_flux(2) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(2), -1.4640973372837307_dp, 1e-9_dp, "sensible_heat_flux(2) does not match expected value.")
+      call f90_expect_near(w_star(2), 0.0_dp, 1e-9_dp, "w_star(2) does not match expected value.")
+      call f90_expect_near(c_d(2), 0.0021821335002087934_dp, 1e-9_dp, "c_d(2) does not match expected value.")
+      call f90_expect_near(c_h(2), 0.003214519174095654_dp, 1e-9_dp, "c_h(2) does not match expected value.")
+      call f90_expect_near(c_e(2), 0.0034747265309467146_dp, 1e-9_dp, "c_e(2) does not match expected value.")
 
       call f90_expect_near(u_star(3), 1.260861637594213_dp, 1e-5_dp, "u_star(3) does not match expected value.")
       call f90_expect_near(t_star(3), -0.061491952723764_dp, 1e-7_dp, "t_star(3) does not match expected value.")
@@ -81,6 +93,10 @@ contains
       call f90_expect_near(wind_stress_v(3), -1.014329321639416_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
       call f90_expect_near(latent_heat_flux(3), -361.76108401388097_dp, 1e-9_dp, "latent_heat_flux(3) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(3), -82.956322198020032_dp, 1e-9_dp, "sensible_heat_flux(3) does not match expected value.")
+      call f90_expect_near(w_star(3), 0.0_dp, 1e-9_dp, "w_star(3) does not match expected value.")
+      call f90_expect_near(c_d(3), 0.0034055999896374003_dp, 1e-9_dp, "c_d(3) does not match expected value.")
+      call f90_expect_near(c_h(3), 0.0016091919689922699_dp, 1e-9_dp, "c_h(3) does not match expected value.")
+      call f90_expect_near(c_e(3), 0.0016593232548206662_dp, 1e-9_dp, "c_e(3) does not match expected value.")
 
    end subroutine test_compute_scales_and_fluxes_moninobukhov_true
    !$f90tw )
@@ -93,8 +109,8 @@ contains
       type(t_fluxes), allocatable :: flux_array(:)
       real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
       real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
-      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    obukhov_length(:), richardson_number(:)
+      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
+                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
       real(kind=dp) :: tolerance = 1e-5_dp
       type(t_options) :: options
       
@@ -121,6 +137,10 @@ contains
       call get_wind_stress(wind_stress_u, wind_stress_v)
       call get_latent_heat_flux(latent_heat_flux)
       call get_sensible_heat_flux(sensible_heat_flux)
+      call get_w_star(w_star)
+      call get_transfer_coeff_momentum(c_d)
+      call get_transfer_coeff_sensible_heat(c_h)
+      call get_transfer_coeff_latent_heat(c_e)
 
       call f90_expect_near(u_star(1), 0.479416158782993_dp, 1e-5_dp, "u_star(1) does not match expected value.")
       call f90_expect_near(t_star(1), -0.021149810129999_dp, 1e-7_dp, "t_star(1) does not match expected value.")
@@ -134,6 +154,10 @@ contains
       call f90_expect_near(wind_stress_v(1), 0.20351913190267898_dp, 1e-9_dp, "wind_stress_v(1) does not match expected value.")
       call f90_expect_near(latent_heat_flux(1), -124.1632069431982_dp, 1e-9_dp, "latent_heat_flux(1) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(1), -10.705244722352852_dp, 1e-9_dp, "sensible_heat_flux(1) does not match expected value.")
+      call f90_expect_near(w_star(1),0.0_dp, 1e-9_dp, "w_star(1) does not match expected value.")
+      call f90_expect_near(c_d(1), 0.0017750611811957755_dp, 1e-9_dp, "c_d(1) does not match expected value.")
+      call f90_expect_near(c_h(1), 0.0014065352100570325_dp, 1e-9_dp, "c_h(1) does not match expected value.")
+      call f90_expect_near(c_e(1), 0.0014599356045223147_dp, 1e-9_dp, "c_e(1) does not match expected value.")
 
       call f90_expect_near(u_star(2), 0.016365185405138_dp, 1e-5_dp, "u_star(2) does not match expected value.")
       call f90_expect_near(t_star(2), -0.050263329612856_dp, 1e-5_dp, "t_star(2) does not match expected value.")
@@ -147,6 +171,10 @@ contains
       call f90_expect_near(wind_stress_v(2), -0.00031438777173743298_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
       call f90_expect_near(latent_heat_flux(2), -5.6674609233521922_dp, 1e-9_dp, "latent_heat_flux(2) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(2), -0.85891175900128047_dp, 1e-9_dp, "sensible_heat_flux(2) does not match expected value.")
+      call f90_expect_near(w_star(2), 0.0_dp, 1e-9_dp, "w_star(2) does not match expected value.")
+      call f90_expect_near(c_d(2), 0.0012092839468330519_dp, 1e-9_dp, "c_d(2) does not match expected value.")
+      call f90_expect_near(c_h(2), 0.0016166209610199069_dp, 1e-9_dp, "c_h(2) does not match expected value.")
+      call f90_expect_near(c_e(2), 0.0017033816192243661_dp, 1e-9_dp, "c_e(2) does not match expected value.")
 
       call f90_expect_near(u_star(3), 1.254106938341015_dp, 1e-5_dp, "u_star(3) does not match expected value.")
       call f90_expect_near(t_star(3), -0.073256318751260_dp, 1e-7_dp, "t_star(3) does not match expected value.")
@@ -160,7 +188,107 @@ contains
       call f90_expect_near(wind_stress_v(3), -1.0034952837275031_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
       call f90_expect_near(latent_heat_flux(3), -428.65719607731927_dp, 1e-9_dp, "latent_heat_flux(3) does not match expected value.")
       call f90_expect_near(sensible_heat_flux(3), -98.29789107188887_dp, 1e-9_dp, "sensible_heat_flux(3) does not match expected value.")
+      call f90_expect_near(w_star(3), 0.0_dp, 1e-9_dp, "w_star(3) does not match expected value.")
+      call f90_expect_near(c_d(3), 0.0033692248217176671_dp, 1e-9_dp, "c_d(3) does not match expected value.")
+      call f90_expect_near(c_h(3), 0.0017938274301410018_dp, 1e-9_dp, "c_h(3) does not match expected value.")
+      call f90_expect_near(c_e(3), 0.0018566944575505956_dp, 1e-9_dp, "c_e(3) does not match expected value.")
 
    end subroutine test_compute_scales_and_fluxes_moninobukhov_false
    !$f90tw )
+
+   !$f90tw TESTCODE(TEST, test_atmospheric_stability, test_compute_scales_and_fluxes_moninobukhov_free_convection, test_compute_scales_and_fluxes_moninobukhov_free_convection,
+   subroutine test_compute_scales_and_fluxes_moninobukhov_free_convection() bind(C)
+      real(kind=dp), allocatable :: wind_velocity_u(:), wind_velocity_v(:), air_temperature(:), dew_point_temperature(:), &
+                                    air_pressure(:), charnock(:), surface_temperature(:)
+      type(t_scales), allocatable :: scaling_parameter_array(:)
+      type(t_fluxes), allocatable :: flux_array(:)
+      real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
+      real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
+      real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), w_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
+                                    obukhov_length(:), richardson_number(:), c_d(:), c_h(:), c_e(:)
+      type(t_options) :: options
+      
+      options%include_stability = .true.
+      options%include_free_convection = .true.
+      wind_velocity_u = [7.869952506297818_dp, 0.117833360326781_dp, 18.539150194088315_dp]
+      wind_velocity_v = [8.218675428381800_dp, -0.455614551078914_dp, -11.095442028172844_dp]
+      air_temperature = [286.212334904992247_dp, 285.769323685018151_dp, 280.824297920699621_dp]
+      dew_point_temperature = [283.140027966959963_dp, 283.279402521152690_dp, 275.760981569780142_dp]
+      air_pressure = [101190.122711076852283_dp, 99932.877309904928552_dp, 100434.759443715374800_dp]
+      charnock = [0.031984724136352_dp, 0.007887448339510_dp, 0.063390066055710_dp]
+      surface_temperature = [286.743896484375000_dp, 286.676513671875000_dp, 282.813232421875000_dp]
+      
+      call compute_scales_and_fluxes(wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
+                                  air_pressure, charnock, surface_temperature, options)
+
+      call get_u_star(u_star)
+      call get_t_star(t_star)
+      call get_q_star(q_star)
+      call get_z0_momentum(z0_momentum)
+      call get_z0_heat(z0_heat)
+      call get_z0_humidity(z0_humidity)
+      call get_obukhov_length(obukhov_length)
+      call get_richardson_number(richardson_number)
+      call get_wind_stress(wind_stress_u, wind_stress_v)
+      call get_latent_heat_flux(latent_heat_flux)
+      call get_sensible_heat_flux(sensible_heat_flux)
+      call get_w_star(w_star)
+      call get_transfer_coeff_momentum(c_d)
+      call get_transfer_coeff_sensible_heat(c_h)
+      call get_transfer_coeff_latent_heat(c_e)
+
+      call f90_expect_near(u_star(1), 0.48503892913306618_dp, 1e-5_dp, "u_star(1) does not match expected value.")
+      call f90_expect_near(t_star(1), -0.017768759087295315_dp, 1e-7_dp, "t_star(1) does not match expected value.")
+      call f90_expect_near(q_star(1), -7.0972344359100857e-05_dp, 1e-9_dp, "q_star(1) does not match expected value.")
+      call f90_expect_near(z0_momentum(1), 0.00077069986987583989_dp, 1e-7_dp, "z0_momentum(1) does not match expected value.")
+      call f90_expect_near(z0_heat(1), 1.2370298329560207e-05_dp, 1e-9_dp, "z0_heat(1) does not match expected value.")
+      call f90_expect_near(z0_humidity(1), 1.9173962410818321e-05_dp, 1e-9_dp, "z0_humidity(1) does not match expected value.")
+      call f90_expect_near(obukhov_length(1), -578.17152640039592_dp, 1e-1_dp, "obukhov_length(1) does not match expected value.")
+      call f90_expect_near(richardson_number(1), -0.0026341587450735087_dp, 1e-7_dp, "richardson_number(1) does not match expected value.")
+      call f90_expect_near(wind_stress_u(1), 0.19948184684347289_dp, 1e-9_dp, "wind_stress_u(1) does not match expected value.")
+      call f90_expect_near(wind_stress_v(1), 0.2083210224901236_dp, 1e-9_dp, "wind_stress_v(1) does not match expected value.")
+      call f90_expect_near(latent_heat_flux(1), -105.5428430767558_dp, 1e-9_dp, "latent_heat_flux(1) does not match expected value.")
+      call f90_expect_near(sensible_heat_flux(1), -9.0993664326169714_dp, 1e-9_dp, "sensible_heat_flux(1) does not match expected value.")
+      call f90_expect_near(w_star(1), 0.79468308944495336_dp, 1e-9_dp, "w_star(1) does not match expected value.")
+      call f90_expect_near(c_d(1), 0.0018169424996666017_dp, 1e-9_dp, "c_d(1) does not match expected value.")
+      call f90_expect_near(c_h(1), 0.0012651450626063774_dp, 1e-9_dp, "c_h(1) does not match expected value.")
+      call f90_expect_near(c_e(1), 0.0013076690827855135_dp, 1e-9_dp, "c_e(1) does not match expected value.")
+            
+      call f90_expect_near(u_star(2), 0.027461288178040878_dp, 1e-5_dp, "u_star(2) does not match expected value.")
+      call f90_expect_near(t_star(2), -0.056706055294144637_dp, 1e-5_dp, "t_star(2) does not match expected value.")
+      call f90_expect_near(q_star(2), -0.00013124762840313573_dp, 1e-8_dp, "q_star(2) does not match expected value.")
+      call f90_expect_near(z0_momentum(2), 6.0692098657220496e-05_dp, 1e-8_dp, "z0_momentum(2) does not match expected value.")
+      call f90_expect_near(z0_heat(2), 0.00021849302305211344_dp, 1e-7_dp, "z0_heat(2) does not match expected value.")
+      call f90_expect_near(z0_humidity(2), 0.00033866418573077589_dp, 1e-6_dp, "z0_humidity(2) does not match expected value.")
+      call f90_expect_near(obukhov_length(2), -0.7047203096046154_dp, 1e-4_dp, "obukhov_length(2) does not match expected value.")
+      call f90_expect_near(richardson_number(2), -1.0983972949202758_dp, 1e-4_dp, "richardson_number(2) does not match expected value.")
+      call f90_expect_near(wind_stress_u(2), 0.00022894769431259983_dp, 1e-9_dp, "wind_stress_u(2) does not match expected value.")
+      call f90_expect_near(wind_stress_v(2), -0.00088524931034390385_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
+      call f90_expect_near(latent_heat_flux(2), -10.928846269008968_dp, 1e-9_dp, "latent_heat_flux(2) does not match expected value.")
+      call f90_expect_near(sensible_heat_flux(2), -1.6260230845591246_dp, 1e-9_dp, "sensible_heat_flux(2) does not match expected value.")
+      call f90_expect_near(w_star(2), 0.42203237296988277_dp, 1e-9_dp, "w_star(2) does not match expected value.")
+      call f90_expect_near(c_d(2), 0.0034050872081563561_dp, 1e-9_dp, "c_d(2) does not match expected value.")
+      call f90_expect_near(c_h(2), 0.0035568473805944528_dp, 1e-9_dp, "c_h(2) does not match expected value.")
+      call f90_expect_near(c_e(2), 0.0038105394089474687_dp, 1e-9_dp, "c_e(2) does not match expected value.")
+      
+      call f90_expect_near(u_star(3), 1.26513874946048_dp, 1e-5_dp, "u_star(3) does not match expected value.")
+      call f90_expect_near(t_star(3), -0.061475542273589472_dp, 1e-7_dp, "t_star(3) does not match expected value.")
+      call f90_expect_near(q_star(3), -9.2317720021125625e-05_dp, 1e-9_dp, "q_star(3) does not match expected value.")
+      call f90_expect_near(z0_momentum(3), 0.010346525962056419_dp, 1e-6_dp, "z0_momentum(3) does not match expected value.")
+      call f90_expect_near(z0_heat(3), 4.7427650809076874e-06_dp, 1e-9_dp, "z0_heat(3) does not match expected value.")
+      call f90_expect_near(z0_humidity(3), 7.3512858754069154e-06_dp, 1e-9_dp, "z0_humidity(3) does not match expected value.")
+      call f90_expect_near(obukhov_length(3), -1490.2281217368877_dp, 2e-1_dp, "obukhov_length(3) does not match expected value.")
+      call f90_expect_near(richardson_number(3), -0.0020764345448452777_dp, 1e-7_dp, "richardson_number(3) does not match expected value.")
+      call f90_expect_near(wind_stress_u(3), 1.7063484580044113_dp, 1e-9_dp, "wind_stress_u(3) does not match expected value.")
+      call f90_expect_near(wind_stress_v(3), -1.0212275210806181_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
+      call f90_expect_near(latent_heat_flux(3), -362.88862010436793_dp, 1e-9_dp, "latent_heat_flux(3) does not match expected value.")
+      call f90_expect_near(sensible_heat_flux(3), -83.21566057764511_dp, 1e-9_dp, "sensible_heat_flux(3) does not match expected value.")
+      call f90_expect_near(w_star(3), 1.5068281349378128_dp, 1e-9_dp, "w_star(3) does not match expected value.")
+      call f90_expect_near(c_d(3), 0.0034287606214403969_dp, 1e-9_dp, "c_d(3) does not match expected value.")
+      call f90_expect_near(c_h(3), 0.0016142384707827039_dp, 1e-9_dp, "c_h(3) does not match expected value.")
+      call f90_expect_near(c_e(3), 0.0016645136081998144_dp, 1e-9_dp, "c_e(3) does not match expected value.")
+
+   end subroutine test_compute_scales_and_fluxes_moninobukhov_free_convection
+   !$f90tw )
+
 end module test_atmospheric_stability

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
@@ -16,7 +16,7 @@ contains
       real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
       real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
       real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    monin_obukhov_length(:), richardson_number(:)
+                                    obukhov_length(:), richardson_number(:)
       type(t_options) :: options
       
       options%include_stability = .true.
@@ -37,7 +37,7 @@ contains
       call get_z0_momentum(z0_momentum)
       call get_z0_heat(z0_heat)
       call get_z0_humidity(z0_humidity)
-      call get_monin_obukhov_length(monin_obukhov_length)
+      call get_obukhov_length(obukhov_length)
       call get_richardson_number(richardson_number)
       call get_wind_stress(wind_stress_u, wind_stress_v)
       call get_latent_heat_flux(latent_heat_flux)
@@ -49,7 +49,7 @@ contains
       call f90_expect_near(z0_momentum(1), 0.000766075070655_dp, 1e-7_dp, "z0_momentum(1) does not match expected value.")
       call f90_expect_near(z0_heat(1), 0.000012407831933_dp, 1e-9_dp, "z0_heat(1) does not match expected value.")
       call f90_expect_near(z0_humidity(1), 0.000019232139496_dp, 1e-9_dp, "z0_humidity(1) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(1), -574.507255494245101_dp, 1e-1_dp, "monin_obukhov_length(1) does not match expected value.")
+      call f90_expect_near(obukhov_length(1), -574.507255494245101_dp, 1e-1_dp, "obukhov_length(1) does not match expected value.")
       call f90_expect_near(richardson_number(1), -0.002646973390076_dp, 1e-7_dp, "richardson_number(1) does not match expected value.")
       call f90_expect_near(wind_stress_u(1), 0.19827531947147781_dp, 1e-9_dp, "wind_stress_u(1) does not match expected value.")
       call f90_expect_near(wind_stress_v(1), 0.20706103307367529_dp, 1e-9_dp, "wind_stress_v(1) does not match expected value.")
@@ -62,7 +62,7 @@ contains
       call f90_expect_near(z0_momentum(2), 0.000075442471892_dp, 1e-8_dp, "z0_momentum(2) does not match expected value.")
       call f90_expect_near(z0_heat(2), 0.000272922727444_dp, 1e-7_dp, "z0_heat(2) does not match expected value.")
       call f90_expect_near(z0_humidity(2), 0.000423030227538_dp, 1e-6_dp, "z0_humidity(2) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(2), -0.401534400984983_dp, 1e-4_dp, "monin_obukhov_length(2) does not match expected value.")
+      call f90_expect_near(obukhov_length(2), -0.401534400984983_dp, 1e-4_dp, "obukhov_length(2) does not match expected value.")
       call f90_expect_near(richardson_number(2), -1.974372173626931_dp, 1e-4_dp, "richardson_number(2) does not match expected value.")
       call f90_expect_near(wind_stress_u(2), 0.00014672001126972184_dp, 1e-9_dp, "wind_stress_u(2) does not match expected value.")
       call f90_expect_near(wind_stress_v(2), -0.00056730769523640964_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
@@ -75,7 +75,7 @@ contains
       call f90_expect_near(z0_momentum(3), 0.010276823644789_dp, 1e-6_dp, "z0_momentum(3) does not match expected value.")
       call f90_expect_near(z0_heat(3), 0.000004758824805_dp, 1e-9_dp, "z0_heat(3) does not match expected value.")
       call f90_expect_near(z0_humidity(3), 0.000007376178448_dp, 1e-9_dp, "z0_humidity(3) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(3), -1479.651083435764122_dp, 2e-1_dp, "monin_obukhov_length(3) does not match expected value.")
+      call f90_expect_near(obukhov_length(3), -1479.651083435764122_dp, 2e-1_dp, "obukhov_length(3) does not match expected value.")
       call f90_expect_near(richardson_number(3), -0.002086552554703_dp, 1e-7_dp, "richardson_number(3) does not match expected value.")
       call f90_expect_near(wind_stress_u(3), 1.6948223957543_dp, 1e-9_dp, "wind_stress_u(3) does not match expected value.")
       call f90_expect_near(wind_stress_v(3), -1.014329321639416_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
@@ -94,7 +94,7 @@ contains
       real(kind=dp), allocatable :: wind_stress_u(:), wind_stress_v(:)
       real(kind=dp), allocatable :: latent_heat_flux(:), sensible_heat_flux(:)
       real(kind=dp), allocatable :: u_star(:), t_star(:), q_star(:), z0_momentum(:), z0_heat(:), z0_humidity(:), &
-                                    monin_obukhov_length(:), richardson_number(:)
+                                    obukhov_length(:), richardson_number(:)
       real(kind=dp) :: tolerance = 1e-5_dp
       type(t_options) :: options
       
@@ -116,7 +116,7 @@ contains
       call get_z0_momentum(z0_momentum)
       call get_z0_heat(z0_heat)
       call get_z0_humidity(z0_humidity)
-      call get_monin_obukhov_length(monin_obukhov_length)
+      call get_obukhov_length(obukhov_length)
       call get_richardson_number(richardson_number)
       call get_wind_stress(wind_stress_u, wind_stress_v)
       call get_latent_heat_flux(latent_heat_flux)
@@ -128,7 +128,7 @@ contains
       call f90_expect_near(z0_momentum(1), 0.000752955407655_dp, 1e-7_dp, "z0_momentum(1) does not match expected value.")
       call f90_expect_near(z0_heat(1), 0.000012516200200_dp, 1e-9_dp, "z0_heat(1) does not match expected value.")
       call f90_expect_near(z0_humidity(1), 0.000019400110310_dp, 1e-9_dp, "z0_humidity(1) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(1), 0.0_dp, 0.0_dp, "monin_obukhov_length(1) does not match expected value.")
+      call f90_expect_near(obukhov_length(1), 0.0_dp, 0.0_dp, "obukhov_length(1) does not match expected value.")
       call f90_expect_near(richardson_number(1), 0.0_dp, 0.0_dp, "richardson_number(1) does not match expected value.")
       call f90_expect_near(wind_stress_u(1), 0.19488370311667183_dp, 1e-9_dp, "wind_stress_u(1) does not match expected value.")
       call f90_expect_near(wind_stress_v(1), 0.20351913190267898_dp, 1e-9_dp, "wind_stress_v(1) does not match expected value.")
@@ -141,7 +141,7 @@ contains
       call f90_expect_near(z0_momentum(2), 0.000101038350813_dp, 1e-8_dp, "z0_momentum(2) does not match expected value.")
       call f90_expect_near(z0_heat(2), 0.000366628877207_dp, 1e-7_dp, "z0_heat(2) does not match expected value.")
       call f90_expect_near(z0_humidity(2), 0.000568274759671_dp, 1e-6_dp, "z0_humidity(2) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(2), 0.0_dp, 0.0_dp, "monin_obukhov_length(2) does not match expected value.")
+      call f90_expect_near(obukhov_length(2), 0.0_dp, 0.0_dp, "obukhov_length(2) does not match expected value.")
       call f90_expect_near(richardson_number(2), 0.0_dp, 0.0_dp, "richardson_number(2) does not match expected value.")
       call f90_expect_near(wind_stress_u(2), 8.130856993426958e-05_dp, 1e-9_dp, "wind_stress_u(2) does not match expected value.")
       call f90_expect_near(wind_stress_v(2), -0.00031438777173743298_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
@@ -154,7 +154,7 @@ contains
       call f90_expect_near(z0_momentum(3), 0.010166908002376_dp, 1e-6_dp, "z0_momentum(3) does not match expected value.")
       call f90_expect_near(z0_heat(3), 0.000004784484715_dp, 1e-9_dp, "z0_heat(3) does not match expected value.")
       call f90_expect_near(z0_humidity(3), 0.000007415951308_dp, 1e-9_dp, "z0_humidity(3) does not match expected value.")
-      call f90_expect_near(monin_obukhov_length(3), 0.0_dp, 0.0_dp, "monin_obukhov_length(3) does not match expected value.")
+      call f90_expect_near(obukhov_length(3), 0.0_dp, 0.0_dp, "obukhov_length(3) does not match expected value.")
       call f90_expect_near(richardson_number(3), 0.0_dp, 0.0_dp, "richardson_number(3) does not match expected value.")
       call f90_expect_near(wind_stress_u(3), 1.6767200204232942_dp, 1e-9_dp, "wind_stress_u(3) does not match expected value.")
       call f90_expect_near(wind_stress_v(3), -1.0034952837275031_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")


### PR DESCRIPTION
# What was done 
- add a new mdu option Wrihis_windstress and the corresponding codes for writing wind stress to his file
- add the calculations of bulk transfer coefficients (C_D, C_H, and C_E) in module atmospheric_stability and the corresponding getter
- create cache variables for the extra variables in m_wind (w_star, obukhov_length, C_D, C_H, and C_E) and assign values to them in setwindstress() using the batch getter
- introduce the corresponding IVAL_* and IPNT_* parameters and modify the relevant files accordingly, to work with valobs() for the extra variables; 
- add a new mdu option Wrihis_bulk_exchange_coefficients to write the extra variables (w_star, obukhov_length, C_D, C_H, and C_E) to his file, if MOST is used

# Evidence of the work done 
<img width="646" height="611" alt="20260708_UNST-9888_extra_output_variables_in_his_file" src="https://github.com/user-attachments/assets/55377191-d0f0-4e05-b3cf-34635ef30d17" />

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9888