### PR TITLE
 DEVOPSCICD-13: Bump versions of checkout and ksm GitHub actions to latest

### DIFF
--- a/.github/workflows/cancel_teamcity_builds.yml
+++ b/.github/workflows/cancel_teamcity_builds.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -102,7 +102,7 @@ jobs:
         env:
           KSM_APP_CONFIG: ${{ secrets.KSM_APP_CONFIG }}
           KSM_RECORD_UID: ${{ secrets.KSM_RECORD_UID }}
-        uses: Keeper-Security/ksm-action@v1.1.0
+        uses: Keeper-Security/ksm-action@v1.3.0
         with:
           keeper-secret-config: ${{ env.KSM_APP_CONFIG }}
           secrets: |-

--- a/.github/workflows/synch-to-gitlab.yml
+++ b/.github/workflows/synch-to-gitlab.yml
@@ -8,7 +8,7 @@ jobs:
     if: ${{ github.repository == 'Deltares/delft3d' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
          fetch-depth: 0
       - name: Sync to GitLab


### PR DESCRIPTION
# What was done 
Bumped versions of checkout and ksm actions to latest.

# Issue link
DEVOPSCICD-13