### PR TITLE
UNST-10213  Use of 32 bit integers for SWAN time axis crashes D-Waves

### DIFF
--- a/src/third_party_open/swan/src/agioncmd.f90
+++ b/src/third_party_open/swan/src/agioncmd.f90
@@ -278,7 +278,7 @@
             call nccheck ( nf90_create( ncfile, NF90_NOCLOBBER + NF90_NETCDF4, ncid) )
             if ( recordaxe%nstatm ) then
                 call nccheck ( nf90_def_dim( ncid, 'time', NF90_UNLIMITED, recordaxe%dimid ) );
-                call nccheck ( nf90_def_var( ncid, 'time', NF90_INT, recordaxe%dimid, recordaxe%varid ) )
+                call nccheck ( nf90_def_var( ncid, 'time', NF90_INT64, recordaxe%dimid, recordaxe%varid ) )
                 call nccheck ( nf90_put_att( ncid, recordaxe%varid, 'units', 'seconds since 1970-01-01') )
                 call nccheck ( nf90_put_att( ncid, recordaxe%varid, 'calendar', 'gregorian') )
                 call nccheck ( nf90_put_att( ncid, recordaxe%varid, 'standard_name', 'time') )
@@ -2553,7 +2553,7 @@
 
         function timeindex64(tarr, t) result (ti)
             integer(kind=8), dimension(:), intent( in)  :: tarr
-            integer,                       intent( in)  :: t
+            integer(kind=8),               intent( in)  :: t
             integer                                     :: ti
             if ( t >= minval(tarr) .and. t <= maxval(tarr) ) then
                 ! somewhere in the existing time axe  .and. (t <= max(tarr,1))
@@ -2601,7 +2601,8 @@
 
         function datevec_from_epoch( t_in ) result (datevec)
             integer(kind=8), intent( in)  :: t_in
-            integer                       :: t, year, month, s
+            integer(kind=8)               :: t, s
+            integer                       :: year, month
             integer                       :: datevec(6)
             ! number of days per month
             integer, save           :: ndpm(12)
@@ -2614,7 +2615,8 @@
             t = t - datevec(5)*60
             datevec(4) = mod(t,86400)/3600
             t = t-datevec(4)*3600
-            do year = 1970, 2038
+            year = 1970
+            do
                 if ( (mod(year,400) == 0) .or. ( (mod(year,4) == 0) .and. (mod(year,100) /= 0 )) ) then
                     s = 366*86400
                 else
@@ -2624,6 +2626,7 @@
                     exit
                 else
                     t = t-s
+                    year = year + 1
                 end if
             end do
             datevec(1) = year

--- a/src/third_party_open/swan/src/swn_outnc.f90
+++ b/src/third_party_open/swan/src/swn_outnc.f90
@@ -307,9 +307,9 @@ contains
 !
       logical                             :: lopen, file_exists, &
                                              EQREAL, STPNOW
-      integer                             :: ip, ierr, otype, xpctime2, &
-                                             i, tmip, binnr, irq, &
+      integer                             :: ip, ierr, otype, i, tmip, binnr, irq, &
                                              tip, ips(MIP), iproc, nref, ilpos
+      integer(kind=8)                     :: xpctime2
       integer, save                       :: IENT=0
       character(len=80)                   :: binfile, ncfile, basefile
       character(len=256)                  :: errmsg
@@ -564,9 +564,10 @@ contains
 !  5. Local variables
 !
       logical                                        :: EQREAL, lopen, do_open_files, write_header
-      integer                                        :: ip, ierr, otype, xpctmp(2), xpctime, &
+      integer                                        :: ip, ierr, otype, xpctmp(2), &
                                                         pnr, ri, i, tmip, irq, iproc, &
                                                         binnr, xi, yi, npnts
+      integer(kind=8)                                :: xpctime
       integer, allocatable                           :: ips(:)
       integer, save                                  :: IENT=0
       character(len=80)                              :: outfile
@@ -727,7 +728,7 @@ contains
 
         write(OQI(1), IOSTAT=ierr) xpctime, tmip
         if (ierr /= 0) then
-          write(errmsg, '(A, "-> IOSTAT=", I3, " time=", I10, " TMIP=", I4, " OQI(1)=", I3)') &
+          write(errmsg, '(A, "-> IOSTAT=", I3, " time=", I20, " TMIP=", I4, " OQI(1)=", I3)') &
                   trim(outfile), ierr, xpctime, tmip, oqi(1)
           call MSGERR(4, errmsg)
           return
@@ -905,12 +906,12 @@ contains
 !
       integer,                      intent(   in) :: oqi(4)
       type(spcaux_type), target,    intent(inout) :: spcaux
-      integer,           optional,  intent(   in) :: xpctime2
+      integer(kind=8),   optional,  intent(   in) :: xpctime2
 !
 !  5. Local variables
 !
-      integer                             :: ierr, xpctmp(2), xpctime, pnr, ri, irq, i, &
-                                             ncid
+      integer                             :: ierr, xpctmp(2), ri, irq, i, ncid
+      integer(kind=8)                     :: xpctime, pnr
       character(len=256)                  :: errmsg
       integer, save                       :: IENT=0
       logical                             :: spc_as_map, wetnode_list, noaux
@@ -958,7 +959,7 @@ contains
           ! If provided, check the time against a reference time
           if ( present(xpctime2) ) then
             if ( xpctime2 /= xpctime ) then
-                write(errmsg, '(I12, " does not equal ", I12)') xpctime2, xpctime
+                write(errmsg, '(I20, " does not equal ", I20)') xpctime2, xpctime
                 call MSGERR(4, errmsg)
                 return
             end if
@@ -1349,8 +1350,8 @@ contains
         integer,                intent(   in) :: irq, ivtype, nref, col, myk, mxk
         real,                   intent(   in) :: data(mxk * myk), excv
 
-        integer                               :: ri, pnr, xpctmp(2), i, &
-                                                 xpctime, ilpos, ncid
+        integer                               :: ri, xpctmp(2), i, ilpos, ncid
+        integer(kind=8)                       :: xpctime, pnr
         integer, save                         :: IENT=0
         character(len=40)                     :: name
         if (LTRACE) call STRACE (IENT,'swn_outnc_appendblock')
@@ -1409,7 +1410,8 @@ contains
     end subroutine swn_outnc_close_on_end
 
     subroutine record_index(ncid, recordaxe, xpctime, ri, reading, filename)
-        integer,                              intent(   in) :: ncid, xpctime
+        integer,                              intent(   in) :: ncid
+        integer(kind=8),                      intent(   in) :: xpctime
         type(recordaxe_type),                 intent(inout) :: recordaxe
         integer,                              intent(  out) :: ri
         logical,                              intent(   in) :: reading  !< ncfile used for reading

--- a/src/utils_lgpl/nefis/packages/nefis/CMakeLists.txt
+++ b/src/utils_lgpl/nefis/packages/nefis/CMakeLists.txt
@@ -33,6 +33,14 @@ add_library(${library_name} ${headers}
                             ${source}
                             ${ini_version_file})
 
+# The d3d4-suite also builds nefis_dll with OUTPUT_NAME nefis. On Windows,
+# that DLL's import library would otherwise overwrite this static archive
+# (nefis.lib) in a multi-configuration build directory. Keep the target name
+# unchanged so consumers still link to the static library target.
+if (WIN32)
+    set_target_properties(${library_name} PROPERTIES OUTPUT_NAME nefis_static)
+endif()
+
 # Set additional dependencies
 target_include_directories(${library_name}  PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/include" ${version_include_dir})
 


### PR DESCRIPTION
# What was done 

Increased data size for time axis on nc hotfile writer in SWAN to int64 to accomodate runs in the very far future
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
test case to SWAN testbed: P:\dflowfm\maintenance\JIRA\10000-10999\10213
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link

UNST-10213
