### PR TITLE
UNST-10125: Effe wachten... Python! (Try to fix -1073741819)

### DIFF
--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -146,7 +146,7 @@ object WindowsTest : BuildType({
 
                 rem Desperate attempt to fix the accursed, unutterable "Exit code -1073741819" problem.
                 echo "Effe wachten..."
-                timeout /t 3 /nobreak >nul
+                timeout /t 3 /nobreak
                 echo "...Python!"
 
                 python TestBench.py %%argsList%%

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -146,7 +146,7 @@ object WindowsTest : BuildType({
 
                 rem Desperate attempt to fix the accursed, unutterable "Exit code -1073741819" problem.
                 echo "Effe wachten..."
-                timeout /t 3 /nobreak
+                ping -n 5 -w 1000 localhost > nul
                 echo "...Python!"
 
                 python TestBench.py %%argsList%%

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -143,6 +143,12 @@ object WindowsTest : BuildType({
                 call C:\venv\Scripts\activate.bat
                 uv pip sync pip/win-requirements.txt
                 if %%ERRORLEVEL%% NEQ 0 exit /b 1
+
+                rem Desperate attempt to fix the accursed, unutterable "Exit code -1073741819" problem.
+                echo "Effe wachten..."
+                timeout /t 3 /nobreak >nul
+                echo "...Python!"
+
                 python TestBench.py %%argsList%%
             """.trimIndent()
 

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -144,10 +144,9 @@ object WindowsTest : BuildType({
                 uv pip sync pip/win-requirements.txt
                 if %%ERRORLEVEL%% NEQ 0 exit /b 1
 
-                rem Desperate attempt to fix the accursed, unutterable "Exit code -1073741819" problem.
-                echo "Effe wachten..."
+                rem Wait for five seconds. Kludge to get rid of the "-1073741819" exit codes we've 
+                rem been dealing with during the module import phase of "Python TestBench.py"
                 ping -n 5 -w 1000 localhost > nul
-                echo "...Python!"
 
                 python TestBench.py %%argsList%%
             """.trimIndent()


### PR DESCRIPTION
# What was done 

Added sleep after installing dependencies and before invoking `python TestBench.py`
The stacktraces that get printed by python point to importlib internal cpython modules. It seems the crash happens on calls to `read`. Check the stacktraces in failing builds and look up the source code here: https://github.com/python/cpython/tree/v3.12.12/Lib/importlib

@mihai-pricope suggested to me that maybe loading the libraries right after installing them to the venv could be problematic. Nobody likes this solution, but the other things we tried didn't seem to work. I will run the pipeline probably ten times (with filter, so that no test cases actually run). If the problem doesn't occur anymore, we're keeping the changes

UPDATE 2026-07-31:
I have run the 'Test' build hundreds of times now over the course of several days (in the order of 10 full pipeline runs). Thankfully, the `-1073741819` exit code occurs before any tests actually run, so I ran the build with a very restrictive test case filter (that match no actual tests). This way I can reproduce the problem quickly without using too much of the build agents' resources. I have not been able to produce a single `-1073741819` exit code. To me that makes me more confident that this fix actually works, even though it is an eyesore.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
