### PR TITLE
UNST-9482: Dump ec message stack as warn

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
@@ -1629,7 +1629,7 @@ contains
          ! TODO: AvD: I'd rather have a full message stack that will combine EC + meteo + dflowfm, and any caller may print any pending messages.
          ! For now: Print the EC message stack here, and leave the rest to the caller.
          ! TODO: RL: the message below is from m_meteo::message, whereas timespace::getmeteoerror() returns timespace::errormessage. So now this message here is lost/never printed at call site.
-         message = dump_ec_message_stack(LEVEL_ERROR, callback_msg)
+         message = dump_ec_message_stack(LEVEL_WARN, callback_msg)
          ! Leave this concluding message for the caller to print or not. (via getmeteoerror())
       end if
       message = 'm_meteo::ec_addtimespacerelation: Error while initializing '''//trim(name)//''' from file: '''//trim(filename)//''''

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -574,7 +574,7 @@ contains
             write (msgbuf, '(a,i0,a)') 'set_external_forcings:: Offline wave coupling with waveforcing=', waveforcing, '. &
                & Error reading data from nc file.'
             call warn_flush() ! ECMessage stack is not very informative
-            message = dump_ec_message_stack(LEVEL_ERROR, callback_msg)
+            message = dump_ec_message_stack(LEVEL_WARN, callback_msg)
          end if
 
          if (jawave == WAVE_NC_OFFLINE) then


### PR DESCRIPTION
# What was done 

Dump ec message stack as warn because as ERROR will stop after the first message
 

# Evidence of the work done 

- [X ]	Video/figures \
```
** WARNING: set_external_forcings:: Offline wave coupling with waveforcing=1.  Error reading data from nc file.
** WARNING: ...
** WARNING: Updating target failed, quantity='wavedirection', itemId=       4
** WARNING: Updating source failed, quantity='sea_surface_wave_from_direction', item=       1, location=
** WARNING: Requested time preceeds current forcing EC-timelevel by 5.993 days = 517800.000 seconds.
** WARNING:        Current EC-time: t= 56627.000 seconds
** WARNING:              Requested: t= 56621.007 seconds
** WARNING:        in file: '../../../../09482/output_swan2D.nc'.
** WARNING: Updating target failed, quantity='wavedirection', itemId=       3
** WARNING: Updating source failed, quantity='sea_surface_wave_significant_height', item=       2, location=
** WARNING: Requested time preceeds current forcing EC-timelevel by 5.993 days = 517800.000 seconds.
** WARNING:        Current EC-time: t= 56627.000 seconds
** WARNING:              Requested: t= 56621.007 seconds
** WARNING:        in file: '../../../../09482/output_swan2D.nc'.
** WARNING: Error while updating meteo/structure forcing at time=  29203800.00000000000
```
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X ]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9482