### PR TITLE
sedmor branch: improvements related to wave forcing 

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_waves.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_waves.f90
@@ -63,8 +63,10 @@ module m_waves
 
    real(kind=dp) :: ftauw !< Swartfactor, tune bed shear stress
    real(kind=dp) :: fwfac !< Soulsby factor, tune streaming
-   real(kind=dp) :: fbreak !< tune breaking in tke model
-   real(kind=dp) :: fwavpendep !< Layer thickness as proportion of Hrms over which wave breaking adds to TKE source. Default 0.5
+   real(kind=dp) :: fbreak !< factor for adjusting wave breaking contribution in tke model
+   real(kind=dp) :: fforc !< factor for adjusting wave forces in momentum equation, default 1
+   real(kind=dp) :: fwavpendep !< layer thickness as proportion of Hrms over which wave breaking adds to TKE source. Default 1.5
+   real(kind=dp) :: strlyrfac !< streaming layer thickness is strlyrfac*wave boundary layer thickness. Default 3.0 
 
    character(len=4) :: rouwav !< Friction model for wave induced shear stress
 
@@ -95,11 +97,11 @@ module m_waves
 
    ! parameters, may be overwritten by user in mdu-file
    real(kind=dp) :: gammax !< Maximum wave height/water depth ratio
-   real(kind=dp) :: alfdeltau = 20.0_dp !< coeff for thickness of wave bed boundary layer
    real(kind=dp) :: hminlw !< [m] minimum depth for wave forcing in flow momentum equation RHS.
    integer :: jatpwav = TPWAVDEFAULT !< TPWAV, TPWAVSMOOTH, TPWAVRELATIVE
    integer :: jauorb !< multiply with factor sqrt(pi)/2 (=0), or not (=1). Default 0, delft3d style
    integer :: jauorbfromswan !< 1: get uorb from SWAN, compare with Delft3D
+   integer :: jawavevellogprof !< 1: set depth-averaged velocity from u1 of base layers
    logical :: extfor_wave_initialized !< is set to .true. when the "external forcing"-part that must be initialized for WAVE during running (instead of during initialization) has actually been initialized
 
 contains
@@ -118,6 +120,9 @@ contains
       fwfac = 1.0_dp
       fbreak = 1.0_dp
       fwavpendep = 1.5_dp ! best setting based on sensitivity
+      jawavevellogprof = 1
+      fforc = 1.0_dp
+      strlyrfac = 3.0_dp
 
       call reset_waves()
    end subroutine default_waves

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_waves.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_waves.f90
@@ -65,6 +65,8 @@ module m_waves
    real(kind=dp) :: fwfac !< Soulsby factor, tune streaming
    real(kind=dp) :: fbreak !< tune breaking in tke model
    real(kind=dp) :: fwavpendep !< Layer thickness as proportion of Hrms over which wave breaking adds to TKE source. Default 0.5
+   real(kind=dp) :: fforc !< factor for adjusting wave forces in momentum equation, default 1
+   real(kind=dp) :: strlyrfac !< factor for adjusting wave forces in momentum equation, default 1
 
    character(len=4) :: rouwav !< Friction model for wave induced shear stress
 
@@ -82,6 +84,7 @@ module m_waves
    real(kind=dp), allocatable :: cfwavhi(:)
    real(kind=dp), allocatable :: cfhi_vanrijn(:)
    real(kind=dp), allocatable :: wblt(:)
+   integer :: jawavevellogprof
 
    real(kind=dp) :: facmax !< maximum wave force
    real(kind=dp) :: JONSWAPgamma0 = 3.3 !< Peak enhancement factor JONSWAP
@@ -118,6 +121,9 @@ contains
       fwfac = 1.0_dp
       fbreak = 1.0_dp
       fwavpendep = 1.5_dp ! best setting based on sensitivity
+      jawavevellogprof = 1
+      fforc = 1.0_dp
+      strlyrfac = 3.0_dp
 
       call reset_waves()
    end subroutine default_waves

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1538,8 +1538,9 @@ contains
       call prop_get(md_ptr, 'waves', '3Dwaveturbpendepth', fwavpendep) ! Layer thickness as proportion of Hrms over which wave breaking adds to TKE source. Default 0.5
       !
       ! safety
-      if (fwavpendep < 0.0_dp) then
+      if (fwavpendep <= 0.0_dp) then
          fwavpendep = 0.0_dp
+         jawavebreakerturbulence=WAVE_BREAKER_TURB_OFF
          write (msgbuf, *) 'unstruc_model::readMDUFile: 3Dwaveturbpendepth<0.0, reset to 0.0. Wave breaking switched off as a source for TKE.'
          call warn_flush()
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1505,7 +1505,7 @@ contains
       call prop_get(md_ptr, 'waves', 'ftauw', ftauw) ! factor for adjusting wave related bottom shear stress
       call prop_get(md_ptr, 'waves', 'fbreak', fbreak) ! factor for adjusting wave breaking contribution to tke
       call prop_get(md_ptr, 'waves', 'fforc', fforc) ! factor for adjusting wave forces in momentum equation
-      call prop_get(md_ptr, 'waves', 'streamlyrfac', strlyrfac) ! factor for adjusting streaming layer thickness in momentum equation
+      call prop_get(md_ptr, 'waves', 'streamLyrFac', strlyrfac) ! factor for adjusting streaming layer thickness in momentum equation
 
       if (ftauw < 0.0_dp) then
          call mess(LEVEL_WARN, 'unstruc_model::readMDUFile: ftauw<0.0, reset to 0.0. Bed shear stress due to waves switched off.')
@@ -1523,6 +1523,11 @@ contains
          call mess(LEVEL_WARN, 'unstruc_model::readMDUFile: fforc<=0.0, reset to 0.0. Wave forces switched off.')
          fforc = 0.0_dp
          jawaveforces = WAVE_FORCES_OFF
+      end if
+      if (strlyrfac <= 0.0_dp .and. jawave > NO_WAVES .and. .not. flow_without_waves) then
+         call mess(LEVEL_ERROR, 'unstruc_model::readMDUFile: Only streamLyrFac > 0.0 is allowed.')
+         istat=-1
+         return
       end if
 
       if (jawave <= WAVE_FETCH_YOUNG) then
@@ -3464,38 +3469,48 @@ contains
 
       ! jre wm67
       if (writeall .or. jawave > NO_WAVES) then
-         call prop_set(prop_ptr, 'waves', 'Wavemodelnr', jawave, 'Wave model nr. (0: none, 1: fetch/depth limited Hurdle-Stive, 2: fetch/depth limited Young-Verhagen, 3: SWAN, 5: uniform, 7: Offline Wave Coupling')
-         call prop_set(prop_ptr, 'waves', 'Rouwav', rouwav, 'Friction model for wave induced shear stress: FR84 (default) or: MS90, HT91, GM79, DS88, BK67, CJ85, OY88, VR04')
-         call prop_set(prop_ptr, 'waves', 'Gammax', gammax, 'Maximum wave height/water depth ratio')
-         call prop_set(prop_ptr, 'waves', 'uorbfac', jauorb, 'Orbital velocities: 0=D3D style; 1=Guza style')
-         call prop_set(prop_ptr, 'waves', 'jahissigwav', his_write_settings%sigwav, '1: sign wave height on his output; 0: hrms wave height on his output. Default=1.')
-         call prop_set(prop_ptr, 'waves', 'jamapsigwav', map_write_settings%sigwav, '1: sign wave height on map output; 0: hrms wave height on map output. Default=0 (legacy behaviour).')
-         call prop_set(prop_ptr, 'waves', 'hminlw', hminlw, 'Cut-off depth for application of wave forces in momentum balance')
+         call prop_set(prop_ptr, 'waves', 'waveModelNr', jawave, 'Wave model nr. (0: none, 1: fetch/depth limited Hurdle-Stive, 2: fetch/depth limited Young-Verhagen, 3: SWAN, 5: uniform, 7: Offline Wave Coupling')
          if (flow_without_waves) then
             fww = 1
          else
             fww = 0
          end if
-         call prop_set(prop_ptr, 'waves', 'FlowWithoutWaves', fww, '1: Do not use wave data in the flow computations, it will only be passed through to D-WAQ; 0: use wave information. Default 0.')
+         call prop_set(prop_ptr, 'waves', 'flowWithoutWaves', fww, '1: Do not use wave data in the flow computations, it will only be passed through to D-WAQ; 0: use wave information. Default 0.')
+         !
+         call prop_set(prop_ptr, 'waves', 'jaHisSigWav', his_write_settings%sigwav, '1: sign wave height on his output; 0: hrms wave height on his output. Default=1.')
+         call prop_set(prop_ptr, 'waves', 'jaMapSigWav', map_write_settings%sigwav, '1: sign wave height on map output; 0: hrms wave height on map output. Default=0 (legacy behaviour).')
+         
+         call prop_set(prop_ptr, 'waves', 'jaUOrbFromSwan', jauorbfromswan, '1: use orbital velocities from com file; 0=internal uorb calculation. Default=0.')
+         call prop_set(prop_ptr, 'waves', 'uOrbFac', jauorb, 'Orbital velocities: 0=D3D style; 1=Guza style')
+         
+         call prop_set(prop_ptr, 'waves', 'rouWav', rouwav, 'Friction model for wave induced shear stress: FR84 (default) or: MS90, HT91, GM79, DS88, BK67, CJ85, OY88, VR04')
+         call prop_set(prop_ptr, 'waves', 'gammax', gammax, 'Maximum wave height/water depth ratio')
+         call prop_set(prop_ptr, 'waves', 'fwFac', fwfac, 'factor for adjusting wave boundary layer streaming, default 1.0.')
+         call prop_set(prop_ptr, 'waves', 'fTauw', ftauw, 'factor for adjusting wave related bottom shear stress.')
+         call prop_set(prop_ptr, 'waves', 'fBreak', fbreak, 'factor for adjusting wave breaking contribution to tke.')
+         call prop_set(prop_ptr, 'waves', 'fForc', fforc, 'factor for adjusting wave forces in momentum equation.')
+         call prop_set(prop_ptr, 'waves', 'streamLyrFac', strlyrfac, 'factor for adjusting streaming layer thickness in momentum equation.')
+         
+         call prop_set(prop_ptr, 'waves', 'hMinLw', hminlw, 'Cut-off depth for application of wave forces in momentum balance')
          if (writeall .or. hwavuni /= 0.0_dp) then
-            call prop_set(prop_ptr, 'waves', 'Hwavuni', hwavuni, 'root mean square wave height (m)')
-            call prop_set(prop_ptr, 'waves', 'Twavuni', twavuni, 'root mean square wave period (s)')
-            call prop_set(prop_ptr, 'waves', 'Phiwavuni', phiwavuni, 'root mean square wave direction, (deg), math convention')
+            call prop_set(prop_ptr, 'waves', 'hWavUni', hwavuni, 'root mean square wave height (m)')
+            call prop_set(prop_ptr, 'waves', 'tWavUni', twavuni, 'root mean square wave period (s)')
+            call prop_set(prop_ptr, 'waves', 'phiWavUni', phiwavuni, 'root mean square wave direction, (deg), math convention')
          end if
          if (writeall .or. jawaveswartdelwaq /= WAVE_WAQ_SHEAR_STRESS_HYD) then
-            call prop_set(prop_ptr, 'waves', 'WaveSwartDelwaq', jaWaveSwartDelwaq, 'if WaveSwartDelwaq == 1 .and. Tiwaq > 0 then increase tauwave to Delwaq with 0.5rho*fw*uorbuorb')
+            call prop_set(prop_ptr, 'waves', 'waveSwartDelwaq', jaWaveSwartDelwaq, 'if WaveSwartDelwaq == 1 .and. Tiwaq > 0 then increase tauwave to Delwaq with 0.5rho*fw*uorbuorb')
          end if
          if (writeall .or. jawave == WAVE_FETCH_HURDLE .or. jawave == WAVE_FETCH_YOUNG) then
-            call prop_set(prop_ptr, 'waves', 'Tifetchcomp', Tifetch, 'Time interval fetch comp (s) in wavemodel 1,2')
+            call prop_set(prop_ptr, 'waves', 'tiFetchComp', Tifetch, 'Time interval fetch comp (s) in wavemodel 1,2')
          end if
          if (writeall .or. kmx > 0) then
-            call prop_set(prop_ptr, 'waves', '3Dstokesprofile', jawaveStokes, 'Stokes profile. 0: no, 1:uniform over depth, 2: 2nd order Stokes theory; 3: 2, with vertical stokes gradient in adve ')
-            call prop_set(prop_ptr, 'waves', '3Dwavebreakerturbulence', jawavebreakerturbulence, 'Add wave-induced production terms in turbulence modelling: 0 = no, 1 = yes')
-            call prop_set(prop_ptr, 'waves', '3Dwavestreaming', jawavestreaming, 'Influence of wave streaming. 0: no, 1: added to adve                                                                 ')
-            call prop_set(prop_ptr, 'waves', '3Dwaveboundarylayer', jawavedelta, 'Boundary layer formulation. 1: Sana                                                                                  ')
+            call prop_set(prop_ptr, 'waves', '3dStokesProfile', jawaveStokes, 'Stokes profile. 0: no, 1:uniform over depth, 2: 2nd order Stokes theory; 3: 2, with vertical stokes gradient in adve ')
+            call prop_set(prop_ptr, 'waves', '3dWaveBreakerTurbulence', jawavebreakerturbulence, 'Add wave-induced production terms in turbulence modelling: 0 = no, 1 = yes')
+            call prop_set(prop_ptr, 'waves', '3dWaveStreaming', jawavestreaming, 'Influence of wave streaming. 0: no, 1: added to adve                                                                 ')
+            call prop_set(prop_ptr, 'waves', '3dWaveBoundaryLayer', jawavedelta, 'Boundary layer formulation. 1: Sana                                                                                  ')
          end if
          if (jawave == WAVE_NC_OFFLINE) then
-            call prop_set(prop_ptr, 'waves', 'Waveforcing', waveforcing, 'Wave forcing (in combination with Wavemodelnr = 7 only). 1: based on radiation stress gradients, 2: based on dissipation, NOT implemented yet, 3: based on dissipation at free surface and water column, NOT implemented yet')
+            call prop_set(prop_ptr, 'waves', 'waveForcing', waveforcing, 'Wave forcing (in combination with Wavemodelnr = 7 only). 1: based on radiation stress gradients, 2: based on dissipation, NOT implemented yet, 3: based on dissipation at free surface and water column, NOT implemented yet')
          end if
 
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1504,6 +1504,9 @@ contains
       call prop_get(md_ptr, 'waves', 'fwfac', fwfac) ! factor for adjusting wave boundary layer streaming, default 1.0
       call prop_get(md_ptr, 'waves', 'ftauw', ftauw) ! factor for adjusting wave related bottom shear stress
       call prop_get(md_ptr, 'waves', 'fbreak', fbreak) ! factor for adjusting wave breaking contribution to tke
+      call prop_get(md_ptr, 'waves', 'fforc', fforc) ! factor for adjusting wave forces in momentum equation
+      call prop_get(md_ptr, 'waves', 'streamlyrfac', strlyrfac) ! factor for adjusting streaming layer thickness in momentum equation
+
       if (ftauw < 0.0_dp) then
          call mess(LEVEL_WARN, 'unstruc_model::readMDUFile: ftauw<0.0, reset to 0.0. Bed shear stress due to waves switched off.')
          ftauw = 0.0_dp
@@ -1515,6 +1518,11 @@ contains
       if (fbreak < 0.0_dp) then
          call mess(LEVEL_WARN, 'unstruc_model::readMDUFile: fbreak<0.0, reset to 0.0. Wave breaking contribution to tke switched off.')
          fbreak = 0.0_dp
+      end if
+      if (fforc <= 0.0_dp) then
+         call mess(LEVEL_WARN, 'unstruc_model::readMDUFile: fforc<=0.0, reset to 0.0. Wave forces switched off.')
+         fforc = 0.0_dp
+         jawaveforces = WAVE_FORCES_OFF
       end if
 
       if (jawave <= WAVE_FETCH_YOUNG) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -4764,7 +4764,7 @@ contains
                   end if
                end if
                if (map_write_settings%wav_twav > 0 .and. allocated(twav)) then
-                  ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, nc_precision, UNC_LOC_S, 'tp', 'sea_surface_wave_period_at_variance_spectral_density_maximum', 'Peak wave period', 's')
+                  ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, nc_precision, UNC_LOC_S, 'twav', '', 'Peak wave period', 's')
                end if
                if (map_write_settings%wav_phiwav > 0 .and. allocated(phiwav)) then
                   ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_thetamean, nc_precision, UNC_LOC_S, 'thetamean', 'sea_surface_wave_from_direction', 'Wave from direction', 'degree')
@@ -4778,7 +4778,7 @@ contains
                   ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_hwav, nc_precision, UNC_LOC_S, 'hwav', 'sea_surface_wave_significant_height', 'Significant wave height', 'm', jabndnd=jabndnd_)
                end if
                ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_thetamean, nc_precision, UNC_LOC_S, 'thetamean', 'sea_surface_wave_from_direction', 'Wave from direction', 'degree', jabndnd=jabndnd_)
-               ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, nc_precision, UNC_LOC_S, 'twav', 'sea_surface_wave_period_at_variance_spectral_density_maximum', 'Wave peak period', 's') ! we assume working with the peak period in all our formulations
+               ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_twav, nc_precision, UNC_LOC_S, 'twav', '', 'Peak wave period', 's')
                ierr = unc_def_var_map(mapids%ncid, mapids%id_tsp, mapids%id_uorb, nc_precision, UNC_LOC_S, 'uorb', 'sea_surface_wave_orbital_velocity', 'Wave orbital velocity', 'm s-1', jabndnd=jabndnd_) ! not CF
                !
                if (jawavestokes > NO_STOKES_DRIFT) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -46,7 +46,7 @@ contains
       use m_get_czz0, only: getczz0
       use m_flowgeom, only: ln, dxi, csu, snu
       use m_flowtimes, only: dti
-      use m_waves, only: ustokes, vstokes, wblt
+      use m_waves, only: ustokes, vstokes, wblt, jawavevellogprof, strlyrfac
       use m_waveconst, only: NO_WAVES, NO_STOKES_DRIFT, WAVE_STREAMING_OFF
       use m_sediment, only: stm_included
       use m_flowtimes, only: dts
@@ -64,7 +64,7 @@ contains
       real(kind=dp) :: taubxuLL ! taubxu = ymxpar*(taucur+tauwav)
 
       real(kind=dp) :: csw, snw ! wave direction cosines
-      real(kind=dp) :: Dfu, Dfu0, Dfu1, htop, dzu ! wave dissipation by bed friction, / (rhomean*c*deltau)
+      real(kind=dp) :: Dfu, Dfu0, Dfu1, htop ! wave dissipation by bed friction, / (rhomean*c*deltau)
       real(kind=dp) :: deltau ! wave dissipation layer thickness
       real(kind=dp) :: u2dh
       real(kind=dp) :: z0urouL, rhoL, uorbu
@@ -75,6 +75,7 @@ contains
       real(kind=dp) :: s, sd, er, ers, dzb, uu, vv, alin
       real(kind=dp) :: cphi, sphi
       real(kind=dp) :: fsqrtt = sqrt(2.0_dp)
+      real(kind=dp) :: slfacdeltau
 
       cfuhi3D = 0.0_dp
       ustbLL = 0.0_dp
@@ -121,7 +122,7 @@ contains
                   hdzb = 0.5_dp * hu(Lb) + z00
                   sqcf = vonkar / (log(1.0_dp + 0.5_dp * hu(Lb) / z00))
                else if (jaustarint == 4) then
-                  !hdzb  = 0.5d0*hu(Lb)     + c9of1*z00/0.65d0
+                  !hdzb  = 0.5_dp*hu(Lb)     + c9of1*z00/0.65_dp
                   dzb = hu(Lb) / ee + c9of1 * z00 * 0.66_dp
                   sqcf = vonkar / (log(dzb / z00))
                else if (jaustarint == 5) then
@@ -164,18 +165,13 @@ contains
                   u2dh = umod
                else
                   ! here we assume that z0/dzb is small and c9of1==1, ie we use jaustarint==1 approach, cf 3D validation doc Mohamed
-                  !u2dh = umod*(log((1d0+hu(LL))/z0urou(LL))-1d0)/(log(dzb/z0urou(LL))-1d0)
-
-                  ! UNST-6297 formulation above gives u2dh of order too big in very shallow water
-
-                  ! Delft3D:
-                  !u2dh = (umod/hu(LL)                                             &
-                  !     & *((hu(LL) + z0urou(LL))*log(1d0 + hu(LL)/z0urou(LL))     &
-                  !     & - hu(LL)))/log(1d0 + 0.5d0*(max(dzb,0.01d0))/z0urou(LL))
-
-                  ! use available depth-averaged u1, v
-                  u2dh = sqrt((u1(LL) - ustokes(LL))**2 + &
-                              (v(LL) - vstokes(LL))**2)
+                  if (jawavevellogprof == 0) then
+                     u2dh = umod * (log((1_dp + hu(LL)) / z0urou(LL)) - 1_dp) / (log(dzb / z0urou(LL)) - 1_dp)
+                  else
+                     ! use available depth-averaged u1, v
+                     u2dh = sqrt((u1(LL) - ustokes(LL))**2 + &
+                                 (v(LL) - vstokes(LL))**2)
+                  end if
                end if
                !
                if (cz > 0.0_dp) then
@@ -194,7 +190,6 @@ contains
                   sphi = -csw * snu(LL) + snw * csu(LL)
                   abscos = abs(cphi * uu + sphi * vv) / umod
                   call getsoulsbywci(modind, ustc2, ustw2, fw, cdrag, umod, abscos, taubpuLL, taubxuLL)
-                  ! ustbLL = sqrt(umod*taubpuLL)
                else if (modind == 9) then ! wave-current interaction van Rijn (2004)
                   call getvanrijnwci(LL, umod, u2dh, taubpuLL, z0urouL)
                   taubxuLL = rhoL * (ustc2 + ustw2) ! depth-averaged, see taubot
@@ -208,7 +203,7 @@ contains
                   end if
                else if (modind == 0) then ! exception where you don't want wave influence on bed shear stress with jawave>0
                   if (sqcf > 0.0_dp) then
-                     z0urouL = dzb * exp(-vonkar / sqcf - 1.0_dp) ! inverse of jaustarint == 1 above
+                     z0urouL = z00 ! no wave enhancement
                      taubpuLL = ustbLL * ustbLL / umod ! use flow ustar
                      taubxuLL = rhoL * taubpuLL * umod
                   else
@@ -234,42 +229,44 @@ contains
                   z0urou(LL) = z0urouL
                end if
                z00 = z0urou(LL) ! wave enhanced z0 for turbulence
-               !
-               if (stm_included) then
-                  wblt(LL) = deltau
-               end if
-               !
-               ! Streaming below deltau with linear distribution
-               if (jawavestreaming > WAVE_STREAMING_OFF .and. deltau > 1.0e-7_dp) then ! Streaming below deltau with linear distribution
-                  Dfu0 = Dfuc ! (m/s2)
-                  do L = Lb, Ltop(LL)
-                     if (hu(L) <= deltau) then
-                        htop = min(hu(L), deltau) ! max height within waveboundarylayer
-                        alin = 1.0_dp - htop / deltau ! linear from 1 at bed to 0 at deltau
-                        Dfu1 = Dfuc * alin
-                        dzu = htop - hu(L - 1)
-                        adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1) * dzu / deltau
-                        Dfu0 = Dfu1
-                     end if
-                     if (hu(L) > deltau) then
-                        if (L == Lb) then
-                           adve(L) = adve(L) - Dfuc * deltau / (2.0 * hu(L)) ! everything in bottom layer
-                        end if
-                        exit
-                     end if
-                  end do
-               end if
             else
-               if (sqcf > 0.0_dp) then
+               if (sqcf > 0_dp) then
                   ! taubu for too small wave case needs to be filled
                   z0urou(LL) = z00 ! just use current only z0
                   taubpuLL = ustbLL * ustbLL / umod ! use flow ustar
                   taubxuLL = rhoL * taubpuLL * umod
                else
-                  taubu(LL) = 0.0_dp
-                  taubxu(LL) = 0.0_dp
+                  taubu(LL) = 0_dp
+                  taubxu(LL) = 0_dp
                   z0urou(LL) = epsz0
                end if
+            end if
+            !
+            if (stm_included) wblt(LL) = deltau
+            !
+            ! Streaming below strlyrfac*deltau with linear distribution, see van Rijn 2011 p9.177
+            if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then ! weakly turbulent flume cases ~1mm-1cm, real turbulent cases 5-50cm
+               slfacdeltau = strlyrfac * deltau
+               Dfu0 = Dfuc ! (m/s2)
+               do L = Lb, Ltop(LL)
+                  if (hu(L) <= slfacdeltau) then
+                     htop = min(hu(L), slfacdeltau) ! max height within streaming layer
+                     alin = 1_dp - htop / slfacdeltau ! linear from 1 at bed to 0 at slfacdeltau (= strlyrfac * deltau)
+                     Dfu1 = Dfuc * alin
+                     adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1)
+                     Dfu0 = Dfu1
+                  end if
+                  if (hu(L) > slfacdeltau) then
+                     if (L == Lb) then
+                        adve(L) = adve(L) - Dfuc * slfacdeltau / (2.0_dp * hu(L)) ! everything in bottom layer
+                     else
+                        alin = (min(hu(L), slfacdeltau) - hu(L - 1)) / (2.0_dp * (hu(L) - hu(L - 1)))
+                        Dfu1 = Dfuc * alin
+                        adve(L) = adve(L) - Dfu1
+                     end if
+                     exit
+                  end if
+               end do
             end if
          end if ! end jawave
 
@@ -277,7 +274,7 @@ contains
          cfuhi3D = cfuhiLL * umod ! cfuhi3D = frc. contr. to diagonal
 
          if (jawave == NO_WAVES .or. flow_without_waves) then
-            z0urou(LL) = z0ucur(LL) ! morfo, bedforms, trachytopes
+            z0urou(LL) = z00 ! morfo, bedforms, trachytopes
          end if
 
       else if (friction_type == 10) then ! Hydraulically smooth, glass etc
@@ -336,7 +333,7 @@ contains
 
       else if (friction_type == 11) then ! Noslip
 
-         !    advi(Lb) = advi(Lb) +  2d0*(vicwwu(Lb)+vicouv)/hu(Lb)**2
+         !    advi(Lb) = advi(Lb) +  2_dp*(vicwwu(Lb)+vicouv)/hu(Lb)**2
          cfuhi3D = 2.0_dp * (vicwwu(Lb) + vicoww%get(LL)) / hu(Lb)**2
 
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -72,7 +72,7 @@ contains
 
       integer :: nit, nitm = 100
       real(kind=dp) :: r, rv = 123.8_dp, e = 8.84_dp, eps = 1.0e-2_dp
-      real(kind=dp) :: s, sd, er, ers, dzb, uu, vv, alin
+      real(kind=dp) :: s, sd, er, ers, dzb, uu, vv
       real(kind=dp) :: dz
       real(kind=dp) :: cphi, sphi
       real(kind=dp) :: fsqrtt = sqrt(2.0_dp)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -73,6 +73,7 @@ contains
       integer :: nit, nitm = 100
       real(kind=dp) :: r, rv = 123.8_dp, e = 8.84_dp, eps = 1.0e-2_dp
       real(kind=dp) :: s, sd, er, ers, dzb, uu, vv, alin
+      real(kind=dp) :: dz
       real(kind=dp) :: cphi, sphi
       real(kind=dp) :: fsqrtt = sqrt(2.0_dp)
       real(kind=dp) :: slfacdeltau
@@ -251,7 +252,7 @@ contains
                slfacdeltau = strlyrfac * deltau
                Dfu0 = Dfuc ! (m/s2)
                do L = Lb, Ltop(LL)
-                  Dfu1 = max(0.0_fp, 1.0_dp - hu(L) / slfacdeltau) * Dfuc
+                  Dfu1 = max(0.0_dp, 1.0_dp - hu(L) / slfacdeltau) * Dfuc
                   if (L == Lb) then
                      dz = hu(L)
                   else

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -245,25 +245,23 @@ contains
             if (stm_included) wblt(LL) = deltau
             !
             ! Streaming below strlyrfac*deltau with linear distribution, see van Rijn 2011 p9.177
-            if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then ! weakly turbulent flume cases ~1mm-1cm, real turbulent cases 5-50cm
+            if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then
+               ! weakly turbulent flume cases ~1mm-1cm, real turbulent cases 5-50cm
+               ! linear from 1 at bed to 0 at slfacdeltau
                slfacdeltau = strlyrfac * deltau
                Dfu0 = Dfuc ! (m/s2)
                do L = Lb, Ltop(LL)
-                  if (hu(L) <= slfacdeltau) then
-                     htop = min(hu(L), slfacdeltau) ! max height within streaming layer
-                     alin = 1_dp - htop / slfacdeltau ! linear from 1 at bed to 0 at slfacdeltau (= strlyrfac * deltau)
-                     Dfu1 = Dfuc * alin
-                     adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1)
-                     Dfu0 = Dfu1
+                  Dfu1 = max(0.0_fp, 1.0_dp - hu(L) / slfacdeltau) * Dfuc
+                  if (L == Lb) then
+                     dz = hu(L)
+                  else
+                     dz = hu(L) - hu(L - 1)
                   end if
-                  if (hu(L) > slfacdeltau) then
-                     if (L == Lb) then
-                        adve(L) = adve(L) - Dfuc * slfacdeltau / (2.0_dp * hu(L)) ! everything in bottom layer
-                     else
-                        alin = (min(hu(L), slfacdeltau) - hu(L - 1)) / (2.0_dp * (hu(L) - hu(L - 1)))
-                        Dfu1 = Dfuc * alin
-                        adve(L) = adve(L) - Dfu1
-                     end if
+                  adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1) / dz
+                  if (Dfu1 > 0.0_dp) then
+                     ! streaming layer extends into next layer
+                     Dfu0 = Dfu1
+                  else
                      exit
                   end if
                end do

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -274,7 +274,7 @@ contains
             ! Streaming acceleration decreases linearly from Dfuc at the bed
             ! to zero at slfacdeltau.
             if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then
-               slfacdeltau = strlyrfac * deltau
+               slfacdeltau = min(hu(LL), strlyrfac * deltau)
                if (slfacdeltau > 0.0_dp) then
                do L = Lb, Ltop(LL)
                      zbot = hu(L - 1)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustbcfuhi.f90
@@ -69,10 +69,12 @@ contains
       real(kind=dp) :: u2dh
       real(kind=dp) :: z0urouL, rhoL, uorbu
       real(kind=dp) :: umodeps
+      real(kind=dp) :: z0log, depth, eta, logfac
+      real(kind=dp) :: zbot, dzu
 
       integer :: nit, nitm = 100
       real(kind=dp) :: r, rv = 123.8_dp, e = 8.84_dp, eps = 1.0e-2_dp
-      real(kind=dp) :: s, sd, er, ers, dzb, uu, vv, alin
+      real(kind=dp) :: s, sd, er, ers, dzb, uu, vv
       real(kind=dp) :: cphi, sphi
       real(kind=dp) :: fsqrtt = sqrt(2.0_dp)
       real(kind=dp) :: slfacdeltau
@@ -166,7 +168,20 @@ contains
                else
                   ! here we assume that z0/dzb is small and c9of1==1, ie we use jaustarint==1 approach, cf 3D validation doc Mohamed
                   if (jawavevellogprof == 0) then
-                     u2dh = umod * (log((1_dp + hu(LL)) / z0urou(LL)) - 1_dp) / (log(dzb / z0urou(LL)) - 1_dp)
+                     depth = hu(LL)
+                     z0log = max(z00, epsz0)
+
+                     if (ustbLL > 0.0_dp .and. depth > 0.0_dp) then
+                        eta = c9of1 * z0log / depth
+
+                        logfac = (1.0_dp + eta) * &
+                                 log(depth / z0log + c9of1) - &
+                                 eta * log(c9of1) - 1.0_dp
+
+                        u2dh = max(0.0_dp, ustbLL * logfac / vonkar)
+                     else
+                        u2dh = 0.0_dp
+                     end if
                   else
                      ! use available depth-averaged u1, v
                      u2dh = sqrt((u1(LL) - ustokes(LL))**2 + &
@@ -220,7 +235,16 @@ contains
                !
                ! set wave enhanced z0 for turbulence and morphology
                if (sqcf > 0.0_dp) then
-                  z0urou(LL) = dzb * exp(-vonkar / sqcf - 1.0_dp) ! inverse of jaustarint == 1 above, updated ustar
+                  select case (jaustarint)
+                  case (0)
+                     z0urou(LL) = 0.5_dp * hu(Lb) / &
+                                  (exp(vonkar / sqcf) - c9of1)
+                  case (3)
+                     z0urou(LL) = 0.5_dp * hu(Lb) / &
+                                  (exp(vonkar / sqcf) - 1.0_dp)
+                  case default
+                     z0urou(LL) = dzb * exp(-vonkar / sqcf - 1.0_dp) ! inverse of jaustarint == 1 above, updated ustar
+                  end select
                   z0urou(LL) = min(z0urou(LL), 10.0_dp)
                else
                   z0urou(LL) = epsz0
@@ -235,6 +259,8 @@ contains
                   z0urou(LL) = z00 ! just use current only z0
                   taubpuLL = ustbLL * ustbLL / umod ! use flow ustar
                   taubxuLL = rhoL * taubpuLL * umod
+                  taubu(LL) = taubpuLL * rhoL * (u1Lb + ustokes(Lb))
+                  taubxu(LL) = taubxuLL
                else
                   taubu(LL) = 0_dp
                   taubxu(LL) = 0_dp
@@ -245,28 +271,33 @@ contains
             if (stm_included) wblt(LL) = deltau
             !
             ! Streaming below strlyrfac*deltau with linear distribution, see van Rijn 2011 p9.177
-            if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then ! weakly turbulent flume cases ~1mm-1cm, real turbulent cases 5-50cm
+            ! Streaming acceleration decreases linearly from Dfuc at the bed
+            ! to zero at slfacdeltau.
+            if (jawavestreaming /= WAVE_STREAMING_OFF .and. deltau > 1.0e-4_dp) then
                slfacdeltau = strlyrfac * deltau
-               Dfu0 = Dfuc ! (m/s2)
-               do L = Lb, Ltop(LL)
-                  if (hu(L) <= slfacdeltau) then
-                     htop = min(hu(L), slfacdeltau) ! max height within streaming layer
-                     alin = 1_dp - htop / slfacdeltau ! linear from 1 at bed to 0 at slfacdeltau (= strlyrfac * deltau)
-                     Dfu1 = Dfuc * alin
-                     adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1)
-                     Dfu0 = Dfu1
-                  end if
-                  if (hu(L) > slfacdeltau) then
-                     if (L == Lb) then
-                        adve(L) = adve(L) - Dfuc * slfacdeltau / (2.0_dp * hu(L)) ! everything in bottom layer
-                     else
-                        alin = (min(hu(L), slfacdeltau) - hu(L - 1)) / (2.0_dp * (hu(L) - hu(L - 1)))
-                        Dfu1 = Dfuc * alin
-                        adve(L) = adve(L) - Dfu1
-                     end if
-                     exit
-                  end if
-               end do
+               if (slfacdeltau > 0.0_dp) then
+                  do L = Lb, Ltop(LL)
+                     zbot = hu(L - 1)
+                     dzu = hu(L) - zbot
+                     if (dzu <= 0.0_dp) cycle
+                     if (zbot >= slfacdeltau) exit
+                     !
+                     ! Upper boundary of the active part of this layer.
+                     htop = min(hu(L), slfacdeltau)
+                     !
+                     ! Streaming acceleration at the lower and upper boundaries
+                     ! of the active part.
+                     Dfu0 = Dfuc * (1.0_dp - zbot / slfacdeltau)
+                     Dfu1 = Dfuc * (1.0_dp - htop / slfacdeltau)
+                     !
+                     ! Average over the active interval, then account for the
+                     ! fraction of the complete computational layer that is active.
+                     adve(L) = adve(L) - 0.5_dp * (Dfu0 + Dfu1) * (htop - zbot) / dzu
+                     !
+                     if (hu(L) >= slfacdeltau) exit
+                  end do
+               end if
+
             end if
          end if ! end jawave
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
@@ -39,8 +39,8 @@ module m_get_ustwav
 contains
    subroutine getustwav(LL, z00, fw, ustw2, csw, snw, Dfu, Dfuc, deltau, costu, uorbu) ! at u-point, get ustarwave and get ustokes
       use precision, only: dp
-      use m_flow, only: hu, jawavestokes, ag, jawave, rhomean, EPS10
-      use m_flowgeom, only: ln, csu, snu
+      use m_flow, only: hu, jawavestokes, ag, EPS10
+      use m_flowgeom, only: ln, csu, snu, acl
       use m_waves, only: twav, ustokes, vstokes, phiwav, hwav, gammax, jauorb, ftauw, fwfac, strlyrfac
       use m_waveconst, only: STOKES_DRIFT_2NDORDER, STOKES_DRIFT_DEPTHUNIFORM, WAVE_SURFBEAT
       use m_sferic, only: twopi, dg2rd, pi
@@ -60,9 +60,13 @@ contains
       integer :: k1, k2, Lb, Lt, L
       real(kind=dp) :: Tsig, Hrms, asg, rk, shs, phi1, phi2, dks, aks, omeg, f1u, f2u, f3u, sintu
       real(kind=dp) :: p1, p2, h, z, uusto, fac
+      real(kind=dp) :: ac1, ac2
+      real(kind=dp) :: streamdepth
 
       real(kind=dp), parameter :: alfaw = 20.0_dp
-      real(kind=dp), parameter :: halfsqpi = 1.0_dp/(2.0_dp * sqrt(acos(-1.0_dp)))
+      real(kind=dp), parameter :: halfsqpi = 1.0_dp / (2.0_dp * sqrt(acos(-1.0_dp)))
+
+      ustw2 = 0.0_dp
       Dfu = 0.0_dp
       Dfuc = 0.0_dp
       deltau = 0.0_dp
@@ -72,10 +76,17 @@ contains
       costu = 1.0_dp
       fw = 0.0_dp
 
+      if (z00 <= 0.0_dp) then ! guard for hydraulically smooth flow
+         return
+      end if
+
+      ac1 = acl(LL)
+      ac2 = 1.0_dp - ac1
+
       call getLbotLtop(LL, Lb, Lt)
       k1 = ln(1, LL)
       k2 = ln(2, LL)
-      Tsig = 0.5_dp * (twav(k1) + twav(k2))
+      Tsig = ac1 * twav(k1) + ac2 * twav(k2)
       ustokes(Lb:Lt) = 0.0_dp
       vstokes(Lb:Lt) = 0.0_dp
       ustokes(LL) = 0.0_dp
@@ -90,11 +101,11 @@ contains
 
       phi1 = phiwav(k1)
       phi2 = phiwav(k2)
-      csw = 0.5_dp * (cos(phi1 * dg2rd) + cos(phi2 * dg2rd))
-      snw = 0.5_dp * (sin(phi1 * dg2rd) + sin(phi2 * dg2rd))
+      csw = ac1 * cos(phi1 * dg2rd) + ac2 * cos(phi2 * dg2rd)
+      snw = ac1 * sin(phi1 * dg2rd) + ac2 * sin(phi2 * dg2rd)
 
       call getwavenr(hu(LL), tsig, rk)
-      Hrms = 0.5_dp * (hwav(k1) + hwav(k2))
+      Hrms = ac1 * hwav(k1) + ac2 * hwav(k2)
       Hrms = min(hrms, gammax * hu(LL))
       asg = 0.5_dp * Hrms ! Wave amplitude = 0.5*Hrms
       shs = sinhsafei(rk * hu(LL))
@@ -143,11 +154,15 @@ contains
          deltau = max(deltau, ee * z00) ! alfaw makes wbl at least ~2ks thick
 
          call soulsby(tsig, uorbu, z00, fw) ! streaming with different calibration fac fwfac + soulsby fws
-         Dfu = halfsqpi * fw * uorbu**3 ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
-         Dfu = fwfac * Dfu / strlyrfac / deltau ! divided by 3 deltau    (m2/s3) see van Rijn, streaming layer about 3-5 times wbl
-         Dfuc = Dfu * rk / omeg * costu ! Dfuc = dfu/c/delta,  (m /s2) is contribution to adve
-         deltau = alfaw * deltau ! as in delft3d
-         deltau = min(0.5_dp * hu(LL), deltau) !
+         deltau = min(0.5_dp * hu(LL), alfaw * deltau)
+         streamdepth = min(hu(LL), strlyrfac * deltau)  ! divided by 3 deltau see van Rijn, streaming layer about 3-5 times wbl
+         Dfu = fwfac * halfsqpi * fw * uorbu**3    ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
+
+         if (streamdepth > 0.0_dp) then
+            Dfuc = 2.0_dp * Dfu * rk / omeg * costu / streamdepth   ! Dfuc = dfu/c/delta,  (m /s2) is contribution to adve
+         else
+            Dfuc = 0.0_dp
+         end if
 
       else
          ustw2 = 0.0_dp

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
@@ -76,10 +76,6 @@ contains
       costu = 1.0_dp
       fw = 0.0_dp
 
-      if (z00 <= 0.0_dp) then ! guard for hydraulically smooth flow
-         return
-      end if
-
       ac1 = acl(LL)
       ac2 = 1.0_dp - ac1
 
@@ -113,7 +109,8 @@ contains
       sintu = -csw * snu(LL) + snw * csu(LL)
 
       if (jawaveStokes == STOKES_DRIFT_DEPTHUNIFORM) then
-         uusto = 0.5_dp * omeg * asg * asg / hu(LL)
+         !uusto = 0.5_dp * omeg * asg * asg / hu(LL)
+         uusto = 0.5_dp * ag * asg**2 * rk / (omeg * hu(LL)) ! with tanh(kh)
          ustokes(Lb:Lt) = costu * uusto
          vstokes(Lb:Lt) = sintu * uusto
          ustokes(LL) = costu * uusto ! for convenience
@@ -144,6 +141,11 @@ contains
             fac = sqrt(pi) / 2.0_dp
          end if
          uorbu = omeg * asg * shs * fac ! Orbital velocity, sqrt factor to match delft3d
+         !
+         if (z00 <= 0.0_dp) then ! guard for hydraulically smooth flow
+            return
+         end if
+         !
          call Swart(Tsig, uorbu, z00, fw, ustw2)
          ustw2 = ftauw * ustw2 ! ustar wave squared times calibrationcoeff ftauw
 
@@ -155,11 +157,11 @@ contains
 
          call soulsby(tsig, uorbu, z00, fw) ! streaming with different calibration fac fwfac + soulsby fws
          deltau = min(0.5_dp * hu(LL), alfaw * deltau)
-         streamdepth = min(hu(LL), strlyrfac * deltau)  ! divided by 3 deltau see van Rijn, streaming layer about 3-5 times wbl
-         Dfu = fwfac * halfsqpi * fw * uorbu**3    ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
+         streamdepth = min(hu(LL), strlyrfac * deltau) ! divided by 3 deltau see van Rijn, streaming layer about 3-5 times wbl
+         Dfu = fwfac * halfsqpi * fw * uorbu**3 ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
 
          if (streamdepth > 0.0_dp) then
-            Dfuc = 2.0_dp * Dfu * rk / omeg * costu / streamdepth   ! Dfuc = dfu/c/delta,  (m /s2) is contribution to adve
+            Dfuc = 2.0_dp * Dfu * rk / omeg * costu / streamdepth ! Dfuc = dfu/c/delta,  (m /s2) is contribution to adve
          else
             Dfuc = 0.0_dp
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
@@ -62,7 +62,7 @@ contains
       real(kind=dp) :: p1, p2, h, z, uusto, fac
 
       real(kind=dp), parameter :: alfaw = 20.0_dp
-      real(kind=dp), parameter :: halfsqpi = 1.0_dp/(2.0_dp * acos(-1.0_dp))
+      real(kind=dp), parameter :: halfsqpi = 1.0_dp/(2.0_dp * sqrt(acos(-1.0_dp)))
       Dfu = 0.0_dp
       Dfuc = 0.0_dp
       deltau = 0.0_dp

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getustwav.f90
@@ -41,11 +41,10 @@ contains
       use precision, only: dp
       use m_flow, only: hu, jawavestokes, ag, jawave, rhomean, EPS10
       use m_flowgeom, only: ln, csu, snu
-      use m_waves, only: twav, ustokes, vstokes, phiwav, hwav, gammax, jauorb, ftauw, alfdeltau, fwfac
+      use m_waves, only: twav, ustokes, vstokes, phiwav, hwav, gammax, jauorb, ftauw, fwfac, strlyrfac
       use m_waveconst, only: STOKES_DRIFT_2NDORDER, STOKES_DRIFT_DEPTHUNIFORM, WAVE_SURFBEAT
       use m_sferic, only: twopi, dg2rd, pi
       use m_get_Lbot_Ltop, only: getlbotltop
-      use m_xbeach_data, only: R, cwav, gammaxxb, roller
       use mathconsts, only: ee
 
       integer, intent(in) :: LL
@@ -58,11 +57,12 @@ contains
       real(kind=dp), intent(out) :: uorbu
 
       real(kind=dp), external :: sinhsafei
-      integer :: k1, k2, Lb, Lt, L, Lmin
+      integer :: k1, k2, Lb, Lt, L
       real(kind=dp) :: Tsig, Hrms, asg, rk, shs, phi1, phi2, dks, aks, omeg, f1u, f2u, f3u, sintu
       real(kind=dp) :: p1, p2, h, z, uusto, fac
-      real(kind=dp) :: rolthk, rmax, erol, crol, mass
 
+      real(kind=dp), parameter :: alfaw = 20.0_dp
+      real(kind=dp), parameter :: halfsqpi = 1.0_dp/(2.0_dp * acos(-1.0_dp))
       Dfu = 0.0_dp
       Dfuc = 0.0_dp
       deltau = 0.0_dp
@@ -124,38 +124,6 @@ contains
          ! depth averaged
          ustokes(LL) = costu * ag * asg * asg * rk / omeg / 2.0_dp / hu(LL) ! these are needed, also for 3D models (see u bnd furu)
          vstokes(LL) = sintu * ag * asg * asg * rk / omeg / 2.0_dp / hu(LL)
-
-         ! add 3D roller contribution to stokes drift
-         if (jawave == WAVE_SURFBEAT .and. roller == 1) then
-            ! roller mass flux
-            rmax = 0.125_dp * rhomean * ag * (gammaxxb * h)**2
-            erol = min(0.5_dp * (R(k1) + R(k2)), rmax)
-            crol = max(0.5_dp * (cwav(k1) + cwav(k2)), 1.0e-1_dp)
-            mass = 2.0_dp * erol / crol / rhomean
-            !
-            if (Lt > Lb) then
-               !
-               ! determine roller thickness
-               lmin = Lt
-               rolthk = 0.0_dp
-               do L = Lt - 1, Lb, -1
-                  lmin = L
-                  rolthk = hu(Lt) - hu(L)
-                  if (rolthk >= 0.5_dp * hrms) then
-                     exit
-                  end if
-               end do
-               !
-               ! depth dependent contribution
-               ustokes(Lmin:Lt) = ustokes(Lmin:Lt) + mass / rolthk * costu
-               vstokes(Lmin:Lt) = vstokes(Lmin:Lt) + mass / rolthk * sintu
-            end if
-            !
-            ! depth averaged contribution
-            ustokes(LL) = ustokes(LL) + mass / h * costu
-            vstokes(LL) = ustokes(LL) + mass / h * sintu
-         end if
-
       end if
 
       if (shs > EPS10) then
@@ -171,14 +139,15 @@ contains
          dks = 33.0_dp * z00 ! should be 30 for consistency with getust
          aks = asg * shs / dks * fac ! uorbu/(omega*ks), uorbu/omega = particle excursion length
 
-         deltau = 0.09_dp * dks * aks**0.82_dp ! thickness of wave boundary layer from Fredsoe and Deigaard
-         deltau = alfdeltau * max(deltau, ee * z00) ! alfaw = 20d0
-         deltau = min(0.5_dp * hu(LL), deltau) !
+         deltau = 0.09_dp * dks * aks**0.82_dp ! thickness of wave boundary layer from Fredsoe and Deigaard (1992)
+         deltau = max(deltau, ee * z00) ! alfaw makes wbl at least ~2ks thick
 
          call soulsby(tsig, uorbu, z00, fw) ! streaming with different calibration fac fwfac + soulsby fws
-         Dfu = 0.28_dp * fw * uorbu**3 ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
-         Dfu = fwfac * Dfu / deltau ! divided by deltau    (m2/s3), missing rho divided out in adve denominator rho*delta
+         Dfu = halfsqpi * fw * uorbu**3 ! random waves: 0.28=1/2sqrt(pi) (m3/s3)
+         Dfu = fwfac * Dfu / strlyrfac / deltau ! divided by 3 deltau    (m2/s3) see van Rijn, streaming layer about 3-5 times wbl
          Dfuc = Dfu * rk / omeg * costu ! Dfuc = dfu/c/delta,  (m /s2) is contribution to adve
+         deltau = alfaw * deltau ! as in delft3d
+         deltau = min(0.5_dp * hu(LL), deltau) !
 
       else
          ustw2 = 0.0_dp

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
@@ -91,6 +91,8 @@ contains
       if (iadvec == 0) then
          javau = 0
       end if
+      
+      womegu = 0.0_dp
 
       if (iturbulencemodel == 1) then ! 1=constant
 
@@ -451,10 +453,11 @@ contains
                   ! check if first layer is thicker than fwavpendep*wave height
                   ! Then use JvK solution
                   if (hu(LL) - hu(Lt - 1) >= fwavpendep * hrmsLL) then
-                     dk(kxL - 1) = dk(kxL - 1) + pkwmag * fwavpendep * hrmsLL / (hu(LL) - hu(Lt - 1)) ! m2/s3
+                     pkwav(kxL - 1) = 0.5_dp * pkwmag * fwavpendep * hrmsLL / (hu(LL) - hu(Lt - 1))
+                     dk(kxL - 1) = dk(kxL - 1) + pkwav(kxL - 1) ! m2/s3
                   else
                      ! distribute over layers
-                     do L = Lt - 1, Lb
+                     do L = Lt - 1, Lb, -1
                         if (hu(L + 1) < wdep) then
                            exit
                         end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/update_verticalprofiles.f90
@@ -114,7 +114,7 @@ contains
                call getustbcfuhi(LL, Lb, ustb(LL), cfuhi(LL), hdzb, z00, cfuhi3D) !Constant
                advi(Lb) = advi(Lb) + cfuhi3D
                !
-               if (jawave > NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_DEPTHUNIFORM .and. .not. flow_without_waves) then ! Ustokes correction at bed
+               if (jawave /= NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_DEPTHUNIFORM .and. .not. flow_without_waves) then ! Ustokes correction at bed
                   adve(Lb) = adve(Lb) - cfuhi3D * ustokes(Lb)
                end if
 
@@ -169,7 +169,7 @@ contains
                call getustbcfuhi(LL, Lb, ustb(LL), cfuhi(LL), hdzb, z00, cfuhi3D) ! algebraic
                advi(Lb) = advi(Lb) + cfuhi3D
                !
-               if (jawave > NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_DEPTHUNIFORM .and. .not. flow_without_waves) then ! Ustokes correction at bed
+               if (jawave /= NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_DEPTHUNIFORM .and. .not. flow_without_waves) then ! Ustokes correction at bed
                   adve(Lb) = adve(Lb) - cfuhi3D * ustokes(Lb)
                end if
 
@@ -319,12 +319,12 @@ contains
                vicu = viskin + 0.5_dp * (vicwwu(Lb0) + vicwwu(Lb)) * sigtkei
 
                ! Calculate turkin source from wave dissipation: preparation
-               if (jawave > NO_WAVES) then
+               if (jawave /= NO_WAVES) then
                   if (jawaveStokes > NO_STOKES_DRIFT .and. .not. flow_without_waves) then ! Ustokes correction at bed
                      adve(Lb) = adve(Lb) - cfuhi3D * ustokes(Lb)
                   end if
 
-                  if (jawave > NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
+                  if (jawave /= NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
                      k1 = ln(1, LL)
                      k2 = ln(2, LL)
                      ac1 = acl(LL)
@@ -420,7 +420,7 @@ contains
                   ! Addition of production and of dissipation to matrix ;
                   ! observe implicit treatment by Newton linearization.
 
-                  if (jawave > NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_2NDORDER_VISC .and. .not. flow_without_waves) then ! vertical shear based on eulerian velocity field, see turclo,note JvK, Ardhuin 2006
+                  if (jawave /= NO_WAVES .and. jawaveStokes >= STOKES_DRIFT_2NDORDER_VISC .and. .not. flow_without_waves) then ! vertical shear based on eulerian velocity field, see turclo,note JvK, Ardhuin 2006
                      dijdij(k) = ((u1(Lu) - ustokes(Lu) - u1(L) + ustokes(L))**2 + (v(Lu) - vstokes(Lu) - v(L) + vstokes(L))**2) / dzw(k)**2
                   else
                      dijdij(k) = ((u1(Lu) - u1(L))**2 + (v(Lu) - v(L))**2) / dzw(k)**2
@@ -447,7 +447,7 @@ contains
 
                end do ! Lb, Lt-1
 
-               if (jawave > NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
+               if (jawave /= NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
                   ! check if first layer is thicker than fwavpendep*wave height
                   ! Then use JvK solution
                   if (hu(LL) - hu(Lt - 1) >= fwavpendep * hrmsLL) then
@@ -676,7 +676,7 @@ contains
                      sourtu = c1e * cmukep * turkin0(L) * dijdij(k)
                      !
                      ! Add wave dissipation production term
-                     if (jawave > NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
+                     if (jawave /= NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
                         sourtu = sourtu + pkwav(k) * c1e * tureps0(L) / max(turkin0(L), 1.0e-7_dp)
                      end if
 
@@ -729,7 +729,7 @@ contains
                   bk(kxL) = 1.0_dp
                   ck(kxL) = 0.0_dp
                   dk(kxL) = 4.0_dp * abs(ustw(LL))**3 / (vonkar * dzu(Lt - Lb + 1))
-                  if (jawave > NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then ! wave dissipation at surface, neumann bc, dissipation over fwavpendep*Hrms
+                  if (jawave /= NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then ! wave dissipation at surface, neumann bc, dissipation over fwavpendep*Hrms
                      dk(kxL) = dk(kxL) + dzu(Lt - Lb + 1) * pkwmag / (fwavpendep * hrmsLL)
                   end if
 
@@ -841,8 +841,8 @@ contains
                      end do
                      epsbot = tureps1(Lb) + dzu(1) * abs(ustb(LL))**3 / (vonkar * hdzb * hdzb)
                      epssur = tureps1(Lt - 1) - 4.0_dp * abs(ustw(LL))**3 / (vonkar * dzu(Lt - Lb + 1))
-                     if (jawave > NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
-                        epssur = epssur - dzu(Lt - Lb + 1) * fwavpendep * pkwmag / hrmsLL
+                     if (jawave /= NO_WAVES .and. jawavebreakerturbulence > WAVE_BREAKER_TURB_OFF) then
+                        epssur = epssur - dzu(Lt - Lb + 1) * pkwmag / (hrmsLL * fwavpendep)
                      end if
                      epsbot = max(epsbot, eps_min)
                      epssur = max(epssur, eps_min)
@@ -868,7 +868,9 @@ contains
                   vicwwu(Lb0:Lt) = min(vicwmax, cmukep * turkin1(Lb0:Lt) * tureps1(Lb0:Lt))
                end if
 
-               vicwwu(Lt) = min(vicwwu(Lt), vicwwu(Lt - 1) * Eddyviscositysurfacmax)
+               if (jawave == NO_WAVES .or. jawavebreakerturbulence == WAVE_BREAKER_TURB_OFF) then
+                  vicwwu(Lt) = min(vicwwu(Lt), vicwwu(Lt - 1) * Eddyviscositysurfacmax)
+               end if
                vicwwu(Lb0) = min(vicwwu(Lb0), vicwwu(Lb) * Eddyviscositybedfacmax)
 
                call vertical_profile_u0(dzu, womegu, Lb, Lt, kxL, LL)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
@@ -84,12 +84,12 @@ contains
       ac1 = acL(LL)
       ac2 = 1.0_dp - ac1
 
-      do L = Lb, 0 ! Lt
-         k = L - Lb + 1
-         k1 = ln(1, L)
-         k2 = ln(2, L)
-         dzv(k) = ac1 * (zws(k1) - zws(k1 - 1)) + ac2 * (zws(k2) - zws(k2 - 1)) ! volume weighted dzu , ok for pillar
-      end do
+      !do L = Lb, 0 ! Lt
+      !   k = L - Lb + 1
+      !   k1 = ln(1, L)
+      !   k2 = ln(2, L)
+      !   dzv(k) = ac1 * (zws(k1) - zws(k1 - 1)) + ac2 * (zws(k2) - zws(k2 - 1)) ! volume weighted dzu , ok for pillar
+      !end do
 
       jav3 = 0
       if (javau == 3) then
@@ -249,7 +249,7 @@ contains
          end if
 
          if (jawave > NO_WAVES .and. jawaveStokes == STOKES_DRIFT_2NDORDER_VISC_ADVE .and. .not. flow_without_waves) then ! ustokes correction in vertical viscosity
-            ustv = vstress * (ustokes(L) - ustokes(L - 1))
+            ustv = vstress * (ustokes(L+1) - ustokes(L))
             d(k + 1) = d(k + 1) + ustv / dzu(k + 1)
             d(k) = d(k) - ustv / dzu(k)
          end if
@@ -258,7 +258,7 @@ contains
 
       agp = ag
       if (jahelmert > 0 .and. jsferic > 0) then ! possibly operationalise later for now avoid the checks
-         st2 = sin(dg2rd * yu(L))**2
+         st2 = sin(dg2rd * yu(LL))**2
          agp = 9.7803253359 * (1.0_dp + 0.00193185265241 * st2) / sqrt(1.0_dp - 0.00669437999013 * st2)
       end if
       gdxi = agp * dxi(LL)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
@@ -113,6 +113,9 @@ contains
          ! vstress  = (vicwwu(L) + vicoww + viskin ) / dzLw                    ! 08-12-14 : add kinematic viscosity
 
          ! vstress  = ( max(vicwwu(L), vicoww) + viskin ) / dzLw                 ! 23-12-14 : D3D like
+         
+         adv = 0.0_dp
+         adv1 = 0.0_dp
 
          if (jav3 == 1) then ! vertical advection upwind implicit
             if (womegu(k) > 0.0_dp) then
@@ -264,7 +267,7 @@ contains
       gdxi = agp * dxi(LL)
 
       if (jarhoxu >= 2) then
-         gdxi = gdxi * rhomean / rhou(L)
+         gdxi = gdxi * rhomean / rhou(L) ! top layer rho!
       end if
 
       k1 = ln(1, LL)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/vertical_profile_u0.f90
@@ -45,7 +45,7 @@ contains
 
    subroutine vertical_profile_u0(dzu, womegu, Lb, Lt, kxL, LL)
       use precision, only: dp
-      use m_flow, only: kmxx, jafilter, u0, zws, javau, javau3onbnd, vicwwu, vicoww, jarhoxu, rhou, jawave, no_waves, jawavestokes, stokes_drift_2ndorder_visc_adve, flow_without_waves, ag, jahelmert, rhomean, s0, drop3d, hu, advi, adve, ru, fu
+      use m_flow, only: kmxx, jafilter, u0, javau, javau3onbnd, vicwwu, vicoww, jarhoxu, rhou, jawave, no_waves, jawavestokes, stokes_drift_2ndorder_visc_adve, flow_without_waves, ag, jahelmert, rhomean, s0, drop3d, hu, advi, adve, ru, fu
       use m_flowgeom, only: acl, ln, lnxi, iadv, yu, dxi, iadv_subgrid_weir, iadv_rajaratnam_weir, iadv_villemonte_weir, bob, teta
       use m_flowtimes, only: dti
       use m_waves, only: ustokes
@@ -53,7 +53,7 @@ contains
       use m_filter_data, only: ustar, itype
       implicit none
       integer :: Lb, Lt, kxL, LL
-      real(kind=dp) :: a(kmxx), b(kmxx), c(kmxx), d(kmxx), e(kmxx), dzu(kxL), womegu(kxL - 1), dzv(kmxx)
+      real(kind=dp) :: a(kmxx), b(kmxx), c(kmxx), d(kmxx), e(kmxx), dzu(kxL), womegu(kxL - 1)
 
       integer :: L, k, k1, k2
       real(kind=dp) :: dzLw, vstress, adv, adv1, tt, ustv, st2, agp, dzurho

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/compute_wave_forcing_rhs.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/compute_wave_forcing_rhs.f90
@@ -102,8 +102,9 @@ contains
          !
          if (kmx == 0) then
             call tauwave()
-            call xbeach_flow_bc()
          end if
+         !
+         call xbeach_flow_bc()
       end if
       !
       ! Uniform wave field

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
@@ -57,7 +57,7 @@ contains
       integer :: L, LL, Lb, Lt
       real(kind=dp) :: wavfx, wavfy, wavfbx, wavfby
       real(kind=dp) :: wavfu_loc, wavfbu_loc, twavL
-      real(kind=dp) :: wavfv_loc, wavfbv_loc, wavfmag, wavfbmag, wavfang, wavfbang
+      real(kind=dp) :: wavfv_loc, wavfbv_loc, wavfmag, force_scale, dztop
       real(kind=dp) :: fmax, ac1, ac2, hminlwi, rhoL, hminlw, gammaloc
 
       integer :: k1, k2
@@ -91,87 +91,114 @@ contains
             if (hu(L) <= epshu) then
                cycle
             end if
-            if (L > lnx1D) then
-               k1 = ln(1, L)
-               k2 = ln(2, L)
-               ac1 = acl(L)
-               ac2 = 1.0_dp - ac1
 
-               wavfx = ac1 * sxwav(k1) + ac2 * sxwav(k2)
-               wavfy = ac1 * sywav(k1) + ac2 * sywav(k2)
-
-               wavfbx = ac1 * sbxwav(k1) + ac2 * sbxwav(k2)
-               wavfby = ac1 * sbywav(k1) + ac2 * sbywav(k2)
-
-               twavL = ac1 * twav(k1) + ac2 * twav(k2)
-
-               ! limit forces
-               fmax = facmax * hu(L)**1.5 / max(0.1_dp, twavL)
-
-               ! projection in face-normal direction
-               wavfu_loc = wavfx * csu(L) + wavfy * snu(L)
-               wavfv_loc = -wavfx * snu(L) + wavfy * csu(L)
-               wavfbu_loc = wavfbx * csu(L) + wavfby * snu(L)
-               wavfbv_loc = -wavfbx * snu(L) + wavfby * csu(L)
-
-               ! Should be done on the vector norm, nt separate comps
-               wavfmag = min(hypot(wavfu_loc, wavfv_loc), fmax)
-               wavfbmag = min(hypot(wavfbu_loc, wavfbv_loc), fmax)
-               wavfang = atan2(wavfv_loc, wavfu_loc)
-               wavfbang = atan2(wavfbv_loc, wavfbu_loc) ! necessary?
-               wavfu_loc = wavfmag * cos(wavfang)
-               wavfv_loc = wavfmag * sin(wavfang)
-               wavfbu_loc = wavfbmag * cos(wavfbang)
-               wavfbv_loc = wavfbmag * sin(wavfbang)
-
-               wavfu(L) = wavfu_loc + wavfbu_loc
-               wavfv(L) = wavfv_loc + wavfbv_loc
+            ! Wave forcing is not applied to 1D links.
+            if (L <= lnx1D) then
+               cycle
             end if
-            !
-            wavfu(L) = wavfu(L) * min(huvli(L), hminlwi) / rhomean ! Dimensions [m/s^2]
-            wavfv(L) = wavfv(L) * min(huvli(L), hminlwi) / rhomean
-            !
+
+            k1 = ln(1, L)
+            k2 = ln(2, L)
+            ac1 = acl(L)
+            ac2 = 1.0_dp - ac1
+
+            ! Interpolate surface force to the link.
+            wavfx = ac1 * sxwav(k1) + ac2 * sxwav(k2)
+            wavfy = ac1 * sywav(k1) + ac2 * sywav(k2)
+
+            ! Add the depth-distributed body force.
+            wavfx = wavfx + ac1 * sbxwav(k1) + ac2 * sbxwav(k2)
+            wavfy = wavfy + ac1 * sbywav(k1) + ac2 * sbywav(k2)
+
+            twavL = max(ac1 * twav(k1) + ac2 * twav(k2), 0.1_dp)
+            fmax = facmax * hu(L)**1.5_dp / twavL
+
+            ! Project the combined force into link-normal and tangential directions.
+            wavfu_loc = wavfx * csu(L) + wavfy * snu(L)
+            wavfv_loc = -wavfx * snu(L) + wavfy * csu(L)
+
+            ! Limit the magnitude of the combined force vector.
+            wavfmag = hypot(wavfu_loc, wavfv_loc)
+            if (wavfmag > fmax) then
+               wavfu_loc = wavfu_loc * fmax / wavfmag
+               wavfv_loc = wavfv_loc * fmax / wavfmag
+            end if
+
+            ! Convert force [N/m2] to acceleration [m/s2].
+            wavfu(L) = wavfu_loc * min(huvli(L), hminlwi) / rhomean
+            wavfv(L) = wavfv_loc * min(huvli(L), hminlwi) / rhomean
          end do
-      else ! kmx>0
+      else ! kmx > 0
          do LL = 1, lnx
             if (hu(LL) <= epshu) then
                cycle
             end if
+
+            ! Keep the same policy as the 2D branch.
+            if (LL <= lnx1D) then
+               cycle
+            end if
+
             call getLbotLtop(LL, Lb, Lt)
             if (Lt < Lb) then
                cycle
             end if
+
             k1 = ln(1, LL)
             k2 = ln(2, LL)
-            ac1 = acL(LL)
+            ac1 = acl(LL)
             ac2 = 1.0_dp - ac1
-            !
+
             twavL = max(ac1 * twav(k1) + ac2 * twav(k2), 0.1_dp)
-            fmax = facmax * hu(LL)**1.5 / twavL
+            fmax = facmax * hu(LL)**1.5_dp / twavL
             rhoL = rhomean
-            !
-            ! Surface force, assign to top layer
-            !
+
+            ! Surface force at the link.
             wavfx = ac1 * sxwav(k1) + ac2 * sxwav(k2)
             wavfy = ac1 * sywav(k1) + ac2 * sywav(k2)
+
             wavfu_loc = csu(LL) * wavfx + snu(LL) * wavfy
             wavfv_loc = -snu(LL) * wavfx + csu(LL) * wavfy
-            wavfu(Lt) = sign(min(abs(wavfu_loc), fmax), wavfu_loc) / rhoL / max(hu(LL) - hu(Lt - 1), hminlw) ! top layer, as in D3D
-            wavfv(Lt) = sign(min(abs(wavfv_loc), fmax), wavfv_loc) / rhoL / max(hu(LL) - hu(Lt - 1), hminlw) ! this limitation only works in sigma layers
-            !
-            ! Body forces, uniform over depth
-            !
-            wavfx = ac1 * sbxwav(k1) + ac2 * sbxwav(k2)
-            wavfy = ac1 * sbywav(k1) + ac2 * sbywav(k2)
-            wavfu_loc = csu(LL) * wavfx + snu(LL) * wavfy
-            wavfv_loc = -snu(LL) * wavfx + csu(LL) * wavfy
+
+            ! Depth-distributed body force at the link.
+            wavfbx = ac1 * sbxwav(k1) + ac2 * sbxwav(k2)
+            wavfby = ac1 * sbywav(k1) + ac2 * sbywav(k2)
+
+            wavfbu_loc = csu(LL) * wavfbx + snu(LL) * wavfby
+            wavfbv_loc = -snu(LL) * wavfbx + csu(LL) * wavfby
+
+            ! Limit the magnitude of the combined surface-plus-body force.
+            wavfmag = hypot( &
+                      wavfu_loc + wavfbu_loc, &
+                      wavfv_loc + wavfbv_loc)
+
+            force_scale = 1.0_dp
+            if (wavfmag > fmax) then
+               force_scale = fmax / wavfmag
+            end if
+
+            ! Apply the same scale to both contributions so their relative
+            ! magnitude and direction are preserved.
+            wavfu_loc = force_scale * wavfu_loc
+            wavfv_loc = force_scale * wavfv_loc
+            wavfbu_loc = force_scale * wavfbu_loc
+            wavfbv_loc = force_scale * wavfbv_loc
+
+            ! Surface force: apply to the top layer.
+            dztop = hu(LL) - hu(Lt - 1)
+
+            wavfu(Lt) = wavfu_loc / (rhoL * max(dztop, hminlw))
+            wavfv(Lt) = wavfv_loc / (rhoL * max(dztop, hminlw))
+
+            ! Body force: distribute uniformly over the water column.
             do L = Lb, Lt
-               wavfu(L) = wavfu(L) + sign(min(abs(wavfu_loc), fmax), wavfu_loc) / rhoL / max(hu(LL), hminlw)
-               wavfv(L) = wavfv(L) + sign(min(abs(wavfv_loc), fmax), wavfv_loc) / rhoL / max(hu(LL), hminlw)
+               wavfu(L) = wavfu(L) + wavfbu_loc &
+                          / (rhoL * max(hu(LL), hminlw))
+               wavfv(L) = wavfv(L) + wavfbv_loc &
+                          / (rhoL * max(hu(LL), hminlw))
             end do
          end do
-      end if
-      !
+      end if !
       wavfu = fforc * wavfu
       wavfv = fforc * wavfv
 1234  continue

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
@@ -50,7 +50,6 @@ contains
       use m_get_Lbot_Ltop, only: getlbotltop
       use m_flow, only: hu, huvli, wavfu, wavfv, rhomean, kmx
       use m_physcoef, only: sag
-      use precision_basics, only: comparereal
 
       implicit none
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/setwavfu.f90
@@ -45,17 +45,18 @@ contains
       use precision, only: dp
       use m_flowparameters, only: jawaveforces, wave_forces_off, jawave, wave_swan_online, wave_nc_offline, wave_surfbeat, epshu
       use m_flowgeom, only: lnx, lnx1d, ln, acl, csu, snu
-      use m_waves, only: m_waves_hminlw => hminlw, gammax, facmax, sxwav, sywav, sbxwav, sbywav, twav, hwav
+      use m_waves, only: m_waves_hminlw => hminlw, gammax, facmax, sxwav, sywav, sbxwav, sbywav, twav, fforc
       use m_xbeach_data, only: xb_hminlw => hminlw, gammaxxb
       use m_get_Lbot_Ltop, only: getlbotltop
       use m_flow, only: hu, huvli, wavfu, wavfv, rhomean, kmx
       use m_physcoef, only: sag
+      use precision_basics, only: comparereal
 
       implicit none
 
       integer :: L, LL, Lb, Lt
       real(kind=dp) :: wavfx, wavfy, wavfbx, wavfby
-      real(kind=dp) :: wavfu_loc, wavfbu_loc, twavL, hwavL
+      real(kind=dp) :: wavfu_loc, wavfbu_loc, twavL
       real(kind=dp) :: wavfv_loc, wavfbv_loc, wavfmag, wavfbmag, wavfang, wavfbang
       real(kind=dp) :: fmax, ac1, ac2, hminlwi, rhoL, hminlw, gammaloc
 
@@ -145,7 +146,6 @@ contains
             ac1 = acL(LL)
             ac2 = 1.0_dp - ac1
             !
-            hwavL = max(ac1 * hwav(k1) + ac2 * hwav(k2), 0.01_dp)
             twavL = max(ac1 * twav(k1) + ac2 * twav(k2), 0.1_dp)
             fmax = facmax * hu(LL)**1.5 / twavL
             rhoL = rhomean
@@ -159,34 +159,6 @@ contains
             wavfu(Lt) = sign(min(abs(wavfu_loc), fmax), wavfu_loc) / rhoL / max(hu(LL) - hu(Lt - 1), hminlw) ! top layer, as in D3D
             wavfv(Lt) = sign(min(abs(wavfv_loc), fmax), wavfv_loc) / rhoL / max(hu(LL) - hu(Lt - 1), hminlw) ! this limitation only works in sigma layers
             !
-            ! The following is pretty inaccurate for limited nr of layers:
-            !
-            !wavfuL    = 4d0*sign(min(abs(wavfu_loc), fmax), wavfu_loc)/hwavL
-            !wavfvL    = 4d0*sign(min(abs(wavfv_loc), fmax), wavfv_loc)/hwavL          ! hwavL/4 is integral over 0.5*hwavL waterdepth of linear decrease
-         !! Check if first layer is thicker than 0.5*hrms
-         !! In that case, distribute over first layer
-            !dzu=hu(Lt)-hu(Lt-1)
-            !halfwav=0.5*hwavL
-         !!
-            !if (dzu > halfwav) then
-            !   wavfu(Lt) = wavfuL*0.25d0*hwavL/rhoL/dzu                               ! division by 0.5*hrms done above
-            !   wavfv(Lt) = wavfvL*0.25d0*hwavL/rhoL/dzu
-            !else
-            !zw=0.5d0*dzu
-            !do L=Lt,Lb+1,-1
-            !   if (zw<=halfwav) then
-            !      wavfu(L) = wavfuL*(1d0-2d0*zw/hwavL)/rhoL                                     ! division by 0.5*hrms done above
-            !      wavfv(L) = wavfvL*(1d0-2d0*zw/hwavL)/rhoL
-            !      zw = zw + 0.5*(hu(L)-hu(L-2))
-            !   elseif (zw>halfwav .and. hu(L)>(hu(LL)-halfwav)) then                        ! partial layer
-            !      cc = 0.5*(hu(L)+(hu(LL)-halfwav))                                           ! replaced layer center
-            !      zw = hu(LL)-cc                                                                ! depth below surface
-            !      wavfu(L) = wavfuL*(1d0-zw/halfwav)/rhoL                                     ! contribution over partial layer
-            !      wavfv(L) = wavfvL*(1d0-zw/halfwav)/rhoL
-            !   endif
-            !enddo
-            !endif
-            !
             ! Body forces, uniform over depth
             !
             wavfx = ac1 * sbxwav(k1) + ac2 * sbxwav(k2)
@@ -199,6 +171,9 @@ contains
             end do
          end do
       end if
+      !
+      wavfu = fforc * wavfu
+      wavfv = fforc * wavfv
 1234  continue
       return
    end subroutine setwavfu

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/surfbeat/xbeach_math_tools.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/surfbeat/xbeach_math_tools.F90
@@ -431,6 +431,9 @@ contains
          if (stat /= 0) then
             return
          end if
+         ctmp = (0.0_fftkind, 0.0_fftkind)
+         sine = 0.0_fftkind
+         cosine= 0.0_fftkind
          call transform()
          deallocate (sine, cosine, STAT=stat)
          if (stat /= 0) then
@@ -440,6 +443,7 @@ contains
          if (stat /= 0) then
             return
          end if
+         perm = 0
          call permute()
          deallocate (perm, ctmp, STAT=stat)
          if (stat /= 0) then
@@ -447,9 +451,13 @@ contains
          end if
       else
          allocate (ctmp(maxfactor), sine(maxfactor), cosine(maxfactor))
+         ctmp = (0.0_fftkind, 0.0_fftkind)
+         sine = 0.0_fftkind
+         cosine= 0.0_fftkind
          call transform()
          deallocate (sine, cosine)
          allocate (perm(nperm))
+         perm = 0
          call permute()
          deallocate (perm, ctmp)
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/surfbeat/xbeachwaves.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/surfbeat/xbeachwaves.f90
@@ -237,7 +237,7 @@ contains
       ARC = readkey_int(md_surfbeatfile, 'ARC', 1, 0, 1)
       order = readkey_dbl(md_surfbeatfile, 'order', 2.0_dp, 1.0_dp, 2.0_dp)
       freewave = readkey_int(md_surfbeatfile, 'freewave', 0, 0, 1)
-      !epsi        = readkey_dbl (md_surfbeatfile,'epsi',     -1.d0,          -1.d0,   0.2d0   )
+      !epsi        = readkey_dbl (md_surfbeatfile,'epsi',     -1._dp,          -1._dp,   0.2_dp   )
       hminlw = readkey_dbl(md_surfbeatfile, 'hmin', 0.2_dp, 0.001_dp, 1.0_dp)
       allocate (allowednames(2), oldnames(0))
       allowednames = ['abs_1d', 'abs_2d']
@@ -321,13 +321,13 @@ contains
       !if (windmodel .eq. 1) then
       !   call writelog('l','','--------------------------------')
       !   call writelog('l','','Wind source parameters: ')
-      !   mwind       = readkey_dbl (md_surfbeatfile,'mwind',   1.d0,    0.5d0,   1.d0)
+      !   mwind       = readkey_dbl (md_surfbeatfile,'mwind',   1._dp,    0.5_dp,   1._dp)
       !   jawsource   = readkey_int (md_surfbeatfile,'windsource',   0,    0,   1, required=(swave==1 .and. jawind==1), strict=.true.)
       !   jagradcg    = readkey_int (md_surfbeatfile,'jagradcg',   1,    0,   1, required=((swave==1 .and. jawind==1) .and. jawsource==1), strict=.true.)
       !   advecmod    = readkey_int (md_surfbeatfile,'advecmod',    1,         1,      2)
-      !   ndissip     = readkey_dbl (md_surfbeatfile,'ndissip',  3.d0,         1.d0,      10.d0)
-      !   coefdispT   = readkey_dbl (md_surfbeatfile,'coefdispT',  3.5d0,         0.d0,      1000.d0)
-      !   coefdispk   = readkey_dbl (md_surfbeatfile,'coefdispk',  1.d0,         0.d0,      1000.d0)
+      !   ndissip     = readkey_dbl (md_surfbeatfile,'ndissip',  3._dp,         1._dp,      10._dp)
+      !   coefdispT   = readkey_dbl (md_surfbeatfile,'coefdispT',  3.5_dp,         0._dp,      1000._dp)
+      !   coefdispk   = readkey_dbl (md_surfbeatfile,'coefdispk',  1._dp,         0._dp,      1000._dp)
       !endif
       !
       !
@@ -384,7 +384,7 @@ contains
          end if
       end if
       !
-      !facmax = 0.25d0*sqrt(ag)*rhomean*gamma**2
+      !facmax = 0.25_dp*sqrt(ag)*rhomean*gamma**2
       !
       !
       ! Wave-current interaction with non-stationary waves still experimental
@@ -471,7 +471,7 @@ contains
          !if (windmodel.eq.0) then
          do k = 1, ndx
             sigmwav(k) = sum(sigt(:, k), dim=1) / real(ntheta, kind=dp)
-            L0(k) = 2 * pi * ag / (sigmwav(k)**2)
+            L0(k) = 2_dp * pi * ag / (sigmwav(k)**2)
             L1(k) = L0(k)
             Ltemp(k) = L0(k)
          end do
@@ -557,10 +557,10 @@ contains
       !if ( windmodel.eq.1) then
       !   if (jawsource.eq.1) then
       !   !define source term coefficients
-      !      CE1 = 8d0/(aa1*aa1*bb1 ) * (16d0/(aa1*aa1 ) )**(1d0/(2d0* bb1) -1d0 )
-      !      CE2 = 1d0/(2d0* bb1) -1d0
-      !      CT1 = 1d0/(aa2*bb2 ) * (1d0/(aa2 ) )**(1d0/bb2 -1d0 )
-      !      CT2 = 1d0/bb2 -1d0
+      !      CE1 = 8_dp/(aa1*aa1*bb1 ) * (16_dp/(aa1*aa1 ) )**(1_dp/(2_dp* bb1) -1_dp )
+      !      CE2 = 1_dp/(2_dp* bb1) -1_dp
+      !      CT1 = 1_dp/(aa2*bb2 ) * (1_dp/(aa2 ) )**(1_dp/bb2 -1_dp )
+      !      CT2 = 1_dp/bb2 -1_dp
       !   endif
       !   !map wind field to cell centers
       !   call xbeach_map_wind_field(wx, wy, mwind, wmagcc, windspreadfac)
@@ -748,7 +748,7 @@ contains
 
       if (single_dir == 1) then
          do itheta = 1, ntheta_s
-            thetabin_s(itheta) = mod(thetamin + dtheta_s / 2.0 + dtheta_s * (itheta - 1), 2.0_dp * pi)
+            thetabin_s(itheta) = mod(thetamin + dtheta_s / 2.0_dp + dtheta_s * (itheta - 1), 2.0_dp * pi)
          end do
 
          do itheta = 1, ntheta_s
@@ -909,7 +909,7 @@ contains
       allocate (gammax_correct(1:ndx), stat=ierr)
 
       xb_started = 1
-      !ee_eps = 0.00001d0
+      !ee_eps = 0.00001_dp
       !tt_eps = waveps    !important to limit wave celerities to 1 in case of cells for which hs<epshu
 
       hh = 0.0_dp
@@ -917,9 +917,9 @@ contains
       wete = 0
       drr = 0.0_dp
       horadvec = 0.0_dp
-      !horadvec2=0d0
+      !horadvec2 = 0.0_dp
       thetaadvec = 0.0_dp
-      !thetaadvec2=0d0
+      !thetaadvec2 = 0.0_dp
       RH = 0.0_dp
       gammax_correct = .false.
       !
@@ -1096,7 +1096,7 @@ contains
 
       !if (windmodel.eq.1) then
       !  ! wave period depth limitation
-      !   call xbeach_wave_compute_period_depth_limitation( 1.d0/8.d0*rhomean*ag*(gammaxxb*hh**2) , Tdeplim)
+      !   call xbeach_wave_compute_period_depth_limitation( 1._dp/8._dp*rhomean*ag*(gammaxxb*hh**2) , Tdeplim)
       !   do itheta=1,ntheta
       !      tt1(itheta,:) = min(tt1(itheta,:) , Tdeplim )
       !   enddo
@@ -1110,10 +1110,10 @@ contains
       !   if (jawsource.eq.1) then
       !      call xbeach_windsource(ee1, E, tt1, sigmwav , cgwavt, cgwav, hh, dtmaxwav, wsorE, wsorT,egradcg,SwE,SwT)
       !   else
-      !       wsorE=0.d0
-      !       wsorT=0.d0
-      !       SwE=0.d0
-      !       SwT=0.d0
+      !       wsorE=0._dp
+      !       wsorT=0._dp
+      !       SwE=0._dp
+      !       SwT=0._dp
       !   endif
       !endif ! windmodel
 
@@ -1142,20 +1142,20 @@ contains
       !            tt1(itheta,k) = tt1(itheta, k) + min( dtmaxwav * (wsorT(itheta, k) -  ddT(k) ) , tt1(itheta, k) )
       !            !
       !            if(roller==1) then
-      !                  drr(itheta, k) = 2*ag*BR(k)*max(rr(itheta, k),0.0d0)/ cwav(k)
+      !                  drr(itheta, k) = 2*ag*BR(k)*max(rr(itheta, k),0.0_dp)/ cwav(k)
       !                  rr(itheta, k)=rr(itheta, k)+dtmaxwav*(ddlok(itheta, k) -drr(itheta, k))
       !            else if (roller==0) then
-      !               rr(itheta, k)  = 0.0d0
-      !               drr(itheta, k) = 0.0d0
+      !               rr(itheta, k)  = 0.0_dp
+      !               drr(itheta, k) = 0.0_dp
       !            endif
       !            !
       !            ee1(itheta, k)    = max(ee1(itheta, k),ee_eps)
       !            tt1(itheta, k)    = max(tt1(itheta, k), tt_eps)
-      !            rr(itheta, k)     = max(rr(itheta, k),0.0d0)
+      !            rr(itheta, k)     = max(rr(itheta, k),0.0_dp)
       !         else
       !            ee1(itheta, k)    = ee_eps
       !            tt1(itheta, k)    = tt_eps
-      !            rr(itheta, k)     = 0.0d0
+      !            rr(itheta, k)     = 0.0_dp
       !         end if
       !      end do
       !    end do
@@ -1282,7 +1282,7 @@ contains
          !
          ! Correct roller dissipation, check with Dano
          !where (hs>epshu)
-         !   DR = 2d0*ag*beta1*R/cwav
+         !   DR = 2_dp*ag*beta1*R/cwav
          !endwhere
       end if
 
@@ -1407,7 +1407,7 @@ contains
             k2 = ln(2, L)
             Fx(L) = (acL(L) * Fx_cc(k1) + (1.0_dp - acL(L)) * Fx_cc(k2))
             Fy(L) = (acL(L) * Fy_cc(k1) + (1.0_dp - acL(L)) * Fy_cc(k2))
-            !rhoL     = ( acL(L)*rho(k1) + (1d0-acL(L))*rho(k2) )
+            !rhoL = (acL(L) * rho(k1) + (1.0_dp - acL(L)) * rho(k2))
             rhoL = rhomean
             wavfu(L) = (Fx(L) * csu(L) + Fy(L) * snu(L)) / (rhoL * max(hu(L), hminlw))
             wavfv(L) = (-Fx(L) * snu(L) + Fy(L) * csu(L)) / (rhoL * max(hu(L), hminlw))
@@ -1585,7 +1585,7 @@ contains
          where (km > 0.01_dp)
             cwav = sigmwav / km
             cgwav = cwav * (0.5_dp + arg / sinh(2 * arg)) * sqrt(fac) ! &  to include more
-            !                                   + km*(H/2)**2*sqrt(max(par%g*km*tanh(arg),0.001d0))/sqrt(max(fac,0.001d0)) ! include wave steepness
+            !                                   + km*(H/2)**2*sqrt(max(par%g*km*tanh(arg),0.001_dp))/sqrt(max(fac,0.001_dp)) ! include wave steepness
             nwav = 0.5_dp + km * hh / sinh(2 * max(km, 0.00001_dp) * hh)
          elsewhere
             cwav = sqrt(ag * epshu)
@@ -1712,7 +1712,8 @@ contains
       logical :: isRecomputed
 
       integer :: kb, ki, Lb, nw
-      integer :: LL1, LL2, n, lunfil
+      integer :: LL1, LL2, n
+      integer, save :: lunfil ! used for trim(instat) == 'stat_table'
 
       ierror = 1
       if (.not. allocated(dist)) then
@@ -2088,7 +2089,7 @@ contains
                end if
 
                !if (windmodel .eq. 1) then
-               !   zbndw(:,n)=max(e01*E1/max(Emean,0.000001d0)*min(time0/taper,1.d0),Eini)
+               !   zbndw(:,n)=max(e01*E1/max(Emean,0.000001_dp)*min(time0/taper,1._dp),Eini)
                !else
                zbndw(:, n) = e01 * E1 / max(Emean, 0.000001_dp) * min(time0 / taper, 1.0_dp)
                !endif
@@ -2271,7 +2272,7 @@ contains
       break = trim(break)
 
       if (break == 'roelvink1') then ! Dissipation according to Roelvink (1993)
-         !H   = sqrt(8.d0*E/rhomean/ag)
+         !H   = sqrt(8._dp*E/rhomean/ag)
          H = hwav
          hr = hhw
          kmr = min(max(kwav, 0.01_dp), 100.0_dp)
@@ -2311,7 +2312,7 @@ contains
             gam = gamma
          end if
 
-         !H   = sqrt(8.d0/rhomean/ag*E)
+         !H   = sqrt(8._dp/rhomean/ag*E)
          H = hwav
          Hb = tanh(gam * kh / 0.88_dp) * (0.88_dp / max(kwav, 1.0e-10_dp))
          R = Hb / max(H, 0.00001_dp)
@@ -2320,7 +2321,7 @@ contains
          D = 0.25_dp * alpha * f * rhomean * ag * (Hb**2 + H**2) * Qb
 
       elseif (break == 'roelvink2') then
-         !H   = sqrt(8.d0*E/rhomean/ag)
+         !H   = sqrt(8._dp*E/rhomean/ag)
          H = hwav
          hr = hhw
          hh = max(hs, waveps)
@@ -2341,7 +2342,7 @@ contains
             D = D / Trep * H / hh
          end if
       elseif (trim(break) == 'roelvink_daly') then
-         !H   = sqrt(8.d0*E/rhomean/ag)
+         !H   = sqrt(8._dp*E/rhomean/ag)
          H = hwav
          call advec_upw_bulk(thetamean, Qb, cwav, Qb_advec) ! first order upwind, with mean direction
          do k = 1, ndxi
@@ -2362,7 +2363,7 @@ contains
          end if
 
       elseif (break == 'janssen') then ! Dissipation according to Janssen and Battjes (2007)
-         !H   = sqrt(8.d0*E/rhomean/ag)
+         !H   = sqrt(8._dp*E/rhomean/ag)
          H = hwav
          if (wci /= 0) then
             f = sigmwav / 2.0_dp / pi
@@ -2621,13 +2622,13 @@ contains
             do itheta = 2, ntheta - 2
                ctheta_between = 0.5_dp * (veloc(itheta, k) + veloc(itheta + 1, k))
                if (ctheta_between > 0) then
-                  eeup = 1.5_dp * quan(itheta, k) - .5 * quan(itheta - 1, k)
+                  eeup = 1.5_dp * quan(itheta, k) - 0.5_dp * quan(itheta - 1, k)
                   if (eeup < 0.0_dp) then
                      eeup = quan(itheta, k)
                   end if
                   fluxtheta(itheta) = eeup * ctheta_between
                else
-                  eeup = 1.5_dp * quan(itheta + 1, k) - .5 * quan(itheta + 2, k)
+                  eeup = 1.5_dp * quan(itheta + 1, k) - 0.5_dp * quan(itheta + 2, k)
                   if (eeup < 0.0_dp) then
                      eeup = quan(itheta + 1, k)
                   end if
@@ -2640,7 +2641,7 @@ contains
             if (ctheta_between > 0) then
                fluxtheta(itheta) = quan(itheta, k) * ctheta_between
             else
-               eeup = 1.5_dp * quan(itheta + 1, k) - .5 * quan(itheta + 2, k)
+               eeup = 1.5_dp * quan(itheta + 1, k) - 0.5_dp * quan(itheta + 2, k)
                if (eeup < 0.0_dp) then
                   eeup = quan(itheta + 1, k)
                end if
@@ -2650,7 +2651,7 @@ contains
             itheta = ntheta - 1 ! only compute for itheta==ntheta-1
             ctheta_between = .5 * (veloc(itheta + 1, k) + veloc(itheta, k))
             if (ctheta_between > 0) then
-               eeup = 1.5_dp * quan(itheta, k) - .5 * quan(itheta - 1, k)
+               eeup = 1.5_dp * quan(itheta, k) - 0.5_dp * quan(itheta - 1, k)
                if (eeup < 0.0_dp) then
                   eeup = quan(itheta, k)
                end if
@@ -3354,7 +3355,7 @@ contains
       !if (windmodel .eq. 0) then
       factime = 1.0_dp / cats / Trep * dts
       !else
-      !   factime = 1d0/cats/minval(sigmwav)/2d0/pi*dts
+      !   factime = 1_dp/cats/minval(sigmwav)/2_dp/pi*dts
       !endif
 
 !  compute boundary-averaged velocities
@@ -3755,13 +3756,13 @@ contains
 !   if (.not.allocated(wycc)) allocate(wycc(1:ndx), stat = ierr)
 !   if (.not.allocated(wdir))    allocate(wdir(1:ndx),              stat = ierr)
 !
-!   wxcc=0d0
-!   wycc=0d0
-!   wdir=0d0
-!   wmagcc=0d0
-!   dist2=0d0
-!   dist0=0d0
-!   windspreadfac=0d0
+!   wxcc=0_dp
+!   wycc=0_dp
+!   wdir=0_dp
+!   wmagcc=0_dp
+!   dist2=0_dp
+!   dist0=0_dp
+!   windspreadfac=0_dp
 !
 !   do L = 1, lnx                                                              ! interpolate face values to cell centered values
 !      k1 = ln(1,L); k2 = ln(2,L)
@@ -3776,15 +3777,15 @@ contains
 !   do k = 1, ndx
 !      do itheta = 1,ntheta
 !       dist2(itheta, k)=(cos(thetabin(itheta)-wdir(k)))**mwind
-!         if(cos(thetabin(itheta)-wdir(k))<0.d0) then
-!          dist2(itheta,k)=0.0d0
+!         if(cos(thetabin(itheta)-wdir(k))<0._dp) then
+!          dist2(itheta,k)=0.0_dp
 !         end if
 !      end do
-!    if (sum(dist2(:,k))>0.d0) then
+!    if (sum(dist2(:,k))>0._dp) then
 !       dist0 = dist2(:,k)
 !       windspreadfac(:,k) = (dist0/sum(dist0))/dtheta
 !    else
-!       windspreadfac(:,k)=0.d0
+!       windspreadfac(:,k)=0._dp
 !    endif
 !   end do
 !
@@ -3839,9 +3840,9 @@ contains
 !   ierr = 1
 !
 !   allocate( gradcg( 1:ntheta, 1:ndx), stat = ierr)
-!   fE=0d0; fT=0d0; dE=0d0; dT=0d0;
-!   wsorE=0d0; wsorT=0d0;
-!   gradcg=0d0; tgradcg=0d0; gradcg=0d0;
+!   fE=0_dp; fT=0_dp; dE=0_dp; dT=0_dp;
+!   wsorE=0_dp; wsorT=0_dp;
+!   gradcg=0_dp; tgradcg=0_dp; gradcg=0_dp;
 !
 !
 !   ! velocity gradient operator
@@ -3849,7 +3850,7 @@ contains
 !
 !   do k = 1, ndxi
 !
-!        dEful = (Tful / (4.0d0 * pi)) / (CE1 * Eful ** CE2) !d
+!        dEful = (Tful / (4.0_dp * pi)) / (CE1 * Eful ** CE2) !d
 !
 !        do itheta = 1, ntheta
 !
@@ -3874,22 +3875,22 @@ contains
 !           wsorEdlss = min(dE , dEful)
 !           wsorTdlss = dT !max(dT,dTful) !windspreadfac(itheta,k)  * dT * dtheta !max(dT , dTful)
 !
-!           SwE(k)= max(wmagcc(k)**3 * rhomean * wsorEdlss, 0.d0) !
-!           SwT(k)= max(wsorTdlss , 0.d0) !
+!           SwE(k)= max(wmagcc(k)**3 * rhomean * wsorEdlss, 0._dp) !
+!           SwT(k)= max(wsorTdlss , 0._dp) !
 !
 !           !distribute growth over the wave bins, add gradcg component and make dimensional
 !
 !            if (jagradcg .eq. 1) then
-!              ! egradcg = max(-windspreadfac(itheta,k) * ee0(itheta,k) / windspreadfac(itheta,k) * bai(k) * gradcg(itheta,k) , 0d0) ! * Etaper  perhaps use gradcg(nodal)?
-!              egradcg(itheta,k) = max(- ee1(itheta, k) * bai(k) * gradcg(itheta,k) , 0.d0)!
-!              !tgradcg = max(-windspreadfac(itheta,k) * twopi / sigmwav(k) * bai(k) * gradcg(itheta,k)  , 0d0)
+!              ! egradcg = max(-windspreadfac(itheta,k) * ee0(itheta,k) / windspreadfac(itheta,k) * bai(k) * gradcg(itheta,k) , 0_dp) ! * Etaper  perhaps use gradcg(nodal)?
+!              egradcg(itheta,k) = max(- ee1(itheta, k) * bai(k) * gradcg(itheta,k) , 0._dp)!
+!              !tgradcg = max(-windspreadfac(itheta,k) * twopi / sigmwav(k) * bai(k) * gradcg(itheta,k)  , 0_dp)
 !            else
-!                egradcg(itheta,k) = 0.d0
-!                !tgardcg = 0.d0
+!                egradcg(itheta,k) = 0._dp
+!                !tgardcg = 0._dp
 !           endif
 !
-!           wsorE(itheta,k) = max(windspreadfac(itheta,k) * SwE(k)   + egradcg(itheta,k), 0.d0 )
-!           wsorT(itheta,k) = max(windspreadfac(itheta,k) * dtheta * SwT(k) , 0.d0 )
+!           wsorE(itheta,k) = max(windspreadfac(itheta,k) * SwE(k)   + egradcg(itheta,k), 0._dp )
+!           wsorT(itheta,k) = max(windspreadfac(itheta,k) * dtheta * SwT(k) , 0._dp )
 !
 !        enddo
 !
@@ -3924,16 +3925,16 @@ contains
 !
 !   integer                                                  :: nwalls
 !
-!   gradcg = 0d0
-!   velocL = 0d0
-!   cwuL   = 0d0
+!   gradcg = 0_dp
+!   velocL = 0_dp
+!   cwuL   = 0_dp
 !
 !   do L  = 1,lnx                                                              ! upwind (supq) + limited high order (dsq), loop over link
 !        k1  = ln(1,L) ; k2 = ln(2,L)                                          ! linker en rechtercelnr geassocieerd aan de links
 !
 !        do itheta = 1,ntheta
 !
-!            velocL = acL(L)*veloc(itheta,k1) + (1d0-acL(L))*veloc(itheta,k2)
+!            velocL = acL(L)*veloc(itheta,k1) + (1_dp-acL(L))*veloc(itheta,k2)
 !
 !            cwuL    = velocL * wu(L) * ( csu(L)*csx(itheta) + snu(L)*snx(itheta) )   ! *au(L)   met cwi: u1(L) + cg*( csu(L)*csx(itheta) + snu(L)*snx(itheta) )
 !                                                                                     ! inproduct cgx*csu+cgy*snu
@@ -3994,7 +3995,7 @@ contains
 !   real(kind=dp), dimension(ndx)        , intent(in)  :: kwav
 !   real(kind=dp), dimension(ndx)        , intent(out) :: DtotT
 !
-!   DtotT = - coefdispT * tanh(coefdispk * kwav) * 1.d0 /(1.d0 -ndissip) * (twopi) / sigmwav / sigmwav * cgwav * kwav / E * Df
+!   DtotT = - coefdispT * tanh(coefdispk * kwav) * 1._dp /(1._dp -ndissip) * (twopi) / sigmwav / sigmwav * cgwav * kwav / E * Df
 !
 !1234 continue
 !   return
@@ -4019,8 +4020,8 @@ contains
 !
 !   allocate(Edls(1:ndx), Tdls(1:ndx), stat = ierr)
 !
-!   Edls=ag / rhomean / wmagcc**4d0 * E
-!   Tdls=aa2*(16d0* Edls / (aa1*aa1) )**(bb2/(2*bb1))
+!   Edls=ag / rhomean / wmagcc**4_dp * E
+!   Tdls=aa2*(16_dp* Edls / (aa1*aa1) )**(bb2/(2*bb1))
 !   Tmaxdep = wmagcc * Tdls / ag
 !
 !1234 continue
@@ -4052,16 +4053,16 @@ contains
 !
 !   integer                                                :: nwalls
 !
-!   advec = 0d0
+!   advec = 0_dp
 !   do L  = 1,lnx                                                              ! upwind (supq) + limited high order (dsq), loop over link
 !        k1  = ln(1,L) ; k2 = ln(2,L)                                       ! linker en rechtercelnr geassocieerd aan de links
 !
 !        do itheta = 1,ntheta
-!            velocL  = acL(L)*veloc(itheta,k1) + (1d0-acL(L))*veloc(itheta,k2)
+!            velocL  = acL(L)*veloc(itheta,k1) + (1_dp-acL(L))*veloc(itheta,k2)
 !            cwuL    = velocL*( csu(L)*csx(itheta) + snu(L)*snx(itheta) )   ! *au(L)   met cwi: u1(L) + cg*( csu(L)*csx(itheta) + snu(L)*snx(itheta) )
 !                                                                           ! inproduct cgx*csu+cgy*snu
 !            if (cwuL > 0) then                                              !   ->      ds1   ds2
-!                k = k1 ; kd = k2 ; is =  1 ; half = 1d0 - acl(L) ; ip = 0   !   ->   ku     k     kd
+!                k = k1 ; kd = k2 ; is =  1 ; half = 1_dp - acl(L) ; ip = 0   !   ->   ku     k     kd
 !            else                                                            !   <-      ds2   ds1
 !                k = k2 ; kd = k1 ; is = -1 ; half = acl(L)       ; ip = 3   !   <-   kd     k     ku
 !            endif                                                           ! acL = linkse dx fractie van afstand tussen flownodes (slide 83)
@@ -4087,7 +4088,7 @@ contains
 !
 !                    sl3 = slnup(3+ip,L)
 !                    cf  =  dtmaxwav*abs(cwuL)*dxi(L)
-!                    cf  =  half*max( 0d0,1d0-cf )
+!                    cf  =  half*max( 0_dp,1_dp-cf )
 !                    ds2  =  quant(itheta,kd) - quant(itheta,k)        ! ds1 = voorlopende slope, ds2 = eigen slope
 !                    ds1  = (quant(itheta,k)  - waku )*sl3
 !
@@ -4180,12 +4181,12 @@ contains
 !   do k=1,ndxi
 !      if(hdisp(k).ge.waveps) then
 !          do itheta = 1,ntheta
-!             if (2*pi/L0t(itheta,k)*hdisp(k) > 5d0) then
+!             if (2*pi/L0t(itheta,k)*hdisp(k) > 5_dp) then
 !                 Ltempt(itheta,k) = L0t(itheta,k)
 !              else
-!                 !Ltempt(k) = (2d0*pi*ag/(sigt(itheta,k)**2))*(1-exp(-(sigt(itheta,k)*sqrt(hdisp(k)/ag))**(5d0/2d0)))**(2d0/5d0)
+!                 !Ltempt(k) = (2_dp*pi*ag/(sigt(itheta,k)**2))*(1-exp(-(sigt(itheta,k)*sqrt(hdisp(k)/ag))**(5_dp/2_dp)))**(2_dp/5_dp)
 !                 Ltempt(itheta,k) = iteratedispersion(L0t(itheta,k),Ltempt(itheta,k),pi,hdisp(k))
-!                 if (Ltempt(itheta,k)<0.d0) then   ! this is an error from iteratedispersion
+!                 if (Ltempt(itheta,k)<0._dp) then   ! this is an error from iteratedispersion
 !                    Ltempt(itheta,k) = -Ltempt(itheta,k)
 !                    call writelog('lws','','Warning: no convergence in dispersion relation iteration at t = ', &
 !                       time0)
@@ -4214,8 +4215,8 @@ contains
 !       do itheta=1,ntheta
 !         kwavt(itheta,k)  = 2*pi/max(L1t(itheta,k),waveps)
 !         cwavt(itheta,k)  = sigt(itheta,k)/kwavt(itheta,k)
-!         kh   = min(kwavt(itheta,k)*hdisp(k),10.0d0)
-!         nwavt(itheta,k)=0.5d0+kh/max(sinh(2d0*kh),waveps)
+!         kh   = min(kwavt(itheta,k)*hdisp(k),10.0_dp)
+!         nwavt(itheta,k)=0.5_dp+kh/max(sinh(2_dp*kh),waveps)
 !         cgwavt(itheta,k)=cwavt(itheta,k)*nwavt(itheta,k)
 !      enddo
 !   end do
@@ -4224,7 +4225,7 @@ contains
 !      hh=s1(k)-bl(k)
 !      if (hh<epshu) then
 !         do itheta=1,ntheta
-!            kwavt(itheta,k)=0d0
+!            kwavt(itheta,k)=0_dp
 !         enddo
 !      endif
 !   enddo
@@ -4369,7 +4370,7 @@ contains
          end do
       case (callTypeDirections)
          ! bc vary along the boundary: project to links and then to corners
-         ! flownode2corner does not work here, as inner domain cell centers are 0d0 or have old value
+         ! flownode2corner does not work here, as inner domain cell centers are 0_dp or have old value
          ! values come from wave_bc: ee_s(ntheta_s,nbndw)
          !
          do n = 1, nbndw
@@ -4896,7 +4897,7 @@ contains
       integer, dimension(:, :), allocatable :: indx
       integer :: niter
       integer :: sweep, k, iter, count, k1, k2, ierr
-      real(dp) :: Afac, Bfac, Cfac, Drst, percok
+      real(dp) :: Afac, Bfac, Cfac, cfac_lim, Drst, percok
       real(dp) :: x1, x2, xk, y1, y2, yk
       real(dp) :: costh1, costh2, costhk, sinth1, sinth2, sinthk
       real(dp) :: dtol
@@ -4965,9 +4966,10 @@ contains
                         costhk = cos(thetam(k))
                         sinthk = sin(thetam(k))
                         Cfac = x1 * (y2 - yk) + x2 * (yk - y1) + xk * (y1 - y2)
+                        cfac_lim = sign(max(abs(Cfac), dtol), Cfac)
                         Afac = (F(k1) * costh1 * (y2 - yk) + F(k2) * costh2 * (yk - y1) &
-                                - F(k1) * sinth1 * (x2 - xk) - F(k2) * sinth2 * (xk - x1)) / max(Cfac, dtol)
-                        Bfac = (costhk * (y1 - y2) - sinthk * (x1 - x2)) / sign(max(abs(Cfac), dtol), Cfac)
+                                - F(k1) * sinth1 * (x2 - xk) - F(k2) * sinth2 * (xk - x1)) / cfac_lim
+                        Bfac = (costhk * (y1 - y2) - sinthk * (x1 - x2)) / cfac_lim
                         Drst = 2.0_dp * ag * beta / c(k)**2
                         F(k) = (Dw(k) - Afac) / (Bfac + Drst)
                         Er(k) = F(k) / c(k)
@@ -6063,6 +6065,13 @@ contains
 
       ! distribute dissipation
       do k = 1, ndx
+         if (L1(k) < 1e-1_dp) then
+            sxwav(k) = 0_dp
+            sywav(k) = 0_dp
+            sbxwav(k) = 0_dp
+            sbywav(k) = 0_dp
+            cycle
+         end if
          frc = diss(k) * twav(k) / L1(k)
          !
          dir = degrad * phiwav(k) ! cartesian angle, deg
@@ -6135,8 +6144,8 @@ contains
       if (jawavestokes == NO_STOKES_DRIFT) then
          ustokes = 0.0_dp
          vstokes = 0.0_dp
-         ustx_cc(k) = 0.0_dp
-         usty_cc(k) = 0.0_dp ! output
+         ustx_cc = 0.0_dp
+         usty_cc = 0.0_dp
          return
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_comp_stokes_velocities.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_comp_stokes_velocities.f90
@@ -78,7 +78,7 @@ contains
       deltahmin = 0.1_dp ! should be a parameter
       !
       do k = 1, ndx
-         massflux_max = 1.0_dp / 8.0_dp * sag * (hs(k)**1.5) * (gammax**2)
+         massflux_max = (1.0_dp / 8.0_dp) * sag * (hs(k)**1.5) * (gammax**2)
          mnorm = min(sqrt(mxwav(k)**2 + mywav(k)**2), massflux_max)
          mangle = atan2(mywav(k), mxwav(k))
          mx(k) = mnorm * cos(mangle)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_fillsurdis.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_fillsurdis.f90
@@ -45,7 +45,7 @@ contains
       use precision, only: dp
       use m_waves, only: dsurf, dwcap, twav, rlabda, hwav
       use m_sferic, only: pi
-      use m_waveconst, only: wave_swan_online, wave_surfbeat, wave_fetch_hurdle, wave_fetch_young, wave_uniform
+      use m_waveconst, only: wave_swan_online, wave_surfbeat, wave_fetch_hurdle, wave_fetch_young, wave_uniform, WAVE_NC_OFFLINE
       use m_xbeach_data, only: DR, D, roller
       use m_flowparameters, only: jawave
       use m_flow, only: s1, epshu
@@ -60,7 +60,7 @@ contains
       real(kind=dp) :: hsk
 
       select case (jawave)
-      case (WAVE_SWAN_ONLINE)
+      case (WAVE_SWAN_ONLINE, WAVE_NC_OFFLINE)
          surdis = dsurf(k) + dwcap(k)
       case (WAVE_SURFBEAT)
          if (roller > 0) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_shear_velocity.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waves/wave_shear_velocity.f90
@@ -66,7 +66,7 @@ contains
          if (jauorb == 0) then ! for consistency with old d3d convention
             uorbi = uorbi * sqrt(pi) / 2.0_dp
          end if
-         ust = 0.5_dp * omeg * arms * arms / depth
+         ust = 0.5_dp * omeg * arms**2 / (depth * tanhsafe(rk * depth))
          rlabd = twopi / rk
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
@@ -1348,7 +1348,7 @@ contains
 
       if (jawave == CONST .and. .not. flow_without_waves) then
          hs = max(hs, 0.0_dp)
-         hwav = min(hwavcom, gammax * hs)
+         hwav = min(hwavuni, gammax * hs)
          call wave_uorbrlabda()
          if (kmx == 0) then
             if (jawavestokes > NO_STOKES_DRIFT) then


### PR DESCRIPTION
# What was done 

- `[waves] fforc` (default `1.0`) factor for adjusting wave forces in momentum equation (0 = switched off), and `[waves] streamLyrFac` (internally: `strlyrfac`) (default `3.0`) streaming layer thickness factor added (must be > 0)
- `jawavevellogprof` (default `1`) flag for depth-averaged velocity computation ... `1` corresponds to current method, `0` corresponds to alternative method (details: `getustbcfuhi`)
- `tp` renamed to `twav` on map-file (CF name suggesting specific wave period removed)
- various bug fixes related to wave current interaction in 2D and 3D mode

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
Three test cases need updated references: e02_f090_c011_san_francisco_bay_3d, e100_f00_c03_append_com, e02_f022_c106_flow_wave_morpho_straightcoast
- [ ]	Not applicable 

# Documentation  
- [x]	Documentation updated \
Keywords added to json-file
- [ ]	Not applicable 

# Issue link
UNST-9434