### PR TITLE
UNST-10125: Fix exit code -1073741819

### DIFF
--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -131,9 +131,8 @@ object WindowsTest : BuildType({
                     rem Wheels come from the mounted uv cache volume.
                     uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
                     call C:\venv\Scripts\activate.bat
+                    set PYTHONVERBOSE=1
                     uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
-
-                    echo "Running TestBench.py..."
                     python TestBench.py %%argsList%%
             """.trimIndent()
 

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -117,8 +117,10 @@ object WindowsTest : BuildType({
                     rem in a clean container, and the build directory is removed every time, so the
                     rem compiled bytecodes are never reused. In addition, we've run into strange
                     rem -1073741819 (0xC0000005) exit codes during bytecode compilations. We decided
-                    rem to turn off the byte code writing because of this.
+                    rem to turn off the byte code writing because of this. Also set PYTHONFAULTHANDLER
+                    rem in case we still get a crash. That should produce a stacktrace on the crashes.
                     set PYTHONDONTWRITEBYTECODE=1
+                    set PYTHONFAULTHANDLER=1
 
                     set argsList=--username %s3_dsctestbench_accesskey% ^
                     --password %s3_dsctestbench_secret% ^

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -109,39 +109,40 @@ object WindowsTest : BuildType({
             name = "Run TestBench.py"
             id = "RUNNER_testbench"
             workingDir = "test/deltares_testbench/"
-                scriptContent = """
-                    @echo off
+            scriptContent = """
+                @echo off
 
-                    rem The environment and venv are completely clean, so python will write a lot
-                    rem of '.pyc' bytecode files in '__pycache__' directories. Since each build runs
-                    rem in a clean container, and the build directory is removed every time, so the
-                    rem compiled bytecodes are never reused. In addition, we've run into strange
-                    rem -1073741819 (0xC0000005) exit codes during bytecode compilations. We decided
-                    rem to turn off the byte code writing because of this. Also set PYTHONFAULTHANDLER
-                    rem in case we still get a crash. That should produce a stacktrace on the crashes.
-                    set PYTHONDONTWRITEBYTECODE=1
-                    set PYTHONFAULTHANDLER=1
+                rem Python writes a lot of '.pyc' bytecode files in '__pycache__' directories. This build 
+                rem step runs in a clean container with a clean build directory bind-mounted in every time,
+                rem so the bytecode files are never reused. We've run into -1073741819 (0xC0000005) exit codes
+                rem while python was generating these '*.pyc' files. That's why we've decided to turn off the
+                rem bytecode file writing. In case we still get a crash, we set PYTHONFAULTHANDLER. This should
+                rem produce a stacktrace when python crashes.
+                set PYTHONDONTWRITEBYTECODE=1
+                set PYTHONFAULTHANDLER=1
 
-                    set argsList=--username %s3_dsctestbench_accesskey% ^
-                    --password %s3_dsctestbench_secret% ^
-                    --compare ^
-                    --config configs/%configfile% ^
-                    --filter testcase=%case_filter% ^
-                    --log-level DEBUG ^
-                    --parallel ^
-                    --teamcity
+                set argsList=--username %s3_dsctestbench_accesskey% ^
+                --password %s3_dsctestbench_secret% ^
+                --compare ^
+                --config configs/%configfile% ^
+                --filter testcase=%case_filter% ^
+                --log-level DEBUG ^
+                --parallel ^
+                --teamcity
 
-                    if "%copy_failed_cases%"=="true" (
-                        set argsList=%%argsList%% --copy-failed-cases
-                    )
+                if "%copy_failed_cases%"=="true" (
+                    set argsList=%%argsList%% --copy-failed-cases
+                )
 
-                    rem Create the venv on the container filesystem (C:\venv), NOT the bind-mounted work dir,
-                    rem to avoid os error 32 file-lock failures on the mount during install.
-                    rem Wheels come from the mounted uv cache volume.
-                    uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
-                    call C:\venv\Scripts\activate.bat
-                    uv pip sync pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
-                    python TestBench.py %%argsList%%
+                rem Create the venv on the container filesystem (C:\venv), NOT the bind-mounted work dir,
+                rem to avoid os error 32 file-lock failures on the mount during install.
+                rem Wheels come from the mounted uv cache volume.
+                uv venv C:\venv
+                if %%ERRORLEVEL%% NEQ 0 exit /b 1
+                call C:\venv\Scripts\activate.bat
+                uv pip sync pip/win-requirements.txt
+                if %%ERRORLEVEL%% NEQ 0 exit /b 1
+                python TestBench.py %%argsList%%
             """.trimIndent()
 
             dockerImage = "containers.deltares.nl/delft3d-dev/test/delft3d-test-environment-windows:%container.tag%"

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -129,12 +129,11 @@ object WindowsTest : BuildType({
                     rem Create the venv on the container filesystem (C:\venv), NOT the bind-mounted work dir,
                     rem to avoid os error 32 file-lock failures on the mount during install.
                     rem Wheels come from the mounted uv cache volume.
-                    uv venv C:\venv
-                    if errorlevel 1 exit /b 1
+                    uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
                     call C:\venv\Scripts\activate.bat
-                    uv pip sync pip/win-requirements.txt
-                    if errorlevel 1 exit /b 1
+                    uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
 
+                    echo "Running TestBench.py..."
                     python TestBench.py %%argsList%%
             """.trimIndent()
 

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -106,12 +106,19 @@ object WindowsTest : BuildType({
         }
         // script is necessary to dynamically set the copy-failed-cases depending on the paramter
         script {
-
             name = "Run TestBench.py"
             id = "RUNNER_testbench"
             workingDir = "test/deltares_testbench/"
                 scriptContent = """
                     @echo off
+
+                    rem The environment and venv are completely clean, so python will write a lot
+                    rem of '.pyc' bytecode files in '__pycache__' directories. Since each build runs
+                    rem in a clean container, and the build directory is removed every time, so the
+                    rem compiled bytecodes are never reused. In addition, we've run into strange
+                    rem -1073741819 (0xC0000005) exit codes during bytecode compilations. We decided
+                    rem to turn off the byte code writing because of this.
+                    set PYTHONDONTWRITEBYTECODE=1
 
                     set argsList=--username %s3_dsctestbench_accesskey% ^
                     --password %s3_dsctestbench_secret% ^
@@ -132,9 +139,7 @@ object WindowsTest : BuildType({
                     uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
                     call C:\venv\Scripts\activate.bat
                     set PYTHONVERBOSE=2
-                    set PYTHONDEVMODE=1
-                    set PYTHONTRACEMALLOC=1
-                    uv pip sync -v --compile-bytecode pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
+                    uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
                     python TestBench.py %%argsList%%
             """.trimIndent()
 
@@ -146,6 +151,7 @@ object WindowsTest : BuildType({
                 --cpus %teamcity.agent.hardware.cpuCount%
                 --env UV_LINK_MODE=copy
                 --volume test-environment-uv-cache:C:\uv\cache
+                --volume test-environment-pycache:C:\pycache
             """.trimIndent()
         }
         script {

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -140,8 +140,7 @@ object WindowsTest : BuildType({
                     rem Wheels come from the mounted uv cache volume.
                     uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
                     call C:\venv\Scripts\activate.bat
-                    set PYTHONVERBOSE=2
-                    uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
+                    uv pip sync pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
                     python TestBench.py %%argsList%%
             """.trimIndent()
 
@@ -153,7 +152,6 @@ object WindowsTest : BuildType({
                 --cpus %teamcity.agent.hardware.cpuCount%
                 --env UV_LINK_MODE=copy
                 --volume test-environment-uv-cache:C:\uv\cache
-                --volume test-environment-pycache:C:\pycache
             """.trimIndent()
         }
         script {

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -134,7 +134,7 @@ object WindowsTest : BuildType({
                     set PYTHONVERBOSE=2
                     set PYTHONDEVMODE=1
                     set PYTHONTRACEMALLOC=1
-                    uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
+                    uv pip sync -v --compile-bytecode pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
                     python TestBench.py %%argsList%%
             """.trimIndent()
 

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -131,7 +131,9 @@ object WindowsTest : BuildType({
                     rem Wheels come from the mounted uv cache volume.
                     uv venv C:\venv || (echo [ERROR] uv venv failed! & exit /b 1)
                     call C:\venv\Scripts\activate.bat
-                    set PYTHONVERBOSE=1
+                    set PYTHONVERBOSE=2
+                    set PYTHONDEVMODE=1
+                    set PYTHONTRACEMALLOC=1
                     uv pip sync -v pip/win-requirements.txt || (echo [ERROR] uv pip sync failed! & exit /b 1)
                     python TestBench.py %%argsList%%
             """.trimIndent()


### PR DESCRIPTION
# What was done 

See JIRA issue for more details. The error happens in python import phase. The container and build environments are squeeky clean so python writes lots of small `__pycache__/*.pyc` files. The error code happens there every once in a while. My hope is that by turning off the bytecode file writing that this error will go away. The builds will not be any slower, because we never reuse the bytecodes anyway, we only run TestBench.py once, and then the build directory is removed from the agent, and the files that are not bind-mounted in the container are ephemeral anyway.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
