### PR TITLE
UNST-10046 support viscous and constant charnock coefficients

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -138,6 +138,9 @@ module m_flowparameters
    real(kind=dp) :: sensor_height_wind_velocity !< Sensor height of prescribed wind velocity [m]
    real(kind=dp) :: sensor_height_air_temperature !< Sensor height of prescribed air temperature [m]
    real(kind=dp) :: sensor_height_humidity !< Sensor height of prescribed humidity [m]
+   real(kind=dp) :: air_viscous_momentum_coeff !< Air viscous momentum coefficient [-]
+   real(kind=dp) :: air_viscous_heat_coeff !< Air viscous heat coefficient [-]
+   real(kind=dp) :: air_viscous_moisture_coeff !< Air viscous moisture coefficient [-]
 
    integer :: janudge !< temperature and salinity nudging
    integer :: jainiwithnudge !< initialize salinity and temperature with nudge variables
@@ -768,6 +771,9 @@ contains
       sensor_height_wind_velocity = 10.0_dp ! Height of prescribed wind velocity
       sensor_height_air_temperature = 2.0_dp ! Height of prescribed air temperature
       sensor_height_humidity = 2.0_dp ! Height of prescribed humidity
+      air_viscous_momentum_coeff = 0.11_dp ! Air viscous momentum coefficient
+      air_viscous_heat_coeff = 0.40_dp ! Air viscous heat coefficient
+      air_viscous_moisture_coeff = 0.62_dp ! Air viscous moisture coefficient
 
       janudge = 0 ! temperature and salinity nudging
       jainiwithnudge = 0 !< initialize salinity and temperature with nudge variables

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_wind.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_wind.f90
@@ -33,6 +33,7 @@
 module m_wind
 
    use precision, only: dp
+   use m_array_or_scalar, only: t_array_or_scalar
 
    implicit none
 
@@ -42,7 +43,7 @@ module m_wind
    real(kind=dp), dimension(:), allocatable, target :: ec_pwxwy_y !< Temporary array, for comparing EC-module to Meteo1.
    real(kind=dp), dimension(:), allocatable, target :: ec_pwxwy_c !< Temporary array, for comparing EC-module to Meteo1.
    real(kind=dp), dimension(:), allocatable, target :: ec_charnock !< Temporary array, for comparing EC-module to Meteo1.
-   real(kind=dp), dimension(:), allocatable, target :: wcharnock !< space var charnock (-) at u point {"location": "edge", "shape": ["lnx"]}
+   type(t_array_or_scalar), target :: wcharnock !< space var charnock (-) at u point {"location": "edge", "shape": ["lnx"]}
 
    real(kind=dp), dimension(:), allocatable, target :: air_pressure !< atmospheric pressure user specified in (N/m2), internally reworked to (m2/s2)
                                                       !! so that it can be merged with tidep later and difpatm/dx = m/s2, saves 1 array , using mode = 'add'
@@ -159,6 +160,7 @@ contains
       jawind = 0 !< use wind yes or no
       jastresstowind = 0 !< if jawindstressgiven==1, convert stress to wind yes/no 1/0
       ja_computed_airdensity = 0
+      wcharnock%scalar = 0.018_dp !< ecmwf default value of charnock coefficient when wave is not used
       ! Remaining of variables is handled in reset_wind()
       call reset_wind()
    end subroutine default_wind

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_wind.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_wind.f90
@@ -161,6 +161,7 @@ contains
       jastresstowind = 0 !< if jawindstressgiven==1, convert stress to wind yes/no 1/0
       ja_computed_airdensity = 0
       wcharnock%scalar = 0.018_dp !< ecmwf default value of charnock coefficient when wave is not used
+      if (allocated(wcharnock%values)) deallocate (wcharnock%values)
       ! Remaining of variables is handled in reset_wind()
       call reset_wind()
    end subroutine default_wind

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -533,6 +533,7 @@ contains
 
       character(len=32) :: program
       logical :: success, ex, value_parsed
+      logical :: has_charnock_coefficient, has_air_viscous_momentum_coefficient
       character(len=1), dimension(1) :: dummychar
       logical :: dummylog
       character(len=1000) :: charbuf = ' '
@@ -1429,8 +1430,8 @@ contains
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
       call prop_get(md_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature)
       call prop_get(md_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity)
-      call prop_get(md_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar)
-      call prop_get(md_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff)
+      call prop_get(md_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar, has_charnock_coefficient)
+      call prop_get(md_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff, has_air_viscous_momentum_coefficient)
       call prop_get(md_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff)
       call prop_get(md_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff)
 
@@ -1458,6 +1459,21 @@ contains
          call prop_get(md_ptr, 'wind', 'Cdbreakpoints', cdb, 2)
          cdb_user(1:2) = cdb(1:2)
       end if
+
+      if (wind_drag_type == CD_TYPE_CHARNOCK1955 .or. wind_drag_type == CD_TYPE_CHARNOCK_PLUS_VISCOUS) then
+         if (has_charnock_coefficient) then
+            cdb(1) = wcharnock%scalar
+            cdb_user(1) = cdb(1)
+         end if
+      end if
+
+      if (wind_drag_type == CD_TYPE_CHARNOCK_PLUS_VISCOUS) then
+         if (has_air_viscous_momentum_coefficient) then
+            cdb(2) = air_viscous_momentum_coeff
+            cdb_user(2) = cdb(2)
+         end if
+      end if
+
       call prop_get(md_ptr, 'wind', 'Relativewind', relativewind)
       call prop_get(md_ptr, 'wind', 'Windhuorzwsbased', jawindhuorzwsbased)
       call prop_get(md_ptr, 'wind', 'Windpartialdry', jawindpartialdry)
@@ -3323,7 +3339,7 @@ contains
       call prop_set(prop_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity, 'Sensor height of prescribed wind velocity [m]')
       call prop_set(prop_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature, 'Sensor height of prescribed air temperature [m]')
       call prop_set(prop_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity, 'Sensor height of prescribed humidity variable [m]')
-      call prop_set(prop_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar, 'Charnock coefficient [-]')
+      call prop_set(prop_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar, 'Charnock coefficient [-] (may be overridden by space-varying input)')
       call prop_set(prop_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff, 'Air viscous momentum coefficient [-]')
       call prop_set(prop_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff, 'Air viscous heat coefficient [-]')
       call prop_set(prop_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff, 'Air viscous moisture coefficient [-]')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -481,7 +481,7 @@ contains
                         jastresstowind, update_wind_stress_each_time_step, ja_computed_airdensity, jarain, jaqin, jaqext, jaevap, jawind, &
                         wdb, jaevap, jawind, CD_TYPE_CONST, CD_TYPE_SMITHBANKE_2PT, CD_TYPE_SMITHBANKE_3PT, &
                         CD_TYPE_CHARNOCK1955, CD_TYPE_HWANG2005, CD_TYPE_WUEST2003, CD_TYPE_HERSBACH2011, &
-                        CD_TYPE_CHARNOCK_PLUS_VISCOUS, CD_TYPE_GARRATT1977
+                        CD_TYPE_CHARNOCK_PLUS_VISCOUS, CD_TYPE_GARRATT1977, wcharnock
       use network_data, only: zkuni, Dcenterinside, removesmalllinkstrsh, cosphiutrsh
       use m_circumcenter_method, only: circumcenter_method
       use m_sferic, only: anglat, anglon, jasfer3D
@@ -1429,6 +1429,7 @@ contains
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
       call prop_get(md_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature)
       call prop_get(md_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity)
+      call prop_get(md_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar)
       call prop_get(md_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff)
       call prop_get(md_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff)
       call prop_get(md_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff)
@@ -2470,7 +2471,7 @@ contains
       use m_wind, only: jaspacevarcharn, jaheat_eachstep, wind_drag_type, cdb, relativewind, jawindhuorzwsbased, jawindpartialdry, rhoair, &
                         pavbnd, pavini, jastresstowind, update_wind_stress_each_time_step, ja_computed_airdensity, jarain, jaqext, wdb, jaevap, jawind, &
                         CD_TYPE_CONST, CD_TYPE_SMITHBANKE_2PT, CD_TYPE_SMITHBANKE_3PT, &
-                        CD_TYPE_CHARNOCK1955, CD_TYPE_HWANG2005, CD_TYPE_WUEST2003, CD_TYPE_CHARNOCK_PLUS_VISCOUS
+                        CD_TYPE_CHARNOCK1955, CD_TYPE_HWANG2005, CD_TYPE_WUEST2003, CD_TYPE_CHARNOCK_PLUS_VISCOUS, wcharnock
       use network_data, only: zkuni, Dcenterinside, removesmalllinkstrsh, cosphiutrsh
       use m_circumcenter_method, only: circumcenter_method
       use m_sferic, only: anglat, anglon, jsferic, jasfer3D
@@ -3322,6 +3323,7 @@ contains
       call prop_set(prop_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity, 'Sensor height of prescribed wind velocity [m]')
       call prop_set(prop_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature, 'Sensor height of prescribed air temperature [m]')
       call prop_set(prop_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity, 'Sensor height of prescribed humidity variable [m]')
+      call prop_set(prop_ptr, 'meteo', 'CharnockCoefficient', wcharnock%scalar, 'Charnock coefficient [-]')
       call prop_set(prop_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff, 'Air viscous momentum coefficient [-]')
       call prop_set(prop_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff, 'Air viscous heat coefficient [-]')
       call prop_set(prop_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff, 'Air viscous moisture coefficient [-]')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1429,6 +1429,9 @@ contains
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
       call prop_get(md_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature)
       call prop_get(md_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity)
+      call prop_get(md_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff)
+      call prop_get(md_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff)
+      call prop_get(md_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff)
 
       call prop_get(md_ptr, 'wind', 'ICdtyp', wind_drag_type)
       if (wind_drag_type == CD_TYPE_CONST) then
@@ -3319,6 +3322,9 @@ contains
       call prop_set(prop_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity, 'Sensor height of prescribed wind velocity [m]')
       call prop_set(prop_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature, 'Sensor height of prescribed air temperature [m]')
       call prop_set(prop_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity, 'Sensor height of prescribed humidity variable [m]')
+      call prop_set(prop_ptr, 'meteo', 'AirViscousMomentumCoefficient', air_viscous_momentum_coeff, 'Air viscous momentum coefficient [-]')
+      call prop_set(prop_ptr, 'meteo', 'AirViscousHeatCoefficient', air_viscous_heat_coeff, 'Air viscous heat coefficient [-]')
+      call prop_set(prop_ptr, 'meteo', 'AirViscousMoistureCoefficient', air_viscous_moisture_coeff, 'Air viscous moisture coefficient [-]')
       
       if (writeall .or. jased > 0) then
          call prop_set(prop_ptr, 'sediment', 'sedimentModelNr', jased, 'Sediment model nr, (0=no, 1=Krone, 2=SvR2007, 3=E-H, 4=MorphologyModule)')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -71,6 +71,9 @@ module m_atmospheric_stability
       real(kind=dp) :: sensor_height_wind_velocity = 10.0_dp !< Sensor height of prescribed wind velocity [m]
       real(kind=dp) :: sensor_height_humidity = 2.0_dp !< Sensor height of prescribed humidity [m]
       real(kind=dp) :: sensor_height_air_temperature = 2.0_dp !< Sensor height of prescribed air temperature [m]
+      real(kind=dp) :: alpha_m = 0.11_dp ! Air viscous momentum coefficient [-]
+      real(kind=dp) :: alpha_h = 0.40_dp ! Air viscous heat coefficient [-]
+      real(kind=dp) :: alpha_q = 0.62_dp ! Air viscous moisture coefficient [-]
    end type t_options
 
    !> Scaling parameters data type.
@@ -184,7 +187,7 @@ contains
          richardson_number = 0.0_dp
 
          do iteration = 1, MAXIMUM_ITERATION
-            call compute_roughness_lengths(u_star, charnock, z0_momentum, z0_heat, z0_humidity)
+            call compute_roughness_lengths(u_star, charnock, options%alpha_m, options%alpha_h, options%alpha_q, z0_momentum, z0_heat, z0_humidity)
 
             if (options%include_free_convection) then
                convective_velocity_scale = compute_convective_velocity_scale(u_star, t_star, q_star, &
@@ -647,21 +650,22 @@ contains
    end subroutine get_bulk_exchange_diagnostics
 
    !> Compute roughness lengths following an ECMWF-style parameterization.
-   pure subroutine compute_roughness_lengths(u_star, charnock, z0_momentum, z0_heat, z0_humidity)
+   pure subroutine compute_roughness_lengths(u_star, charnock, alpha_m, alpha_h, alpha_q, z0_momentum, z0_heat, z0_humidity)
       real(kind=dp), intent(in) :: u_star !< u* [m/s]
       real(kind=dp), intent(in) :: charnock !< Charnock [-]
+      real(kind=dp), intent(in) :: alpha_m !< Air viscous momentum coefficient [-]
+      real(kind=dp), intent(in) :: alpha_h !< Air viscous heat coefficient [-]
+      real(kind=dp), intent(in) :: alpha_q !< Air viscous moisture coefficient [-]
       real(kind=dp), intent(out) :: z0_momentum !< Roughness length for momentum [m]
       real(kind=dp), intent(out) :: z0_heat !< Roughness length for heat [m]
       real(kind=dp), intent(out) :: z0_humidity !< Roughness length for humidity [m]
-      real(kind=dp), parameter :: ALPHA_M = 0.11_dp ! roughness length coefficient for momentum
-      real(kind=dp), parameter :: ALPHA_H = 0.40_dp ! roughness length coefficient for heat
-      real(kind=dp), parameter :: ALPHA_Q = 0.62_dp ! roughness length coefficient for humidity
+
       real(kind=dp) :: inverse_u_star
 
       inverse_u_star = 1.0_dp / sign(max(abs(u_star), EPS8), u_star)
-      z0_momentum = ALPHA_M * CONST_NU_AIR * inverse_u_star + charnock * u_star * u_star / CONST_GRAVITY
-      z0_heat = ALPHA_H * CONST_NU_AIR * inverse_u_star
-      z0_humidity = ALPHA_Q * CONST_NU_AIR * inverse_u_star
+      z0_momentum = alpha_m * CONST_NU_AIR * inverse_u_star + charnock * u_star * u_star / CONST_GRAVITY
+      z0_heat = alpha_h * CONST_NU_AIR * inverse_u_star
+      z0_humidity = alpha_q * CONST_NU_AIR * inverse_u_star
    end subroutine compute_roughness_lengths
 
    !> Compute saturation-vapor-pressure from temperature (ECMWF_T2esat).

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/setwindstress.f90
@@ -130,7 +130,7 @@ contains
                   wyL = wy(L)
                   call compute_wind_relative_to_surface_on_link(wx(L), wy(L), relativewind, u1(ltop(L)), v(ltop(L)), csu(L), snu(L), wxL, wyL, uwi)
                   if (jaspacevarcharn == 1) then
-                     cdb(1) = wcharnock(L)
+                     cdb(1) = wcharnock%get(L)
                   end if
                   call setcdwcoefficient(uwi, cdw, L)
                   if (ice_modify_winddrag /= ICE_WINDDRAG_NONE) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -179,7 +179,9 @@ contains
       wy = 0.0_dp
       wdsu_x = 0.0_dp
       wdsu_y = 0.0_dp
-      wcharnock = 0.0_dp
+      if (jaspacevarcharn > 0) then
+         wcharnock%values = 0.0_dp
+      end if
       call initialize_array_with_zero(ec_pwxwy_x)
       call initialize_array_with_zero(ec_pwxwy_y)
 
@@ -262,13 +264,13 @@ contains
          end if
          if (allocated(ec_pwxwy_c)) then
             do link = 1, lnx
-               wcharnock(link) = wcharnock(link) + 0.5_dp * (ec_pwxwy_c(ln(1, link)) + ec_pwxwy_c(ln(2, link)))
+               wcharnock%values(link) = wcharnock%values(link) + 0.5_dp * (ec_pwxwy_c(ln(1, link)) + ec_pwxwy_c(ln(2, link)))
             end do
          end if
       end if
       if (allocated(ec_charnock)) then
          do link = 1, lnx
-            wcharnock(link) = wcharnock(link) + 0.5_dp * (ec_charnock(ln(1, link)) + ec_charnock(ln(2, link)))
+            wcharnock%values(link) = wcharnock%values(link) + 0.5_dp * (ec_charnock(ln(1, link)) + ec_charnock(ln(2, link)))
          end do
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -179,7 +179,7 @@ contains
       wy = 0.0_dp
       wdsu_x = 0.0_dp
       wdsu_y = 0.0_dp
-      if (jaspacevarcharn > 0) then
+      if (allocated(ec_pwxwy_c) .or. allocated(ec_charnock)) then
          wcharnock%values = 0.0_dp
       end if
       call initialize_array_with_zero(ec_pwxwy_x)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -680,12 +680,12 @@ contains
          jaspacevarcharn = merge(1, 0, str_tolower(quantity) == 'airpressure_windx_windy_charnock')
          if (jaspacevarcharn == 1) then
             call realloc(ec_pwxwy_c, ndx, keepexisting=.true., fill=0.0_dp)
-            call realloc(wcharnock, lnx, keepexisting=.true., fill=0.0_dp)
+            call realloc(wcharnock%values, lnx, keepexisting=.true., fill=wcharnock%scalar)
          end if
 
       case ('charnock')
          call realloc(ec_charnock, ndx, keepexisting=.true., fill=0.0_dp)
-         call realloc(wcharnock, lnx, keepexisting=.true., fill=0.0_dp)
+         call realloc(wcharnock%values, lnx, keepexisting=.true., fill=wcharnock%scalar)
 
       case ('windx', 'windy', 'windxy', 'stressxy', 'stressx', 'stressy')
          target_location_type = UNC_LOC_U

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -833,8 +833,8 @@ contains
 
                if (jaspacevarcharn == 1) then
                   if (.not. allocated(ec_pwxwy_c)) then
-                     allocate (ec_pwxwy_c(ndx), wcharnock%values(lnx), stat=ierr)
-                     call aerr('ec_pwxwy_c(ndx), wcharnock%values(lnx)', ierr, ndx + lnx)
+                     call realloc(ec_pwxwy_c, ndx, keepexisting=.true., fill=0.0_dp)
+                     call realloc(wcharnock%values, lnx, keepexisting=.true., fill=wcharnock%scalar)
                      ec_pwxwy_c = 0.0_dp
                   end if
                end if
@@ -857,8 +857,7 @@ contains
                   ec_charnock(:) = 0.0_dp
                end if
                if (.not. allocated(wcharnock%values)) then
-                  allocate (wcharnock%values(lnx), stat=ierr)
-                  call aerr('wcharnock%values(lnx)', ierr, lnx)
+                  call realloc(wcharnock%values, lnx, keepexisting=.true., fill=wcharnock%scalar)
                end if
                success = ec_addtimespacerelation(qid, xz(1:ndx), yz(1:ndx), mask, kx, filename, filetype, method, operand, varname=varname)
                if (success) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -833,8 +833,8 @@ contains
 
                if (jaspacevarcharn == 1) then
                   if (.not. allocated(ec_pwxwy_c)) then
-                     allocate (ec_pwxwy_c(ndx), wcharnock(lnx), stat=ierr)
-                     call aerr('ec_pwxwy_c(ndx), wcharnock(lnx)', ierr, ndx + lnx)
+                     allocate (ec_pwxwy_c(ndx), wcharnock%values(lnx), stat=ierr)
+                     call aerr('ec_pwxwy_c(ndx), wcharnock%values(lnx)', ierr, ndx + lnx)
                      ec_pwxwy_c = 0.0_dp
                   end if
                end if
@@ -856,9 +856,9 @@ contains
                   call aerr('ec_charnock(ndx)', ierr, ndx)
                   ec_charnock(:) = 0.0_dp
                end if
-               if (.not. allocated(wcharnock)) then
-                  allocate (wcharnock(lnx), stat=ierr)
-                  call aerr('wcharnock(lnx)', ierr, lnx)
+               if (.not. allocated(wcharnock%values)) then
+                  allocate (wcharnock%values(lnx), stat=ierr)
+                  call aerr('wcharnock%values(lnx)', ierr, lnx)
                end if
                success = ec_addtimespacerelation(qid, xz(1:ndx), yz(1:ndx), mask, kx, filename, filetype, method, operand, varname=varname)
                if (success) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -330,6 +330,7 @@ contains
    !> compute fluxes based on Monin-Obukhov Stability Theory
    module subroutine compute_air_water_interaction_most_fluxes(initialization)
       use precision, only: dp
+      use m_alloc, only: realloc
       use m_flowgeom, only: ndx, lnx, csu, snu
       use m_get_surface_temperature, only: get_surface_temperature
       use m_flowgeom_interpolate, only: link_to_node_vector, link_to_node_scalar
@@ -366,7 +367,10 @@ contains
       call compute_wind_relative_to_surface_on_link(wx(1:lnx), wy(1:lnx), relativewind, u1(ltop(1:lnx)), v(ltop(1:lnx)), &
                                csu(1:lnx), snu(1:lnx), windx_link, windy_link)
       call link_to_node_vector(windx_link, windy_link, windx, windy, ndx)
-      call link_to_node_scalar(wcharnock, charnock, ndx)
+      if (.not. allocated(wcharnock%values)) then
+         call realloc(wcharnock%values, lnx, keepexisting=.true., fill=wcharnock%scalar)
+      end if
+      call link_to_node_scalar(wcharnock%values, charnock, ndx)
 
       call get_surface_temperature(surface_temperature, initialization)
       surface_temperature_kelvin = celsius_to_kelvin(surface_temperature)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -340,7 +340,9 @@ contains
       use physicalconsts, only: celsius_to_kelvin
       use m_flowparameters, only: atmospheric_stability_function, ATMOSPHERIC_STABILITY_FUNCTION_ECMWF, &
                                   free_convection, FREE_CONVECTION_ON, salinity_reduction_factor_saturation_humidity, &
-                                  sensor_height_wind_velocity, sensor_height_air_temperature, sensor_height_humidity
+                                  sensor_height_wind_velocity, sensor_height_air_temperature, sensor_height_humidity, &
+                                  air_viscous_momentum_coeff, air_viscous_heat_coeff, air_viscous_moisture_coeff
+
 
       logical, intent(in) :: initialization !< initialization phase
       
@@ -385,6 +387,9 @@ contains
       atm_stability_options%sensor_height_wind_velocity = sensor_height_wind_velocity
       atm_stability_options%sensor_height_air_temperature = sensor_height_air_temperature
       atm_stability_options%sensor_height_humidity = sensor_height_humidity
+      atm_stability_options%alpha_m = air_viscous_momentum_coeff
+      atm_stability_options%alpha_h = air_viscous_heat_coeff
+      atm_stability_options%alpha_q = air_viscous_moisture_coeff
 
       call compute_scales_and_fluxes(windx, windy, air_temperature_kelvin, dew_point_temperature_kelvin, &
                                      air_pressure, charnock, surface_temperature_kelvin, atm_stability_options)


### PR DESCRIPTION
# What was done 
- Introduce the following four keywords in mdu:
<img width="1225" height="244" alt="image" src="https://github.com/user-attachments/assets/4b062372-bc01-453d-b719-968ac1e3ec73" />

- Modify module atmospheric_stability to accept the 3 viscous variables as extra options
- Modify variable wcharnock, declare it as t_array_or_scalar, to be able to work as scalar or array
- Integration tested using dcsm5, see https://issuetracker.deltares.nl/browse/UNST-10046

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable; it will be documented in https://issuetracker.deltares.nl/browse/UNST-9893

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10046
