### PR TITLE
UNST-9888_improve_wrihis_windstress

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/fm_statistical_output.f90
@@ -1534,7 +1534,7 @@ contains
                              nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_WINDSTRESSX, &
                              'Wrihis_windstress', 'windstressx', 'wind stress on flow element center, x-component', 'surface_downward_x_stress', &
-                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), &
+                    'N m-2', UNC_LOC_STATION, nc_attributes=atts(1:1), description='Write wind stress to his-file', &
                     nc_dim_ids=station_nc_dims_2D)
       call add_output_config(config_set_his, IDX_HIS_WINDSTRESSX_SFERIC, &
                              'Wrihis_windstress', 'windstressx', 'wind stress on flow element center, x-component', 'surface_downward_eastward_stress', &

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flowparameters.f90
@@ -483,7 +483,7 @@ module m_flowparameters
       integer :: bubblescreens = 1 !< Write bubble screen parameters to his file, 0: no, 1: yes
       integer :: tur = 1 !< Write k, eps and vicww to his file, 0: no, 1: yes
       integer :: wind = 1 !< Write wind velocities to his file, 0: no, 1: yes
-      integer :: windstress = 1 !< Write wind stress to his file, 0: no, 1: yes
+      integer :: windstress = 0 !< Write wind stress to his file, 0: no, 1: yes
       integer :: bulk_exchange_coeff = 1 !< Write bulk exchange coefficients to his file, 0: no, 1: yes
       integer :: rain = 1 !< Write precipitation intensity (depth per time) to this file, 0: no, 1: yes
       integer :: infilt = 1 !< Write infiltration rate to this file, 0: no, 1: yes


### PR DESCRIPTION
# What was done 
- set default value of Wrihis_windstress to 0
- add 'property' so that Wrihis_windstress is written in `.dia` file 
<img width="1177" height="231" alt="image" src="https://github.com/user-attachments/assets/4d4cc6a2-375c-4e17-94c0-04736e7847f1" />


# Evidence of the work done 

- [X]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-9888