### PR TITLE
UNST-9690 Fix set env, point the TMP folder to a folder local to the …

### DIFF
--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
@@ -44,9 +44,7 @@ ENV VS2022INSTALLDIR="C:\\Program Files\\Microsoft Visual Studio\\17\\Community\
 # with vswhere (whose own path is stable across VS versions/editions) so the exact
 # VS install folder never needs to be hard-coded.
 RUN $vswhere = 'C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe'; \
-    if (-not (Test-Path $vswhere)) { throw "vswhere.exe not found at $vswhere" }; \
     $gitCmd = & $vswhere -latest -products * -find '**\cmd\git.exe' | Select-Object -First 1; \
-    if (-not $gitCmd) { throw 'Could not locate git.exe in the Visual Studio installation.' }; \
     $gitDir = Split-Path -Parent $gitCmd; \
     Write-Host ('Adding Git to PATH: ' + $gitDir); \
     setx /M PATH ($Env:PATH + ';' + $gitDir)

--- a/ci/dockerfiles/windows/set-env-vs2022.cmd
+++ b/ci/dockerfiles/windows/set-env-vs2022.cmd
@@ -8,5 +8,14 @@ fsutil 8dot3name set C: 0 >nul 2>&1
 fsutil file setshortname "C:\Program Files" PROGRA~1 >nul 2>&1
 fsutil file setshortname "C:\Program Files (x86)" PROGRA~2 >nul 2>&1
 
+rem TeamCity forwards the build configuration's environment variables into the
+rem container. Among the forwarded ones are TEMP/TMP/TMPDIR, which point to a host
+rem folder that is bind-mounted into the container. Executables sometimes cannot be
+rem run from that mount, which breaks builds that compile and run test executables
+rem there (e.g. PETSc's ./configure). Redirect them to a container-local directory.
+if not exist C:\build-temp mkdir C:\build-temp
+set TEMP=C:\build-temp
+set TMP=C:\build-temp
+set TMPDIR=C:\build-temp
+
 call "C:\\Program Files (x86)\\Intel\\oneAPI\\setvars.bat" --force
-call "C:\\Program Files\\Microsoft Visual Studio\\17\\Community\\Common7\\Tools\\VsDevCmd.bat" -arch=amd64 -host_arch=amd64


### PR DESCRIPTION
…container where executables can be executed

- Added lines pointing to the TMP folder
- Removed some untested debug statements
- Removed the visual studio environment sourcing, which is no longer necessary now that the install path environment variable is properly set in the dockerfile so that Intel already loads it

# Issue link UNST-9690
