### PR TITLE
UNST-10160_salinity_dependent_QsatFactor

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -773,7 +773,7 @@ contains
       air_water_interaction_model = AIR_WATER_INTERACTION_MODEL_NONE ! Air-water interaction model
       atmospheric_stability_function = ATMOSPHERIC_STABILITY_FUNCTION_NONE ! Atmospheric stability function
       free_convection = FREE_CONVECTION_OFF ! Free convection model
-      salinity_dependent_evaporation_method = 0 ! Switch for methods for determining salinity_reduction_factor_saturation_humidity
+      salinity_dependent_evaporation_method = SALINITY_DEPENDENT_EVAPORATION_NONE ! Switch for methods for determining salinity_reduction_factor_saturation_humidity
       salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp ! Reduction factor for salinity in saturation humidity calculation, 1.0 means no reduction
       sensor_height_wind_velocity = 10.0_dp ! Height of prescribed wind velocity
       sensor_height_air_temperature = 2.0_dp ! Height of prescribed air temperature

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -33,6 +33,7 @@ module m_flowparameters
    use m_missing
    use m_waveconst
    use messagehandling, only: idlen
+   use m_array_or_scalar, only: t_array_or_scalar
 
    implicit none(type, external)
 
@@ -134,7 +135,12 @@ module m_flowparameters
    integer, parameter :: FREE_CONVECTION_OFF = 0 !< Free convection off
    integer, parameter :: FREE_CONVECTION_ON = 1 !< Free convection on
    
-   real(kind=dp) :: salinity_reduction_factor_saturation_humidity !< Salinity reduction factor for saturation humidity in bulk formulae
+   integer :: salinity_dependent_evaporation_method !< Switch for methods for determining salinity_reduction_factor_saturation_humidity
+   integer, parameter :: SALINITY_DEPENDENT_EVAPORATION_NONE = 0 !< salinity_reduction_factor_saturation_humidity is 1.0 (no reduction)
+   integer, parameter :: SALINITY_DEPENDENT_EVAPORATION_CONSTANT = 1 !< salinity_reduction_factor_saturation_humidity is constant
+   integer, parameter :: SALINITY_DEPENDENT_EVAPORATION_LINEAR = 2 !< salinity_reduction_factor_saturation_humidity is a linear function of local salinity
+   type(t_array_or_scalar), target :: salinity_reduction_factor_saturation_humidity !< Salinity reduction factor for saturation humidity in bulk formulae
+   
    real(kind=dp) :: sensor_height_wind_velocity !< Sensor height of prescribed wind velocity [m]
    real(kind=dp) :: sensor_height_air_temperature !< Sensor height of prescribed air temperature [m]
    real(kind=dp) :: sensor_height_humidity !< Sensor height of prescribed humidity [m]
@@ -767,7 +773,8 @@ contains
       air_water_interaction_model = AIR_WATER_INTERACTION_MODEL_NONE ! Air-water interaction model
       atmospheric_stability_function = ATMOSPHERIC_STABILITY_FUNCTION_NONE ! Atmospheric stability function
       free_convection = FREE_CONVECTION_OFF ! Free convection model
-      salinity_reduction_factor_saturation_humidity = 1.0_dp ! Reduction factor for salinity in saturation humidity calculation, 1.0 means no reduction
+      salinity_dependent_evaporation_method = 0 ! Switch for methods for determining salinity_reduction_factor_saturation_humidity
+      salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp ! Reduction factor for salinity in saturation humidity calculation, 1.0 means no reduction
       sensor_height_wind_velocity = 10.0_dp ! Height of prescribed wind velocity
       sensor_height_air_temperature = 2.0_dp ! Height of prescribed air temperature
       sensor_height_humidity = 2.0_dp ! Height of prescribed humidity

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1425,7 +1425,12 @@ contains
       call prop_get(md_ptr, 'meteo', 'AirSeaInteractionModel', air_water_interaction_model)
       call prop_get(md_ptr, 'meteo', 'StabilityFunctions', atmospheric_stability_function)
       call prop_get(md_ptr, 'meteo', 'FreeConvection', free_convection)
-      call prop_get(md_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity)
+      call prop_get(md_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method)
+      if (salinity_dependent_evaporation_method == 1) then
+         call prop_get(md_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar)
+      else if (salinity_dependent_evaporation_method < 0 .or. salinity_dependent_evaporation_method > 2) then
+         call mess(LEVEL_ERROR, 'SalinityDependentEvaporationMethod can only be set to 0, 1 or 2')
+      end if
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
       call prop_get(md_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature)
       call prop_get(md_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity)
@@ -3351,7 +3356,10 @@ contains
       call prop_set(prop_ptr, 'meteo', 'AirSeaInteractionModel', air_water_interaction_model, 'Air water interaction model (0: none, 1: Monin-Obukhov Similarity Theory).')
       call prop_set(prop_ptr, 'meteo', 'StabilityFunctions', atmospheric_stability_function, 'Atmospheric stability function (0: none, 1: ECMWF).')
       call prop_set(prop_ptr, 'meteo', 'FreeConvection', free_convection, 'Free convection switch (0: off, 1: on).')
-      call prop_set(prop_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity, 'Salinity reduction factor for saturation humidity in bulk formulae.')      
+      call prop_set(prop_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method, 'Salinity dependent evaporation method (0: off, 1: constant reduction factor, 2: surface-salinity dependent reduction factor).')
+      if (salinity_dependent_evaporation_method < 2) then
+         call prop_set(prop_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar, 'Salinity reduction factor for saturation humidity in bulk formulae.')      
+      end if
       call prop_set(prop_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity, 'Sensor height of prescribed wind velocity [m]')
       call prop_set(prop_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature, 'Sensor height of prescribed air temperature [m]')
       call prop_set(prop_ptr, 'meteo', 'HumidityForcingHeight', sensor_height_humidity, 'Sensor height of prescribed humidity variable [m]')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1425,11 +1425,14 @@ contains
       call prop_get(md_ptr, 'meteo', 'AirSeaInteractionModel', air_water_interaction_model)
       call prop_get(md_ptr, 'meteo', 'StabilityFunctions', atmospheric_stability_function)
       call prop_get(md_ptr, 'meteo', 'FreeConvection', free_convection)
-      call prop_get(md_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method)
-      if (salinity_dependent_evaporation_method == 1) then
-         call prop_get(md_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar)
-      else if (salinity_dependent_evaporation_method < 0 .or. salinity_dependent_evaporation_method > 2) then
-         call mess(LEVEL_ERROR, 'SalinityDependentEvaporationMethod can only be set to 0, 1 or 2')
+      call prop_get(md_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method, success)
+      if (success) then
+         if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_CONSTANT) then
+            call prop_get(md_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar)
+         elseif (salinity_dependent_evaporation_method < SALINITY_DEPENDENT_EVAPORATION_NONE .or. &
+                 salinity_dependent_evaporation_method > SALINITY_DEPENDENT_EVAPORATION_LINEAR) then
+            call mess(LEVEL_ERROR, 'SalinityDependentEvaporationMethod can only be set to 0, 1 or 2')
+         end if
       end if
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
       call prop_get(md_ptr, 'meteo', 'AirTemperatureForcingHeight', sensor_height_air_temperature)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -1429,9 +1429,11 @@ contains
       if (success) then
          if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_CONSTANT) then
             call prop_get(md_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar)
-         elseif (salinity_dependent_evaporation_method < SALINITY_DEPENDENT_EVAPORATION_NONE .or. &
-                 salinity_dependent_evaporation_method > SALINITY_DEPENDENT_EVAPORATION_LINEAR) then
+         elseif (.not. ANY(salinity_dependent_evaporation_method == [SALINITY_DEPENDENT_EVAPORATION_NONE,SALINITY_DEPENDENT_EVAPORATION_LINEAR])) then
             call mess(LEVEL_ERROR, 'SalinityDependentEvaporationMethod can only be set to 0, 1 or 2')
+         end if
+         if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_LINEAR .and. jasal == 0) then
+            call mess(LEVEL_ERROR, 'SalinityDependentEvaporationMethod set to 2 but Salinity is turned off in mdu.')
          end if
       end if
       call prop_get(md_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity)
@@ -3359,8 +3361,8 @@ contains
       call prop_set(prop_ptr, 'meteo', 'AirSeaInteractionModel', air_water_interaction_model, 'Air water interaction model (0: none, 1: Monin-Obukhov Similarity Theory).')
       call prop_set(prop_ptr, 'meteo', 'StabilityFunctions', atmospheric_stability_function, 'Atmospheric stability function (0: none, 1: ECMWF).')
       call prop_set(prop_ptr, 'meteo', 'FreeConvection', free_convection, 'Free convection switch (0: off, 1: on).')
-      call prop_set(prop_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method, 'Salinity dependent evaporation method (0: off, 1: constant reduction factor, 2: surface-salinity dependent reduction factor).')
-      if (salinity_dependent_evaporation_method < 2) then
+      call prop_set(prop_ptr, 'meteo', 'SalinityDependentEvaporationMethod', salinity_dependent_evaporation_method, 'Salinity dependent evaporation method (0: off, 1: constant reduction factor, 2: salinity-dependent reduction factor).')
+      if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_CONSTANT) then
          call prop_set(prop_ptr, 'meteo', 'QsatFactor', salinity_reduction_factor_saturation_humidity%scalar, 'Salinity reduction factor for saturation humidity in bulk formulae.')      
       end if
       call prop_set(prop_ptr, 'meteo', 'WindForcingHeight', sensor_height_wind_velocity, 'Sensor height of prescribed wind velocity [m]')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -289,6 +289,8 @@ contains
       real(kind=dp), intent(in) :: wind_velocity_y(:) !< y-direction wind component [m/s].
       real(kind=dp), intent(in) :: air_temperature(:) !< Air temperature [K].
       real(kind=dp), intent(in) :: dew_point_temperature(:) !< Dew-point temperature [K].
+      real(kind=dp), intent(in) :: air_pressure(:) !< Air pressure [Pa].
+      real(kind=dp), intent(in) :: charnock(:) !< Charnock parameter [-].
       real(kind=dp), intent(in) :: surface_temperature(:) !< Surface temperature [K].
       type(t_array_or_scalar), intent(in) :: salt_saturation_humidity_reduction_factor !< Salinity reduction factor of saturation humidity [-]
       type(t_options), intent(in) :: options !< Process options

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -289,10 +289,8 @@ contains
       real(kind=dp), intent(in) :: wind_velocity_y(:) !< y-direction wind component [m/s].
       real(kind=dp), intent(in) :: air_temperature(:) !< Air temperature [K].
       real(kind=dp), intent(in) :: dew_point_temperature(:) !< Dew-point temperature [K].
-      real(kind=dp), intent(in) :: air_pressure(:) !< Air pressure [Pa].
-      real(kind=dp), intent(in) :: charnock(:) !< Charnock parameter [-].
       real(kind=dp), intent(in) :: surface_temperature(:) !< Surface temperature [K].
-      type(t_array_or_scalar), target :: salt_saturation_humidity_reduction_factor !< Salinity reduction factor of saturation humidity [-]
+      type(t_array_or_scalar), intent(in) :: salt_saturation_humidity_reduction_factor !< Salinity reduction factor of saturation humidity [-]
       type(t_options), intent(in) :: options !< Process options
 
       type(t_scales) :: scaling_parameter

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/atmospheric_stability.f90
@@ -22,6 +22,7 @@ module m_atmospheric_stability
    use m_physcoef, only: vonkarw
    use m_flowparameters, only: EPS8
    use MessageHandling, only: err
+   use m_array_or_scalar, only: t_array_or_scalar
 
    implicit none(type, external)
 
@@ -67,7 +68,6 @@ module m_atmospheric_stability
    type :: t_options
       logical :: include_free_convection = .false. !< Use in weak-wind unstable conditions (buoyancy-driven turbulence matters); usually unnecessary in moderate/strong wind or neutral/stable cases.
       logical :: include_stability = .true. !< Use for stability-aware similarity corrections; disable for neutral conditions.
-      real(kind=dp) :: fqsat = 1.0_dp !< Salinity reducing factor of saturation humidity.
       real(kind=dp) :: sensor_height_wind_velocity = 10.0_dp !< Sensor height of prescribed wind velocity [m]
       real(kind=dp) :: sensor_height_humidity = 2.0_dp !< Sensor height of prescribed humidity [m]
       real(kind=dp) :: sensor_height_air_temperature = 2.0_dp !< Sensor height of prescribed air temperature [m]
@@ -108,7 +108,7 @@ contains
 
    !> Compute turbulence scaling parameters for a point value.
    pure function compute_scaling_parameters(wind_velocity_x, wind_velocity_y, air_temperature, dew_point_temperature, &
-                                            air_pressure, charnock, surface_temperature, options) result(result)
+                                            air_pressure, charnock, surface_temperature, salt_saturation_humidity_reduction_factor, options) result(result)
       real(kind=dp), intent(in) :: wind_velocity_x !< x-direction wind component [m/s].
       real(kind=dp), intent(in) :: wind_velocity_y !< y-direction wind component [m/s].
       real(kind=dp), intent(in) :: air_temperature !< Air temperature [K].
@@ -116,10 +116,10 @@ contains
       real(kind=dp), intent(in) :: air_pressure !< Air pressure [Pa].
       real(kind=dp), intent(in) :: charnock !< Charnock parameter [-].
       real(kind=dp), intent(in) :: surface_temperature !< Surface temperature [K].
+      real(kind=dp), intent(in) :: salt_saturation_humidity_reduction_factor !< Salinity reduction factor of saturation humidity
       type(t_options), intent(in) :: options !< Optional model switches.
       type(t_scales) :: result !< Computed scaling outputs.
 
-      real(kind=dp) :: salt_saturation_humidity_reduction_factor
       real(kind=dp) :: wind_velocity_magnitude
       real(kind=dp) :: vapor_pressure, saturated_vapor_pressure ! vapor and saturated vapor pressure at temperature sensor's height
       real(kind=dp) :: saturated_surface_vapor_pressure ! saturated vapor pressure just above water surface
@@ -153,7 +153,6 @@ contains
          vapor_pressure = compute_saturation_pressure(dew_point_temperature)
          saturated_vapor_pressure = compute_saturation_pressure(air_temperature)
          air_humidity = compute_specific_humidity(vapor_pressure, air_pressure)
-         salt_saturation_humidity_reduction_factor = options%fqsat
          saturated_surface_vapor_pressure = compute_saturation_pressure(surface_temperature)
          surface_humidity = compute_specific_humidity(saturated_surface_vapor_pressure, air_pressure)
          surface_humidity = salt_saturation_humidity_reduction_factor * surface_humidity
@@ -285,7 +284,7 @@ contains
    !> Compute arrays of scaling parameters and bulk surface fluxes.
    !! This routine gives no return values. It fills the module arrays with proper values.
    subroutine compute_scales_and_fluxes(wind_velocity_x, wind_velocity_y, air_temperature, dew_point_temperature, &
-                                        air_pressure, charnock, surface_temperature, options)
+                                        air_pressure, charnock, surface_temperature, salt_saturation_humidity_reduction_factor, options)
       real(kind=dp), intent(in) :: wind_velocity_x(:) !< x-direction wind component [m/s].
       real(kind=dp), intent(in) :: wind_velocity_y(:) !< y-direction wind component [m/s].
       real(kind=dp), intent(in) :: air_temperature(:) !< Air temperature [K].
@@ -293,6 +292,7 @@ contains
       real(kind=dp), intent(in) :: air_pressure(:) !< Air pressure [Pa].
       real(kind=dp), intent(in) :: charnock(:) !< Charnock parameter [-].
       real(kind=dp), intent(in) :: surface_temperature(:) !< Surface temperature [K].
+      type(t_array_or_scalar), target :: salt_saturation_humidity_reduction_factor !< Salinity reduction factor of saturation humidity [-]
       type(t_options), intent(in) :: options !< Process options
 
       type(t_scales) :: scaling_parameter
@@ -320,7 +320,8 @@ contains
       do index = 1, number_of_elements
          scaling_parameter = compute_scaling_parameters(wind_velocity_x(index), wind_velocity_y(index), air_temperature(index), &
                                                         dew_point_temperature(index), air_pressure(index), charnock(index), &
-                                                        surface_temperature(index), options)
+                                                        surface_temperature(index), salt_saturation_humidity_reduction_factor%get(index), &
+                                                        options)
 
          vapor_pressure = compute_saturation_pressure(dew_point_temperature(index))
          air_density = compute_air_density(air_temperature(index), air_pressure(index), vapor_pressure)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
@@ -41,15 +41,29 @@ module m_get_surface_salinity
 
    !> Returns the surface-layer salinity for all horizontal cells.
    subroutine get_surface_salinity(surface_salinity, initialization)
-      real(kind=dp), intent(out) :: surface_salinity(ndx)   
+      use MessageHandling, only: err
+      use m_flow, only: sa1
+      use m_transport, only: isalt
+
+      real(kind=dp), intent(out) :: surface_salinity(ndx)
       logical, intent(in) :: initialization !< initialization phase
-      
+
       if (initialization) then
+         if (.not. allocated(sa1)) then
+            call err('get_surface_salinity: salinity is not allocated (Salinity=0); cannot use SalinityDependentEvaporationMethod=2.')
+            surface_salinity = 0.0_dp
+            return
+         end if
          call get_surface_salinity_from_sa1(surface_salinity)
       else
+         if (isalt <= 0) then
+            call err('get_surface_salinity: salinity constituent not active (isalt<=0); cannot use SalinityDependentEvaporationMethod=2.')
+            surface_salinity = 0.0_dp
+            return
+         end if
          call get_surface_salinity_from_constituents(surface_salinity)
       end if
-      
+
    end subroutine get_surface_salinity
    
    !> Returns the surface-layer salinity from constituents(isalt,:) for all horizontal cells.
@@ -85,7 +99,7 @@ module m_get_surface_salinity
       real(kind=dp), intent(in) :: surface_salinity
       real(kind=dp), intent(out) :: salinity_reduction_factor_saturation_humidity
       
-      salinity_reduction_factor_saturation_humidity = 1.0_dp - 5.30e-4_dp * surface_salinity
+      salinity_reduction_factor_saturation_humidity = max(0.0_dp, min(1.0_dp, 1.0_dp - 5.30e-4_dp * max(0.0_dp, surface_salinity)))
    end subroutine get_salinity_reduction_factor_saturation_humidity
 
 end module m_get_surface_salinity

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
@@ -1,0 +1,91 @@
+!----- AGPL --------------------------------------------------------------------
+!
+!  Copyright (C)  Stichting Deltares, 2017-2026.
+!
+!  This file is part of Delft3D (D-Flow Flexible Mesh component).
+!
+!  Delft3D is free software: you can redistribute it and/or modify
+!  it under the terms of the GNU Affero General Public License as
+!  published by the Free Software Foundation version 3.
+!
+!  Delft3D  is distributed in the hope that it will be useful,
+!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+!  GNU Affero General Public License for more details.
+!
+!  You should have received a copy of the GNU Affero General Public License
+!  along with Delft3D.  If not, see <http://www.gnu.org/licenses/>.
+!
+!  contact: delft3d.support@deltares.nl
+!  Stichting Deltares
+!  P.O. Box 177
+!  2600 MH Delft, The Netherlands
+!
+!  All indications and logos of, and references to, "Delft3D",
+!  "D-Flow Flexible Mesh" and "Deltares" are registered trademarks of Stichting
+!  Deltares, and remain the property of Stichting Deltares. All rights reserved.
+!
+!-------------------------------------------------------------------------------
+
+module m_get_surface_salinity
+   use precision_basics, only: dp
+   use m_flowgeom, only: ndx
+   use m_get_kbot_ktop, only: getkbotktop
+   
+   implicit none
+
+   public :: get_surface_salinity
+   public :: get_salinity_reduction_factor_saturation_humidity
+
+   contains
+
+   !> Returns the surface-layer salinity for all horizontal cells.
+   subroutine get_surface_salinity(surface_salinity, initialization)
+      real(kind=dp), intent(out) :: surface_salinity(ndx)   
+      logical, intent(in) :: initialization !< initialization phase
+      
+      if (initialization) then
+         call get_surface_salinity_from_sa1(surface_salinity)
+      else
+         call get_surface_salinity_from_constituents(surface_salinity)
+      end if
+      
+   end subroutine get_surface_salinity
+   
+   !> Returns the surface-layer salinity from constituents(isalt,:) for all horizontal cells.
+   subroutine get_surface_salinity_from_constituents(surface_salinity)
+      use m_transport, only: constituents, isalt
+
+      real(kind=dp), intent(out) :: surface_salinity(ndx)
+
+      integer :: n, kb, kt
+
+      do n = 1, ndx
+         call getkbotktop(n, kb, kt)
+         surface_salinity(n) = constituents(isalt, kt)
+      end do
+   end subroutine get_surface_salinity_from_constituents
+
+   !> Returns the surface-layer salinity from sa1 for all horizontal cells.
+   subroutine get_surface_salinity_from_sa1(surface_salinity)
+      use m_flow, only: sa1
+
+      real(kind=dp), intent(out) :: surface_salinity(ndx)
+
+      integer :: n, kb, kt
+
+      do n = 1, ndx
+         call getkbotktop(n, kb, kt)
+         surface_salinity(n) = sa1(kt)
+      end do
+   end subroutine get_surface_salinity_from_sa1
+
+   !> Returns the salinity reduction factor of saturation humidity.
+   elemental subroutine get_salinity_reduction_factor_saturation_humidity(surface_salinity, salinity_reduction_factor_saturation_humidity)
+      real(kind=dp), intent(in) :: surface_salinity
+      real(kind=dp), intent(out) :: salinity_reduction_factor_saturation_humidity
+      
+      salinity_reduction_factor_saturation_humidity = 1.0_dp - 5.30e-4_dp * surface_salinity
+   end subroutine get_salinity_reduction_factor_saturation_humidity
+
+end module m_get_surface_salinity

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_salinity.f90
@@ -31,6 +31,10 @@ module m_get_surface_salinity
    use precision_basics, only: dp
    use m_flowgeom, only: ndx
    use m_get_kbot_ktop, only: getkbotktop
+   use m_flow, only: sa1
+   use m_transport, only: constituents, isalt
+   use m_flowparameters, only: jasal
+   use MessageHandling, only: mess, LEVEL_ERROR
    
    implicit none
 
@@ -41,58 +45,29 @@ module m_get_surface_salinity
 
    !> Returns the surface-layer salinity for all horizontal cells.
    subroutine get_surface_salinity(surface_salinity, initialization)
-      use MessageHandling, only: err
-      use m_flow, only: sa1
-      use m_transport, only: isalt
-
       real(kind=dp), intent(out) :: surface_salinity(ndx)
       logical, intent(in) :: initialization !< initialization phase
-
-      if (initialization) then
-         if (.not. allocated(sa1)) then
-            call err('get_surface_salinity: salinity is not allocated (Salinity=0); cannot use SalinityDependentEvaporationMethod=2.')
-            surface_salinity = 0.0_dp
-            return
-         end if
-         call get_surface_salinity_from_sa1(surface_salinity)
-      else
-         if (isalt <= 0) then
-            call err('get_surface_salinity: salinity constituent not active (isalt<=0); cannot use SalinityDependentEvaporationMethod=2.')
-            surface_salinity = 0.0_dp
-            return
-         end if
-         call get_surface_salinity_from_constituents(surface_salinity)
+      
+      real(kind=dp), dimension(:), pointer :: sal_ptr
+      integer :: n, kb, kt
+      
+      if (jasal == 0) then
+         call mess(LEVEL_ERROR, 'get_surface_salinity: Salinity is turned off in mdu')
+         return
       end if
-
-   end subroutine get_surface_salinity
-   
-   !> Returns the surface-layer salinity from constituents(isalt,:) for all horizontal cells.
-   subroutine get_surface_salinity_from_constituents(surface_salinity)
-      use m_transport, only: constituents, isalt
-
-      real(kind=dp), intent(out) :: surface_salinity(ndx)
-
-      integer :: n, kb, kt
-
+          
+      if (initialization) then
+         sal_ptr => sa1
+      else
+         sal_ptr => constituents(isalt, :)
+      end if
+      
       do n = 1, ndx
          call getkbotktop(n, kb, kt)
-         surface_salinity(n) = constituents(isalt, kt)
+         surface_salinity(n) = sal_ptr(kt)
       end do
-   end subroutine get_surface_salinity_from_constituents
 
-   !> Returns the surface-layer salinity from sa1 for all horizontal cells.
-   subroutine get_surface_salinity_from_sa1(surface_salinity)
-      use m_flow, only: sa1
-
-      real(kind=dp), intent(out) :: surface_salinity(ndx)
-
-      integer :: n, kb, kt
-
-      do n = 1, ndx
-         call getkbotktop(n, kb, kt)
-         surface_salinity(n) = sa1(kt)
-      end do
-   end subroutine get_surface_salinity_from_sa1
+   end subroutine get_surface_salinity   
 
    !> Returns the salinity reduction factor of saturation humidity.
    elemental subroutine get_salinity_reduction_factor_saturation_humidity(surface_salinity, salinity_reduction_factor_saturation_humidity)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_temperature.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/get_surface_temperature.f90
@@ -31,6 +31,10 @@ module m_get_surface_temperature
    use precision_basics, only: dp
    use m_flowgeom, only: ndx
    use m_get_kbot_ktop, only: getkbotktop
+   use m_transport, only: constituents, itemp
+   use m_flow, only: tem1
+   use m_flowparameters, only: temperature_model, TEMPERATURE_MODEL_NONE
+   use MessageHandling, only: mess, LEVEL_ERROR
    
    implicit none
 
@@ -43,40 +47,24 @@ module m_get_surface_temperature
       real(kind=dp), intent(out) :: surface_temperature(ndx)   
       logical, intent(in) :: initialization !< initialization phase
       
+      real(kind=dp), dimension(:), pointer :: temperature_ptr
+      integer :: n, kb, kt
+      
+      if (temperature_model == TEMPERATURE_MODEL_NONE) then
+         call mess(LEVEL_ERROR, 'get_surface_temperature: Temperature is turned off in mdu')
+         return
+      end if
+
       if (initialization) then
-         call get_surface_temperature_from_tem1(surface_temperature)
+         temperature_ptr => tem1
       else
-         call get_surface_temperature_from_constituents(surface_temperature)
+         temperature_ptr => constituents(itemp,:)
       end if
       
+      do n = 1, ndx
+         call getkbotktop(n, kb, kt)
+         surface_temperature(n) = temperature_ptr(kt)
+      end do
    end subroutine get_surface_temperature
-   
-   !> Returns the surface-layer temperature from constituents(itemp,:) for all horizontal cells.
-   subroutine get_surface_temperature_from_constituents(surface_temperature)
-      use m_transport, only: constituents, itemp
-
-      real(kind=dp), intent(out) :: surface_temperature(ndx)
-
-      integer :: n, kb, kt
-
-      do n = 1, ndx
-         call getkbotktop(n, kb, kt)
-         surface_temperature(n) = constituents(itemp, kt)
-      end do
-   end subroutine get_surface_temperature_from_constituents
-
-   !> Returns the surface-layer temperature from tem1 for all horizontal cells.
-   subroutine get_surface_temperature_from_tem1(surface_temperature)
-      use m_flow, only: tem1
-
-      real(kind=dp), intent(out) :: surface_temperature(ndx)
-
-      integer :: n, kb, kt
-
-      do n = 1, ndx
-         call getkbotktop(n, kb, kt)
-         surface_temperature(n) = tem1(kt)
-      end do
-   end subroutine get_surface_temperature_from_tem1
 
 end module m_get_surface_temperature

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -66,6 +66,7 @@ submodule(fm_external_forcings) fm_external_forcings_update
    use m_physcoef, only: BACKGROUND_AIR_PRESSURE
    use m_flow_initwaveforcings_runtime, only: flow_initwaveforcings_runtime
    use m_waveconst
+   use m_alloc, only: realloc
 
    implicit none
 
@@ -358,6 +359,7 @@ contains
       use m_alloc, only: realloc
       use m_flowgeom, only: ndx, lnx, csu, snu
       use m_get_surface_temperature, only: get_surface_temperature
+      use m_get_surface_salinity, only: get_surface_salinity, get_salinity_reduction_factor_saturation_humidity
       use m_flowgeom_interpolate, only: link_to_node_vector, link_to_node_scalar
       use m_atmospheric_stability, only: compute_scales_and_fluxes, t_options
       use m_relative_wind, only: compute_wind_relative_to_surface_on_link
@@ -367,7 +369,8 @@ contains
       use m_flowparameters, only: atmospheric_stability_function, ATMOSPHERIC_STABILITY_FUNCTION_ECMWF, &
                                   free_convection, FREE_CONVECTION_ON, salinity_reduction_factor_saturation_humidity, &
                                   sensor_height_wind_velocity, sensor_height_air_temperature, sensor_height_humidity, &
-                                  air_viscous_momentum_coeff, air_viscous_heat_coeff, air_viscous_moisture_coeff
+                                  air_viscous_momentum_coeff, air_viscous_heat_coeff, air_viscous_moisture_coeff, &
+                                  salinity_dependent_evaporation_method, SALINITY_DEPENDENT_EVAPORATION_LINEAR
 
 
       logical, intent(in) :: initialization !< initialization phase
@@ -375,6 +378,7 @@ contains
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature
       real(kind=dp), dimension(:), allocatable, save :: windx, windy, charnock
       real(kind=dp), dimension(:), allocatable, save :: surface_temperature_kelvin, air_temperature_kelvin, dew_point_temperature_kelvin
+      real(kind=dp), dimension(:), allocatable, save :: surface_salinity
       real(kind=dp), dimension(lnx) :: windx_link, windy_link
       type(t_options) :: atm_stability_options
 
@@ -412,16 +416,23 @@ contains
          atm_stability_options%include_free_convection = .true.
       end if
 
-      atm_stability_options%fqsat = salinity_reduction_factor_saturation_humidity
       atm_stability_options%sensor_height_wind_velocity = sensor_height_wind_velocity
       atm_stability_options%sensor_height_air_temperature = sensor_height_air_temperature
       atm_stability_options%sensor_height_humidity = sensor_height_humidity
       atm_stability_options%alpha_m = air_viscous_momentum_coeff
       atm_stability_options%alpha_h = air_viscous_heat_coeff
       atm_stability_options%alpha_q = air_viscous_moisture_coeff
+      
+      if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_LINEAR) then
+         call realloc(salinity_reduction_factor_saturation_humidity%values, ndx, keepexisting=.true., fill=salinity_reduction_factor_saturation_humidity%scalar)
+         call realloc(surface_salinity, ndx, keepexisting=.false., fill=0.0_dp)
+         call get_surface_salinity(surface_salinity, initialization)
+         call get_salinity_reduction_factor_saturation_humidity(surface_salinity, salinity_reduction_factor_saturation_humidity%values)
+      end if
 
       call compute_scales_and_fluxes(windx, windy, air_temperature_kelvin, dew_point_temperature_kelvin, &
-                                     air_pressure, charnock, surface_temperature_kelvin, atm_stability_options)
+                                     air_pressure, charnock, surface_temperature_kelvin, salinity_reduction_factor_saturation_humidity, &
+                                     atm_stability_options)
    end subroutine compute_air_water_interaction_most_fluxes
 
    !> Update the relative humidity, dew point temperature, air temperature, cloudiness, solar radiation, and long wave radiation forcings used in the composite heat flux model

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -424,8 +424,12 @@ contains
       atm_stability_options%alpha_q = air_viscous_moisture_coeff
       
       if (salinity_dependent_evaporation_method == SALINITY_DEPENDENT_EVAPORATION_LINEAR) then
-         call realloc(salinity_reduction_factor_saturation_humidity%values, ndx, keepexisting=.true., fill=salinity_reduction_factor_saturation_humidity%scalar)
-         call realloc(surface_salinity, ndx, keepexisting=.false., fill=0.0_dp)
+         if (.not. allocated(salinity_reduction_factor_saturation_humidity%values)) then
+            call realloc(salinity_reduction_factor_saturation_humidity%values, ndx, keepexisting=.false., fill=salinity_reduction_factor_saturation_humidity%scalar)
+         end if
+         if (.not. allocated(surface_salinity)) then
+            call realloc(surface_salinity, ndx, keepexisting=.false., fill=0.0_dp)
+         end if
          call get_surface_salinity(surface_salinity, initialization)
          call get_salinity_reduction_factor_saturation_humidity(surface_salinity, salinity_reduction_factor_saturation_humidity%values)
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
@@ -3,6 +3,7 @@ module test_atmospheric_stability
    use precision, only: dp
    use precision_basics, only: comparereal
    use m_atmospheric_stability
+   use m_array_or_scalar, only: t_array_or_scalar
    implicit none
 
 contains
@@ -17,6 +18,7 @@ contains
       real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
       real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
                                     obukhov_length, richardson_number, c_d, c_h, c_e
+      type(t_array_or_scalar), target :: salinity_reduction_factor_saturation_humidity
       type(t_options) :: options
       
       options%include_stability = .true.
@@ -27,9 +29,10 @@ contains
       air_pressure = [101190.122711076852283_dp, 99932.877309904928552_dp, 100434.759443715374800_dp]
       charnock = [0.031984724136352_dp, 0.007887448339510_dp, 0.063390066055710_dp]
       surface_temperature = [286.743896484375000_dp, 286.676513671875000_dp, 282.813232421875000_dp]
+      salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp
       
       call compute_scales_and_fluxes(wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
-                                  air_pressure, charnock, surface_temperature, options)
+                                  air_pressure, charnock, surface_temperature, salinity_reduction_factor_saturation_humidity, options)
 
       call get_u_star(u_star)
       call get_t_star(t_star)
@@ -111,6 +114,7 @@ contains
       real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
       real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
                                     obukhov_length, richardson_number, c_d, c_h, c_e
+      type(t_array_or_scalar), target :: salinity_reduction_factor_saturation_humidity
       real(kind=dp) :: tolerance = 1e-5_dp
       type(t_options) :: options
       
@@ -122,9 +126,10 @@ contains
       air_pressure = [101190.122711076852283_dp, 99932.877309904928552_dp, 100434.759443715374800_dp]
       charnock = [0.031984724136352_dp, 0.007887448339510_dp, 0.063390066055710_dp]
       surface_temperature = [286.743896484375000_dp, 286.676513671875000_dp, 282.813232421875000_dp]
+      salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp
       
       call compute_scales_and_fluxes(wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
-                                  air_pressure, charnock, surface_temperature, options)
+                                  air_pressure, charnock, surface_temperature, salinity_reduction_factor_saturation_humidity, options)
    
       call get_u_star(u_star)
       call get_t_star(t_star)
@@ -206,6 +211,7 @@ contains
       real(kind=dp), allocatable, dimension(:) :: latent_heat_flux, sensible_heat_flux
       real(kind=dp), allocatable, dimension(:) :: u_star, t_star, q_star, w_star, z0_momentum, z0_heat, z0_humidity, &
                                     obukhov_length, richardson_number, c_d, c_h, c_e
+      type(t_array_or_scalar), target :: salinity_reduction_factor_saturation_humidity
       type(t_options) :: options
       
       options%include_stability = .true.
@@ -217,9 +223,10 @@ contains
       air_pressure = [101190.122711076852283_dp, 99932.877309904928552_dp, 100434.759443715374800_dp]
       charnock = [0.031984724136352_dp, 0.007887448339510_dp, 0.063390066055710_dp]
       surface_temperature = [286.743896484375000_dp, 286.676513671875000_dp, 282.813232421875000_dp]
+      salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp
       
       call compute_scales_and_fluxes(wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
-                                  air_pressure, charnock, surface_temperature, options)
+                                  air_pressure, charnock, surface_temperature, salinity_reduction_factor_saturation_humidity, options)
 
       call get_u_star(u_star)
       call get_t_star(t_star)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_atmospheric_stability.f90
@@ -4,6 +4,7 @@ module test_atmospheric_stability
    use precision_basics, only: comparereal
    use m_atmospheric_stability
    use m_array_or_scalar, only: t_array_or_scalar
+   use m_alloc, only: realloc
    implicit none
 
 contains
@@ -30,6 +31,8 @@ contains
       charnock = [0.031984724136352_dp, 0.007887448339510_dp, 0.063390066055710_dp]
       surface_temperature = [286.743896484375000_dp, 286.676513671875000_dp, 282.813232421875000_dp]
       salinity_reduction_factor_saturation_humidity%scalar = 1.0_dp
+      call realloc(salinity_reduction_factor_saturation_humidity%values, size(surface_temperature), keepexisting=.true., fill=salinity_reduction_factor_saturation_humidity%scalar)
+      salinity_reduction_factor_saturation_humidity%values = [1.0_dp, 0.99_dp, 0.98_dp]
       
       call compute_scales_and_fluxes(wind_velocity_u, wind_velocity_v, air_temperature, dew_point_temperature, &
                                   air_pressure, charnock, surface_temperature, salinity_reduction_factor_saturation_humidity, options)
@@ -67,39 +70,39 @@ contains
       call f90_expect_near(c_h(1), 0.0014208689934920476_dp, 1e-9_dp, "c_h(1) does not match expected value.")
       call f90_expect_near(c_e(1), 0.0014748989040242813_dp, 1e-9_dp, "c_e(1) does not match expected value.")
             
-      call f90_expect_near(u_star(2), 0.021983450898111_dp, 1e-5_dp, "u_star(2) does not match expected value.")
-      call f90_expect_near(t_star(2), -0.063781380223977_dp, 1e-5_dp, "t_star(2) does not match expected value.")
-      call f90_expect_near(q_star(2), -0.000148940393852_dp, 1e-8_dp, "q_star(2) does not match expected value.")
-      call f90_expect_near(z0_momentum(2), 0.000075442471892_dp, 1e-8_dp, "z0_momentum(2) does not match expected value.")
-      call f90_expect_near(z0_heat(2), 0.000272922727444_dp, 1e-7_dp, "z0_heat(2) does not match expected value.")
+      call f90_expect_near(u_star(2), 0.021959777501879552_dp, 1e-5_dp, "u_star(2) does not match expected value.")
+      call f90_expect_near(t_star(2), -0.063662148797144533_dp, 1e-5_dp, "t_star(2) does not match expected value.")
+      call f90_expect_near(q_star(2), -0.00014127432406157292_dp, 1e-8_dp, "q_star(2) does not match expected value.")
+      call f90_expect_near(z0_momentum(2), 0.000075524194341495605_dp, 1e-8_dp, "z0_momentum(2) does not match expected value.")
+      call f90_expect_near(z0_heat(2), 0.00027322300528684709_dp, 1e-7_dp, "z0_heat(2) does not match expected value.")
       call f90_expect_near(z0_humidity(2), 0.000423030227538_dp, 1e-6_dp, "z0_humidity(2) does not match expected value.")
-      call f90_expect_near(obukhov_length(2), -0.401534400984983_dp, 1e-4_dp, "obukhov_length(2) does not match expected value.")
-      call f90_expect_near(richardson_number(2), -1.974372173626931_dp, 1e-4_dp, "richardson_number(2) does not match expected value.")
-      call f90_expect_near(wind_stress_u(2), 0.00014672001126972184_dp, 1e-9_dp, "wind_stress_u(2) does not match expected value.")
-      call f90_expect_near(wind_stress_v(2), -0.00056730769523640964_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
-      call f90_expect_near(latent_heat_flux(2), -9.9282650485071215_dp, 1e-9_dp, "latent_heat_flux(2) does not match expected value.")
-      call f90_expect_near(sensible_heat_flux(2), -1.4640944180384317_dp, 1e-9_dp, "sensible_heat_flux(2) does not match expected value.")
+      call f90_expect_near(obukhov_length(2), -0.40690796328902146_dp, 1e-4_dp, "obukhov_length(2) does not match expected value.")
+      call f90_expect_near(richardson_number(2), -1.9479139245561901_dp, 1e-4_dp, "richardson_number(2) does not match expected value.")
+      call f90_expect_near(wind_stress_u(2), 0.00014640312061274798_dp, 1e-9_dp, "wind_stress_u(2) does not match expected value.")
+      call f90_expect_near(wind_stress_v(2), -0.00056608240560690373_dp, 1e-9_dp, "wind_stress_v(2) does not match expected value.")
+      call f90_expect_near(latent_heat_flux(2), -9.4070428068618668_dp, 1e-9_dp, "latent_heat_flux(2) does not match expected value.")
+      call f90_expect_near(sensible_heat_flux(2), -1.4597738955897894_dp, 1e-9_dp, "sensible_heat_flux(2) does not match expected value.")
       call f90_expect_near(w_star(2), 0.0_dp, 1e-9_dp, "w_star(2) does not match expected value.")
-      call f90_expect_near(c_d(2), 0.0021821300262445326_dp, 1e-9_dp, "c_d(2) does not match expected value.")
-      call f90_expect_near(c_h(2), 0.0032842424452251642_dp, 1e-9_dp, "c_h(2) does not match expected value.")
-      call f90_expect_near(c_e(2), 0.003556338038678844_dp, 1e-9_dp, "c_e(2) does not match expected value.")
+      call f90_expect_near(c_d(2), 0.0021774204572332541_dp, 1e-9_dp, "c_d(2) does not match expected value.")
+      call f90_expect_near(c_h(2), 0.0032745507121213894_dp, 1e-9_dp, "c_h(2) does not match expected value.")
+      call f90_expect_near(c_e(2), 0.0035453171098001504_dp, 1e-9_dp, "c_e(2) does not match expected value.")
 
-      call f90_expect_near(u_star(3), 1.2605930619410015_dp, 1e-5_dp, "u_star(3) does not match expected value.")
-      call f90_expect_near(t_star(3), -0.061488117346359027_dp, 1e-7_dp, "t_star(3) does not match expected value.")
-      call f90_expect_near(q_star(3), -9.2337265830901515e-05_dp, 1e-9_dp, "q_star(3) does not match expected value.")
-      call f90_expect_near(z0_momentum(3), 0.010272354722833723_dp, 1e-6_dp, "z0_momentum(3) does not match expected value.")
+      call f90_expect_near(u_star(3), 1.2605257576398083_dp, 1e-5_dp, "u_star(3) does not match expected value.")
+      call f90_expect_near(t_star(3), -0.061487851538916886_dp, 1e-7_dp, "t_star(3) does not match expected value.")
+      call f90_expect_near(q_star(3), -8.756177722083455e-05_dp, 1e-9_dp, "q_star(3) does not match expected value.")
+      call f90_expect_near(z0_momentum(3), 0.010271257861220856_dp, 1e-6_dp, "z0_momentum(3) does not match expected value.")
       call f90_expect_near(z0_heat(3), 4.7598600384773734e-06_dp, 1e-9_dp, "z0_heat(3) does not match expected value.")
       call f90_expect_near(z0_humidity(3), 7.3777830596399287e-06_dp, 1e-9_dp, "z0_humidity(3) does not match expected value.")
-      call f90_expect_near(obukhov_length(3), -1479.651083435764122_dp, 2e-1_dp, "obukhov_length(3) does not match expected value.")
-      call f90_expect_near(richardson_number(3), -0.002086552554703_dp, 1e-7_dp, "richardson_number(3) does not match expected value.")
-      call f90_expect_near(wind_stress_u(3), 1.6941085481015359_dp, 1e-9_dp, "wind_stress_u(3) does not match expected value.")
-      call f90_expect_near(wind_stress_v(3), -1.0139020930358786_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
-      call f90_expect_near(latent_heat_flux(3), -361.66130457981751_dp, 1e-9_dp, "latent_heat_flux(3) does not match expected value.")
-      call f90_expect_near(sensible_heat_flux(3), -82.9336247571147_dp, 1e-9_dp, "sensible_heat_flux(3) does not match expected value.")
+      call f90_expect_near(obukhov_length(3), -1494.8705407521311_dp, 2e-1_dp, "obukhov_length(3) does not match expected value.")
+      call f90_expect_near(richardson_number(3), -0.0020650340081187547_dp, 1e-7_dp, "richardson_number(3) does not match expected value.")
+      call f90_expect_near(wind_stress_u(3), 1.6939276526935303_dp, 1e-9_dp, "wind_stress_u(3) does not match expected value.")
+      call f90_expect_near(wind_stress_v(3), -1.0137938294697673_dp, 1e-9_dp, "wind_stress_v(3) does not match expected value.")
+      call f90_expect_near(latent_heat_flux(3), -342.93863399702468_dp, 1e-9_dp, "latent_heat_flux(3) does not match expected value.")
+      call f90_expect_near(sensible_heat_flux(3), -82.928838354221909_dp, 1e-9_dp, "sensible_heat_flux(3) does not match expected value.")
       call f90_expect_near(w_star(3), 0.0_dp, 1e-9_dp, "w_star(3) does not match expected value.")
-      call f90_expect_near(c_d(3), 0.0034041655741110614_dp, 1e-9_dp, "c_d(3) does not match expected value.")
-      call f90_expect_near(c_h(3), 0.0018031744251089255_dp, 1e-9_dp, "c_h(3) does not match expected value.")
-      call f90_expect_near(c_e(3), 0.0018663715487940969_dp, 1e-9_dp, "c_e(3) does not match expected value.")
+      call f90_expect_near(c_d(3), 0.0034038020803307261_dp, 1e-9_dp, "c_d(3) does not match expected value.")
+      call f90_expect_near(c_h(3), 0.001803070418981471_dp, 1e-9_dp, "c_h(3) does not match expected value.")
+      call f90_expect_near(c_e(3), 0.0018662636169953025_dp, 1e-9_dp, "c_e(3) does not match expected value.")
 
    end subroutine test_compute_scales_and_fluxes_moninobukhov_true
    !$f90tw )


### PR DESCRIPTION
# What was done 
- Introduce a new mdu keyword SalinityDependentEvaporationMethod
- Introduce module get_surface_salinity.f90 for obtaining surface_salinity and computing saturation humidity reduction factor as a linear function of local surface salinity
- Modify module atmospheric_stability to apply the new reduction factor accordingly, e.g. make the reduction factor as an extra dummy argument (instead of option) and declare it as type t_array_or_scalar.
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [X]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10160