### PR TITLE
Fix signing check file for newly added decayt.dll

### DIFF
--- a/ci/python/ci_tools/dimrset_delivery/all-testbench-binaries.json
+++ b/ci/python/ci_tools/dimrset_delivery/all-testbench-binaries.json
@@ -591,6 +591,10 @@
         {
             "file": "bin\\zlib1.dll",
             "issuedTo": "Stichting Deltares"
+        },
+        {
+            "file": "share\\delft3d\\open_process_lib_example\\code\\decayt.dll",
+            "issuedTo": "Stichting Deltares"
         }
     ],
     "notSigned": [

--- a/ci/python/ci_tools/dimrset_delivery/fm-suite-binaries.json
+++ b/ci/python/ci_tools/dimrset_delivery/fm-suite-binaries.json
@@ -543,6 +543,10 @@
         {
             "file": "bin\\zlib1.dll",
             "issuedTo": "Stichting Deltares"
+        },
+        {
+            "file": "share\\delft3d\\open_process_lib_example\\code\\decayt.dll",
+            "issuedTo": "Stichting Deltares"
         }
     ],
     "notSigned": [


### PR DESCRIPTION
# What was done 

Pull-request #999 added a new `decayt.dll` via a `waq` branch. For `all` branches the CI pipeline checks whether all binaries have been appropriately signed. This check is not performed for `waq` branches and hence it was not pre-merge noticed that the list of binaries had to be updated. This pull request aims to fix that.

It's an alternative to #1098 which simply reverts #999.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
