### PR TITLE
UNST-10134: adding docs to tests

### DIFF
--- a/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c400_nesting_salinity_uxuyadvection/doc.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c400_nesting_salinity_uxuyadvection/doc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 4989b735234965c29d040e9767f29cff.dir
-  size: 568179
+- md5: 3428b11fe1a56a5a9d759465a22eac09.dir
+  size: 568204
   nfiles: 7
   hash: md5
   path: doc

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c400_nesting_salinity_uxuyadvection/doc.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c400_nesting_salinity_uxuyadvection/doc.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: 4989b735234965c29d040e9767f29cff.dir
+  size: 568179
+  nfiles: 7
+  hash: md5
+  path: doc

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: b34a57d5e769437388b615f151dd10ee.dir
-  size: 554664
+- md5: 89fbf4187c9887a77ac16dec4b96a338.dir
+  size: 60447
   nfiles: 3
   hash: md5
   path: doc

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
@@ -1,0 +1,6 @@
+outs:
+- md5: b34a57d5e769437388b615f151dd10ee.dir
+  size: 554664
+  nfiles: 3
+  hash: md5
+  path: doc


### PR DESCRIPTION
# What was done 

added docs to e02_f006_c400_nesting_salinity_uxuyadvection and e02_f006_c401_katwijk_fixed tests
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [X]	Not applicable 

# Tests 
- [X] Tests updated 
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10134