### PR TITLE
Merge sedmor branch: SWAN breaker initialization and check.

### DIFF
--- a/src/third_party_open/swan/src/swancom1.F
+++ b/src/third_party_open/swan/src/swancom1.F
@@ -6047,7 +6047,8 @@
 !
 !     --- calculate fraction of breakers
 !
-      IF ( ETOT .GT. 0. ) THEN
+      QB(KCGRD(1)) = 0.                                                   JRE
+      IF ( ETOT .GT. 0. .AND. ISURF.GT.0) THEN                            JRE
 !
 !       --- calculate Qb when BJ78 breaker is activated
 !

--- a/src/third_party_open/swan/src/swancom1.F
+++ b/src/third_party_open/swan/src/swancom1.F
@@ -6047,8 +6047,7 @@
 !
 !     --- calculate fraction of breakers
 !
-      QB(KCGRD(1)) = 0.                                                   JRE
-      IF ( ETOT .GT. 0. .AND. ISURF.GT.0) THEN                            JRE
+      IF ( ETOT .GT. 0. .AND. ISURF .GT. 0 ) THEN
 !
 !       --- calculate Qb when BJ78 breaker is activated
 !


### PR DESCRIPTION
# What was done 

Added a check to avoid called `FRABRE` when `ISURF == 0` (surf breaking is inactive).

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-9434