### PR TITLE
All/bugfix/unst 10036 oneapi 2026 code issues

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/flowgeom_mask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/flowgeom_mask.f90
@@ -30,8 +30,9 @@
 
 module m_flowgeom_mask
    use precision_basics, only: dp
-   use fm_location_types, only: parse_spatial_location_type, UNC_LOC_CN, UNC_LOC_S, UNC_LOC_S3D, UNC_LOC_U, &
-      SPATIAL_LOCATION_INVALID, SPATIAL_LOCATION_1D, SPATIAL_LOCATION_2D, SPATIAL_LOCATION_ALL
+   use fm_location_types, only: parse_spatial_location_type, UNC_LOC_3DV, UNC_LOC_CN, UNC_LOC_GLOBAL, UNC_LOC_S, &
+      UNC_LOC_S3D, UNC_LOC_U, SPATIAL_LOCATION_INVALID, SPATIAL_LOCATION_1D, SPATIAL_LOCATION_2D, SPATIAL_LOCATION_ALL
+   use messagehandling, only: LEVEL_FATAL, mess
 
    implicit none(type, external)
 
@@ -46,6 +47,7 @@ contains
    subroutine construct_mask(mask, location_type, spatial_location_type, target_mask_file, invert_mask, ierr)
       use m_flowgeom, only: lnx, ndx
       use network_data, only: numk
+      use m_alloc, only: realloc
 
       ! Parameters
       integer, dimension(:), allocatable, intent(inout) :: mask !< Mask array for the target element set.
@@ -62,20 +64,17 @@ contains
       select case (location_type)
       case (UNC_LOC_CN)
          num_elements = numk
-      case (UNC_LOC_S, UNC_LOC_S3D)
+      case (UNC_LOC_3DV, UNC_LOC_S, UNC_LOC_S3D)
          num_elements = ndx
       case (UNC_LOC_U)
          num_elements = lnx
+      case (UNC_LOC_GLOBAL)
+         num_elements = 0
+      case default
+         call mess(LEVEL_FATAL, 'm_flowgeom_mask::construct_mask: Unsupported location type: ', location_type)
       end select
 
-      if (size(mask) /= num_elements) then
-         if (allocated(mask)) then
-            deallocate(mask)
-         end if
-         allocate(mask(num_elements))
-      end if
-
-      mask = 0
+      call realloc(mask, num_elements, keepExisting=.false., fill=0)
 
       call apply_spatial_location_mask(mask, location_type, spatial_location_type)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -408,6 +408,7 @@ contains
       ! ARRANGE
 
       ndx2D = 0
+      call setup_minimal_grid()
       call realloc(bl, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(s1, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(hs, ndx, fill=0.0_dp, keepExisting=.false.)
@@ -415,7 +416,6 @@ contains
       tzone       = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
-      call setup_minimal_grid()
       call initialize_ec_module()
       ierr = m_polygon_destructor()
 

--- a/src/engines_gpl/dsle/packages/tests/test_dimr_bmi.c
+++ b/src/engines_gpl/dsle/packages/tests/test_dimr_bmi.c
@@ -99,7 +99,7 @@ static void test_finalize(void) {
 
 static void test_get_var_parameterized(char *variable_name, double *source) {
   double *destination;
-  int status = get_var(variable_name, &destination);
+  int status = get_var(variable_name, (void**)&destination);
   TEST_ASSERT_EQUAL(DIMR_BMI_OK, status);
   TEST_ASSERT_EQUAL(source, destination);
 }
@@ -123,7 +123,7 @@ TEST_GET_VAR(salinity_lake, config.locks[0].parameters3d.salinity_lake)
 
 static void test_get_var__unknown_var_name(void) {
   double *result;
-  int status = get_var("the_answer_to_life_the_universe_and_everything", &result);
+  int status = get_var("the_answer_to_life_the_universe_and_everything", (void**)&result);
   TEST_ASSERT_EQUAL(DIMR_BMI_FAILURE, status);
 }
 

--- a/src/utils_lgpl/deltares_common/packages/deltares_common_c/src/bmi_shared_lib_fortran_api.c
+++ b/src/utils_lgpl/deltares_common/packages/deltares_common_c/src/bmi_shared_lib_fortran_api.c
@@ -208,15 +208,13 @@ void STDCALL BMI_GET_VAR_POINTER(int64_t* sharedDLLHandle, char* var_name, void*
 
 void STDCALL BMI_GET_VAR_SHAPE(int64_t* sharedDLLHandle, char* var_name, int* values, int var_name_len)
 {
-    typedef void*(STDCALL * MyProc)(char*, double**);
+    typedef void*(STDCALL * MyProc)(char*, int*);
     MyProc proc = (MyProc)GetDllProcedure(sharedDLLHandle, "get_var_shape");
 
-    int i;           // vs2102 and lower do not support typedefs in combination
-    int* bmi_values; // with local variable declaration, hence declare at start of function
     char* c_var_name = strFcpy(var_name, var_name_len);
     if (proc != NULL)
     {
-        (void*)(*proc)(var_name, values);
+        (void*)(*proc)(c_var_name, values);
     }
 
     free(c_var_name);


### PR DESCRIPTION
# What was done

- Fixed multiple bugs in flowgeom_mask that did not initialise num_elements and then properly allocate the mask for multiple location types. This caused unit test_init_spatial_fields_integration.test_initialverticalsalinityprofile to fail with OneAPI 2026
- Throw proper error if an unknown location type is encountered
- Fixed bug in test_init_spatial_fields_integration.test_initialwaterlevel_static_field_populated_at_init where ndx is used before it is set
- Fixed bugs in deltares_common_c code, stronger type checking caught those

# Issue link UNST-10036
