### PR TITLE
DEVOPSCICD-7 (fixup): Do not limit build concurrency in Linux runtime container build config

### DIFF
--- a/ci/teamcity/Delft3D/linux/runtimeContainers.kt
+++ b/ci/teamcity/Delft3D/linux/runtimeContainers.kt
@@ -20,8 +20,7 @@ object LinuxRuntimeContainers : BuildType({
         TemplateMergeRequest,
         TemplatePublishStatus,
         TemplateMonitorPerformance,
-        TemplateDockerRegistry,
-        TemplateBuildConcurrency
+        TemplateDockerRegistry
     )
 
     name = "Runtime Containers"


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSCICD-7