### PR TITLE
UNST-10154: fix crash for dimensionless realization

### DIFF
--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_filereader_read.F90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_filereader_read.F90
@@ -2293,6 +2293,8 @@ contains
                   start(ndims) = timesndx
                end if
                if (relndx > 0 .and. ndims >= 4) then
+                  ! UNST-10154: Limited support if variable contains an extra 'realization' dimension. 
+                  ! Pick the correct index relndx. For now, we assume length(dim) == 1.
                   start(3) = relndx
                end if
                if (n_layers /= 0) then

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_provider.F90
@@ -2622,14 +2622,13 @@ contains
       integer :: lon_varid, lon_dimid, lat_varid, lat_dimid, tim_varid, tim_dimid
       integer :: grid_lon_varid, grid_lat_varid
       integer :: x_varid, x_dimid, y_varid, y_dimid, z_varid, z_dimid, nod_varid, nod_dimid
-      integer :: realization_varid, realization_dimid, dim_offset
 
       integer, dimension(:, :), allocatable :: crd_dimids, crd_dimlen
       integer :: timeint
       integer :: expectedLength
       character(len=:), allocatable :: nameVar ! variable name in error message
       character(len=2) :: cnum1, cnum2 ! 1st and 2nd number converted to string for error message
-      integer :: nrow, ncol, nlay, nrel
+      integer :: nrow, ncol, nlay
       !
       success = .false.
       itemPtr => null()
@@ -2673,8 +2672,7 @@ contains
                                              x_varid, x_dimid, y_varid, y_dimid, &
                                              z_varid, z_dimid, &
                                              tim_varid, tim_dimid, &
-                                             nod_varid, nod_dimid, &
-                                             realization_varid, realization_dimid)) then
+                                             nod_varid, nod_dimid)) then
          ! Exception: inquiry of id's of required coordinate variables failed
          return
       end if
@@ -2954,13 +2952,6 @@ contains
                return
             end if
 
-            if (realization_dimid > 0) then
-               dim_offset = 1
-               nrel = fileReaderPtr%dim_length(dimids(1))
-            else
-               dim_offset = 0
-               nrel = 0
-            end if
             ! this goes wrong when time is defined before space in nc file
             if (grid_type == elmSetType_samples) then
                ncol = fileReaderPtr%dim_length(dimids(1))
@@ -2990,8 +2981,8 @@ contains
                   nrow = fileReaderPtr%dim_length(fileReaderPtr%laty_id)
                   ! Flag indicating that data is stored (X,Y) instead of (Y,X), used to make sure the values are oriented row,column after reading.
                   fileReaderPtr%is_column_major = ecProviderDataIsColumnMajor(dimids(1), dimids(2), fileReaderPtr%lonx_id, fileReaderPtr%laty_id)
-                  if (size(dimids) > 3 + dim_offset) then
-                     nlay = fileReaderPtr%dim_length(dimids(3 + dim_offset))
+                  if (size(dimids) > 3) then
+                     nlay = fileReaderPtr%dim_length(dimids(3))
                   end if
                end if
             end if

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
@@ -1362,8 +1362,7 @@ contains
                                          x_varid, x_dimid, y_varid, y_dimid, &
                                          z_varid, z_dimid, &
                                          tim_varid, tim_dimid, &
-                                         series_varid, series_dimid, &
-                                         realization_varid, realization_dimid) result(success)
+                                         series_varid, series_dimid) result(success)
       use netcdf
       logical :: success
       integer, intent(in) :: ncid !< NetCDF file ID
@@ -1383,8 +1382,6 @@ contains
       integer, intent(out) :: z_dimid !< Z dimension
       integer, intent(out) :: tim_dimid !< Time dimension
       integer, intent(out) :: series_dimid !< Series dimension
-      integer, intent(out) :: realization_varid !< realization varid
-      integer, intent(out) :: realization_dimid !< realization dimension
       integer :: ndim, nvar, ivar, nglobatts, unlimdimid, ierr
       integer, allocatable :: dimids(:)
       character(len=NF90_MAX_NAME) :: units, axis, varname, stdname, cf_role, std_name
@@ -1397,7 +1394,6 @@ contains
       z_varid = -1
       tim_varid = -1
       series_varid = -1
-      realization_varid = -1
 
       lon_dimid = -1
       lat_dimid = -1
@@ -1406,7 +1402,6 @@ contains
       z_dimid = -1
       tim_dimid = -1
       series_dimid = -1
-      realization_dimid = -1
 
       allocate (dimids(NF90_MAX_VAR_DIMS))
 
@@ -1419,14 +1414,6 @@ contains
          if (strcmpi(cf_role, 'timeseries_id')) then
             series_varid = ivar ! store last timeseries_id variable
             series_dimid = dimids(ndim)
-         end if
-         ierr = nf90_get_att(ncid, ivar, 'standard_name', std_name)
-         if (strcmpi(std_name, 'realization')) then
-            realization_varid = ivar ! store last timeseries_id variable
-            if (ndim > 0) then
-               realization_dimid = dimids(ndim)
-            end if
-            cycle
          end if
          units = ''
          ierr = nf90_get_att(ncid, ivar, 'units', units)

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
@@ -1423,7 +1423,9 @@ contains
          ierr = nf90_get_att(ncid, ivar, 'standard_name', std_name)
          if (strcmpi(std_name, 'realization')) then
             realization_varid = ivar ! store last timeseries_id variable
-            realization_dimid = dimids(ndim)
+            if (ndim > 0) then
+               realization_dimid = dimids(ndim)
+            end if
             cycle
          end if
          units = ''


### PR DESCRIPTION
# What was done 

Fix a crash with dimensionless realization. This seems to be ok-ish used further with a check:
```
            if (realization_dimid > 0) then
               dim_offset = 1
               nrel = fileReaderPtr%dim_length(dimids(1))
            else
               dim_offset = 0
               nrel = 0
            end if
```

So <=0 value is actually ok
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [X]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10154