### PR TITLE
UNST-9690 Re-add cygwin to container after cygwin in conan failed

### DIFF
--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2022-i24
@@ -63,6 +63,35 @@ RUN setx /M PATH \"C:\Program Files\uv\bin;C:\Program Files\uv\install;$env:PATH
 RUN uv python install 3.12 --default
 RUN uv tool install 'conan ~= 2.30.0'
 
+ADD setup-x86_64.exe C:\\cygwin-setup-x86_64.exe
+# Install and clean up the package cache in a single layer. The cache uses very
+# long, URL-encoded directory names (e.g. https%3a%2f%2fmirrors.kernel.org%2f...)
+# which break the Windows container layer import (hcsshim::ImportLayer) if they
+# are ever committed to a layer, so they must never persist beyond this RUN.
+RUN Start-Process -FilePath 'C:\cygwin-setup-x86_64.exe' -Wait -NoNewWindow -ArgumentList \
+    '--quiet-mode', \
+    '--no-shortcuts', \
+    '--no-startmenu', \
+    '--no-desktop', \
+    '--no-admin', \
+    '--upgrade-also', \
+    '--root', 'C:\cygwin64', \
+    '--local-package-dir', 'C:\cygwin-packages', \
+    '--site', 'https://ftp.snt.utwente.nl/pub/software/cygwin/', \
+    '--site', 'https://mirrors.kernel.org/sourceware/cygwin/', \
+    '--site', 'https://cygwin.mirror.constant.com/', \
+    '--only-site', \
+    '--packages', 'python3,make,git,cmake'; \
+    Remove-Item -Force C:\cygwin-setup-x86_64.exe; \
+    Remove-Item -Recurse -Force C:\cygwin-packages
+
+# Cygwin's link.exe conflicts with the Intel ifort/ifx compiler. Rename it so the Intel/MSVC linker is
+# picked up instead (see https://petsc.org/main/install/windows/#native-microsoft-intel-windows-compilers).
+RUN if (Test-Path 'C:\cygwin64\bin\link.exe') { Move-Item 'C:\cygwin64\bin\link.exe' 'C:\cygwin64\bin\link-cygwin.exe' }
+
+# Add Cygwin to the PATH (appended so it does not shadow the explicitly installed tools).
+RUN setx /M PATH ($Env:PATH + ';C:\cygwin64\bin')
+
 # Copy the setup script into the container
 COPY set-env-vs2022.cmd C:\\set-env-vs2022.cmd
 


### PR DESCRIPTION
# What was done 

- Add cygwin to windows docker container so that petsc conan package can build inside this container

# Issue link UNST-9690
