### PR TITLE
UNST-10222: Don't append pillarfile information (in global arrays)

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -410,7 +410,7 @@ contains
          allocate (pillar(i))
          do ifil = 1, size(fnames)
             call oldfil(minp, fnames(ifil))
-            call reapol(minp, 1)
+            call reapol(minp, 0)
             allocate (pillar(ifil)%xcor(npl))
             pillar(ifil)%xcor = dmiss
             allocate (pillar(ifil)%ycor(npl))


### PR DESCRIPTION
# What was done 
- bugfix: avoid double-counting of pillarFile data as this is used within a loop `do ifil = 1, size(fnames)`
 
# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-10222