### PR TITLE
Tc/bugfix/unst 9695 fix waq link libraries

### DIFF
--- a/ci/teamcity/Delft3D/windows/collect.kt
+++ b/ci/teamcity/Delft3D/windows/collect.kt
@@ -112,6 +112,7 @@ object WindowsCollect : BuildType({
             param("nexus_repo", "/delft3d-dev")
             param("retention_period", "07_day_retention")
             param("target_path", "/dimrset/%file_path%")
+            enabled = false
         }
     }
 

--- a/ci/teamcity/Delft3D/windows/test.kt
+++ b/ci/teamcity/Delft3D/windows/test.kt
@@ -86,6 +86,7 @@ object WindowsTest : BuildType({
             param("nexus_username", "%nexus_username%")
             param("download_to", "/downloads")
             param("nexus_password", "%nexus_password%")
+            enabled = false
         }
         powerShell {
             name = "Extract artifact"

--- a/src/engines_gpl/part/part_data/CMakeLists.txt
+++ b/src/engines_gpl/part/part_data/CMakeLists.txt
@@ -2,10 +2,11 @@ set(library_name part_data_f)
 
 create_target(${library_name} ${CMAKE_CURRENT_SOURCE_DIR} src_dir .)
 
-# Add dependencies
-set(oss_dependencies waq_hyd_data)
+target_link_libraries(${library_name} PRIVATE
+    waq_definition
+    waq_hyd_data
+)
 
-target_link_libraries(${library_name} ${oss_dependencies})
 set_target_properties(${library_name} PROPERTIES FOLDER engines_gpl/part)
 
 target_compile_options(${library_name} PRIVATE ${openmp_flag})


### PR DESCRIPTION
Fixes issue in WAQ: m_waq_precision is used in part_data_f, but m_waq_precision lives inside the waq_definition target, and that was not linked to part_data_f

# Issue link UNST-9695
