### PR TITLE
UNST-10162 Increase the conan source download timeout from 1 to 5 min…

### DIFF
--- a/run_conan.py
+++ b/run_conan.py
@@ -168,6 +168,9 @@ def conan_install(
         f"build_type={build_type}",
         f"--output-folder={output_folder}",
         f"--lockfile={LOCKFILE}",
+        # Large source archives can exceed Conan's default 60-second read timeout.
+        "--core-conf",
+        "core.net.http:timeout=300",
     ]
 
     if build_policy == BuildPolicy.ALL:


### PR DESCRIPTION
…utes to allow petsc downloads that take a while

# Issue link UNST-10162
