### PR TITLE
UNST-10106 Fixed duplicate keywords in dflowfm kernel's write mdu logic

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
@@ -890,10 +890,10 @@ contains
                              'm', UNC_LOC_RUG, description='Write run-up gauge statistics to his-file')
       call add_output_config(config_set_his, IDX_HIS_RUG_RUX, &
                              'Wrihis_runupgauge', 'rug_x_coordinate', 'time-varying x-coordinate of shoreline position', '', &
-                             'm', UNC_LOC_RUG, description='Write run-up gauge statistics to his-file')
+                             'm', UNC_LOC_RUG)
       call add_output_config(config_set_his, IDX_HIS_RUG_RUY, &
                              'Wrihis_runupgauge', 'rug_y_coordinate', 'time-varying y-coordinate of shoreline position', '', &
-                             'm', UNC_LOC_RUG, description='Write run-up gauge statistics to his-file')
+                             'm', UNC_LOC_RUG)
 
       !
       ! HIS: hydraulic structures

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -3152,9 +3152,7 @@ contains
       if (writeall .or. locsaltmax /= 10.0_dp) then
          call prop_set(prop_ptr, 'numerics', 'LocSaltMax', locsaltmax, 'maximum salinity for case of lock exchange')
       end if
-      if (writeall .or. numlimdt_baorg > 0) then
-         call prop_set(prop_ptr, 'numerics', 'Numlimdt_baorg', Numlimdt_baorg, 'if previous numlimdt > Numlimdt_baorg keep original cell area ba in cutcell')
-      end if
+      call prop_set(prop_ptr, 'numerics', 'Numlimdt_baorg', Numlimdt_baorg, 'if previous numlimdt > Numlimdt_baorg keep original cell area ba in cutcell')
       if (writeall .or. baorgfracmin > 0) then
          call prop_set(prop_ptr, 'numerics', 'Baorgfracmin', Baorgfracmin, 'Cell area = max(orgcellarea*Baorgfracmin, cutcell area) ')
       end if
@@ -3191,7 +3189,6 @@ contains
       end if
 
       call prop_set(prop_ptr, 'numerics', 'FlowSolver', trim(md_flow_solver), 'Flow solver.')
-      call prop_set(prop_ptr, 'numerics', 'Numlimdt_baorg', Numlimdt_baorg, 'if previous numlimdt > Numlimdt_baorg keep original cell area ba in cutcell')
 
       ! Physics
       call prop_set(prop_ptr, 'physics', 'unifFrictCoef', frcuni, 'Uniform friction coefficient [the unit depends on unifFrictType].')


### PR DESCRIPTION
# What was done 

When working on dflowfm_io-related tests I noticed that the dflowfm kernel always writes certain duplicate properties when writing to an mdu file. `Numlimdt_baorg` is always written twice, `wrihis_runupgauge` is always written three times. Just open any .dia file to confirm this.

<img width="477" height="259" alt="image" src="https://github.com/user-attachments/assets/fb089a7f-1217-4792-846d-3f9c942c76cc" />

<img width="389" height="201" alt="image" src="https://github.com/user-attachments/assets/82a38754-62b1-4011-af15-0166673e318b" />

# Issue link

https://issuetracker.deltares.nl/browse/UNST-10106
