### PR TITLE
Remove teamcity concurrency limitation from linux container builds, a…

### DIFF
--- a/ci/teamcity/Delft3D/linux/containers/buildTools.kt
+++ b/ci/teamcity/Delft3D/linux/containers/buildTools.kt
@@ -18,8 +18,7 @@ object LinuxBuildTools : BuildType({
         TemplatePublishStatus,
         TemplateMergeRequest,
         TemplateMonitorPerformance,
-        TemplateDockerRegistry,
-        TemplateBuildConcurrency
+        TemplateDockerRegistry
     )
 
     vcs {

--- a/ci/teamcity/Delft3D/linux/containers/thirdPartyLibs.kt
+++ b/ci/teamcity/Delft3D/linux/containers/thirdPartyLibs.kt
@@ -18,8 +18,7 @@ object LinuxThirdPartyLibs : BuildType({
         TemplatePublishStatus,
         TemplateMergeRequest,
         TemplateMonitorPerformance,
-        TemplateDockerRegistry,
-        TemplateBuildConcurrency
+        TemplateDockerRegistry
     )
 
     vcs {


### PR DESCRIPTION
D-Waq/D-Part and Delft3D both trigger the linux container builds, so they are cancelled if unlucky