### PR TITLE
Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+test/deltares_testbench/configs/ @rene-deltares @matthijs-deltares @robin-deltares @aslowwriter @ahmad-el-sayed @KoenBussemakerDeltares


### PR DESCRIPTION
# What was done 

Added CODEOWNERS. Github requires approval to testbench config files from one of the people involved in the DVC migration.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
