### PR TITLE
make sure dvc diff

### DIFF
--- a/ci/teamcity/Delft3D/ciUtilities/scripts/postDvcDiffReport.sh
+++ b/ci/teamcity/Delft3D/ciUtilities/scripts/postDvcDiffReport.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-set -euo pipefail
+set -euox pipefail
 
 USAGE_STRING="Usage: postDvcDiffReport.sh <target_branch> [<PULL_REQUEST_NUMBER> <GITHUB_BARER_TOKEN>]"
 if [ "$#" -lt 1 ]; then 
@@ -19,7 +19,8 @@ PULL_REQUEST_NUMBER="$2"
 GITHUB_BARER_TOKEN="$3"
 
 SOURCE_BRANCH="$(git rev-parse HEAD)"
-MERGE_BASE_COMMIT_HASH=$(git merge-base "$TARGET_BRANCH" HEAD)
+git fetch origin "$TARGET_BRANCH"
+MERGE_BASE_COMMIT_HASH=$(git merge-base origin/"$TARGET_BRANCH" HEAD)
 
 POST_URL="https://api.github.com/repos/deltares/delft3d/issues/$PULL_REQUEST_NUMBER/comments"
 


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- Apparently newly rolled out agents can not have the full git history causing the dvc diff job to fail. This can be fixed by making sure the job itself fetches main so that it can always determine the merge base 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
[DEVOPSCICD-11](https://issuetracker.deltares.nl/browse/DEVOPSCICD-11)