### PR TITLE
Fix RT_retrieve_var error code overwrite

### DIFF
--- a/src/utils_lgpl/nefis/packages/nefis/src/gt.c
+++ b/src/utils_lgpl/nefis/packages/nefis/src/gt.c
@@ -300,6 +300,10 @@ BInt4 Get_element(BInt4 set, BText grp_name, BText elm_name, BInt4* usr_index, B
             nefis_errno = RT_retrieve_var(set, &grp_pointer, v, &var_file_offset);
             if (nefis_errno != 0)
             {
+                if (nefis_errno != 1)
+                {
+                    return nefis_errno;
+                }
                 nefis_errcnt += 1;
                 nefis_errno = 3006;
                 sprintf(error_text, "Variable dimension %ld not found for:\n group \"%s\", element \"%s\"\n", v + 1,

--- a/src/utils_lgpl/nefis/packages/nefis/src/gt.c
+++ b/src/utils_lgpl/nefis/packages/nefis/src/gt.c
@@ -300,14 +300,14 @@ BInt4 Get_element(BInt4 set, BText grp_name, BText elm_name, BInt4* usr_index, B
             nefis_errno = RT_retrieve_var(set, &grp_pointer, v, &var_file_offset);
             if (nefis_errno != 0)
             {
-                if (nefis_errno != 1)
+                if (nefis_errno == 1) // var_index error in RT_retrieve_var
                 {
-                    return nefis_errno;
+                    nefis_errcnt += 1;
+                    nefis_errno = 3006;
+                    sprintf(error_text, "Variable dimension %ld not found for:\n group \"%s\", element \"%s\"\n",
+                            v + 1, grp_name, elm_name);
                 }
-                nefis_errcnt += 1;
-                nefis_errno = 3006;
-                sprintf(error_text, "Variable dimension %ld not found for:\n group \"%s\", element \"%s\"\n", v + 1,
-                        grp_name, elm_name);
+                free((BData)ch_buffer);
                 return nefis_errno;
             }
         }

--- a/src/utils_lgpl/nefis/packages/nefis/src/rt.c
+++ b/src/utils_lgpl/nefis/packages/nefis/src/rt.c
@@ -367,13 +367,16 @@ BInt4 RT_retrieve_var(BInt4 set, BUInt8* grp_pointer, BInt4 var_index, BUInt8* v
     }
 
     error = RT_update_var_array(set, gd, grp_pointer);
-    if (error == 0 && var_index < retrieve_var[set][gd][1])
+    if (error == 0) // don't overwrite error codes
     {
-        *var_pointer = retrieve_var[set][gd][var_index + 3];
-    }
-    else
-    {
-        error = 1; /*  var_index (c-numbering; retrieve_var (fortran-numbering) */
+        if (var_index < retrieve_var[set][gd][1])
+        {
+            *var_pointer = retrieve_var[set][gd][var_index + 3];
+        }
+        else
+        {
+            error = 1; /*  var_index (c-numbering; retrieve_var (fortran-numbering) */
+        }
     }
 
     return error;


### PR DESCRIPTION
## Description

`RT_retrieve_var` can return either 0, 1 or 9001. When 1 is returned, the caller (`Get_element`) sets up `nefis_errno`, `error_text` and increments `nefis_errcnt`. The problem is that it also does this when 9001 is returned. In this case, it overwrites `nefis_errno` and `error_text`, making error 9001 unreachable from this path, resulting in a misleading error message and also incrementing `nefis_errcnt` more than it should.

This change makes it so `Get_element` converts the generic return value 1 returned by `RT_retrieve_var`, but propagates any other error codes returned.
 

## Testing

Verified by code inspection. The change preserves:
 - success (0 returned)
 - generic error (1 -> generates error 3006)
 - specific error (9001 -> propagates error 9001 unchanged)
 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DELFT3D-37936