### PR TITLE
UNST-10216 fix wave his writer

### DIFF
--- a/src/engines_gpl/wave/packages/io/src/write_wave_his_netcdf.f90
+++ b/src/engines_gpl/wave/packages/io/src/write_wave_his_netcdf.f90
@@ -324,13 +324,13 @@ subroutine write_wave_his_netcdf(sg, sof, n_swan_grids, i_swan, wavedata, nautic
       idvar_statid = nc_def_var(idfile, 'station_id', nf90_char, 2, [iddim_statnamlen, iddim_nstat], '', 'Observation station identifier', '', .false., filename)
       ierror = nc_put_att_and_check(idfile, idvar_statid, 'cf_role', 'timeseries_id', filename, "put_att station_id cf_role")
       idvar_depth = nc_def_var(idfile, 'depth', precision, 2, [iddim_nstat, iddim_time], '', 'Water depth', 'm', .true., filename)
-      idvar_hsig = nc_def_var(idfile, 'hsign', precision, 2, [iddim_nstat, iddim_time], '', 'Significant wave height', 'm', .true., filename)
+      idvar_hsig = nc_def_var(idfile, 'hsig', precision, 2, [iddim_nstat, iddim_time], '', 'Significant wave height', 'm', .true., filename)
       if (nautical_convention) then
          idvar_dir = nc_def_var(idfile, 'dir', precision, 2, [iddim_nstat, iddim_time], 'sea_surface_wave_from_direction', 'Mean wave direction', 'deg', .true., filename)
       else
          idvar_dir = nc_def_var(idfile, 'dir', precision, 2, [iddim_nstat, iddim_time], 'sea_surface_wave_to_direction', 'Mean wave direction', 'deg', .true., filename)
       end if
-      idvar_rtpeak = nc_def_var(idfile, 'rtp', precision, 2, [iddim_nstat, iddim_time], '', 'Relative peak wave period', 'sec', .true., filename)
+      idvar_rtpeak = nc_def_var(idfile, 'rtpeak', precision, 2, [iddim_nstat, iddim_time], '', 'Relative peak wave period', 'sec', .true., filename)
       idvar_tm01 = nc_def_var(idfile, 'tm01', precision, 2, [iddim_nstat, iddim_time], '', 'Mean absolute wave period', 'sec', .true., filename)
       idvar_dspr = nc_def_var(idfile, 'dspr', precision, 2, [iddim_nstat, iddim_time], '', 'Directional spreading of the waves', 'deg', .true., filename)
       idvar_ubot = nc_def_var(idfile, 'ubot', precision, 2, [iddim_nstat, iddim_time], '', 'Rms value maximum of the orbital velocity near bed level', 'm/s', .true., filename)

--- a/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
@@ -375,7 +375,7 @@
             </checks>
         </testCase>
 		<testCase name="e04_f06_c01_write_wavh" ref="dimr_trunk">
-            <path version="2026-07-31T12:53:05.278000">e04_wave/f06-io/c01_write_wavh</path>
+            <path version="2026-07-31T15:53:05.278000">e04_wave/f06-io/c01_write_wavh</path>
             <maxRunTime>120.0</maxRunTime>
             <checks>
                 <file name="wavh-marshall_with_nested_grids.nc" type="NETCDF">

--- a/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
@@ -374,6 +374,19 @@
                 </file>
             </checks>
         </testCase>
+		<testCase name="e04_f06_c01_write_wavh" ref="dimr_trunk">
+            <path version="2026-07-31T12:53:05.278000">e04_wave/f06-io/c01_write_wavh</path>
+            <maxRunTime>120.0</maxRunTime>
+            <checks>
+                <file name="wavh-marshall_with_nested_grids.nc" type="NETCDF">
+                    <parameters>
+                        <parameter name="dir" toleranceAbsolute="400.0"/>
+                        <parameter name="hsig" toleranceAbsolute="0.09"/>
+                        <parameter name="rtpeak" toleranceAbsolute="0.4"/>
+                    </parameters>
+                </file>
+            </checks>
+        </testCase>
         <!-- ======================================================================== -->
         <!-- f06: D-Flow FM + D-Waves coupling, moved to e100                         -->
         <!-- ======================================================================== -->


### PR DESCRIPTION
# What was done 

Introduced in [SWAN-298](https://issuetracker.deltares.nl/browse/SWAN-298):

deterministic variable-name mismatch in the WAVE history writer.
The file is created with:
hsign at [write_wave_his_netcdf.f90 (line 327)]
rtp at [write_wave_his_netcdf.f90 (line 333)]
On later writes, it incorrectly looks for:
hsig at [line 371 (line 371)]
rtpeak at [line 373 (line 373)]
So the first output can create the file, but subsequent output cannot obtain those variable IDs and every put_var fails.
 
Renamed variables back to original hsig and rtpeak

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
e04_f06_c01
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
[UNST-10216](https://issuetracker.deltares.nl/browse/UNST-10216)