### PR TITLE
UNST-10106 Fixed datetime properties containing underscores in testbench mdus

### DIFF
--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c12_166_IntervalCntrl-1/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c12_166_IntervalCntrl-1/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1aba62a20a26a7c37c93719dfa6de184.dir
+- md5: dc6863ac7b071e9499a374780ed3b65d.dir
   size: 512943
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c13_167_IntervalCntrl-2/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c13_167_IntervalCntrl-2/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 76cd505eaf9d021fd59fc3e521fe0545.dir
+- md5: 51fc9df41540d36ffe179550ca9a3fb6.dir
   size: 512884
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c14_168_IntervalCntrl-3/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c14_168_IntervalCntrl-3/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 989e57d8e039865dda0f164692a98f90.dir
+- md5: e8272471c983457f8ff2c333e0a53cee.dir
   size: 512928
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c15_169_IntervalCntrl-4/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c15_169_IntervalCntrl-4/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e6c39242e6327f515e0ef4a0eed31a96.dir
+- md5: a8e94e092caafc4b9c2d62295fd1a0b0.dir
   size: 512945
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c16_170a_IntervalCntrl-5/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c16_170a_IntervalCntrl-5/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 25eaef7bb57ed515791d393378b15034.dir
+- md5: f475bffb252a5858147d2c04d9bebcf6.dir
   size: 153292143
   nfiles: 44
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c17_170b_IntervalCntrl-6/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c17_170b_IntervalCntrl-6/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 893dc3588cbf8ea2a379502f62e71419.dir
+- md5: 1c6399f9a890ac7cc7f379f4d0c72d4e.dir
   size: 515167
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c18_175a_IntervalCntrl-7/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c18_175a_IntervalCntrl-7/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1aef3df0369d6d97f19b848e97408ca7.dir
+- md5: f01386b2c7c35523fcf9774be40159a1.dir
   size: 515193
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c19_175b_IntervalCntrl-8/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c19_175b_IntervalCntrl-8/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: e6fdfa8df28179747117a0a878d2ce8d.dir
+- md5: c598786e2d2a6385446003ff3c73b429.dir
   size: 515190
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c20_171_PIDCntrl-1/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c20_171_PIDCntrl-1/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7e1b5671d30f7734d6c4b8a71a60cf66.dir
+- md5: 87470d3c07aac4510f6f44dd36bcd806.dir
   size: 513143
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c21_172a_PIDCntrl-2/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c21_172a_PIDCntrl-2/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 2679ff72407250334170e5aea6c7b40f.dir
+- md5: ebf72fd64b0b20dd4d200d17992675ad.dir
   size: 513090
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c22_172b_PIDCntrl-3/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c22_172b_PIDCntrl-3/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b36331731f230c2c4cc308c60b720a8e.dir
+- md5: 7764b8edd0b5dbf7995935ec56b9fe25.dir
   size: 513150
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c23_173a_PIDCntrl-4/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c23_173a_PIDCntrl-4/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 7d10d18777da3ce579e57ab9dfc356a3.dir
+- md5: 50df3b01fc24f6ba24c2163874fe779a.dir
   size: 513157
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c24_173b_PIDCntrl-5/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c24_173b_PIDCntrl-5/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: ebe8c9bfd8eb0a4f11b40cb6f387fc90.dir
+- md5: 34f8930ff7ac12374911846d0e49d4cb.dir
   size: 514468
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c25_257a_PIDCntrl-6/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c25_257a_PIDCntrl-6/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 45cdc3a0042a486429fd63c501628ad2.dir
+- md5: 1801dbc13ac19fa0faa4b26e716a94f7.dir
   size: 515258
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c26_257b_PIDCntrl-7/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c26_257b_PIDCntrl-7/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 1bfd21fa9c049b36331927d7ee794795.dir
+- md5: 6eeef4e6f36086e30898cbbdae318ac8.dir
   size: 515312
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c27_256_PIDCntrl-8/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c27_256_PIDCntrl-8/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: b58562b1f4151f643c49381905886ce1.dir
+- md5: e3ab8dc11261d92598f10db4092a71f4.dir
   size: 476368
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c61_245c_InTimeDiffCntrlTypes-3/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c61_245c_InTimeDiffCntrlTypes-3/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: cfd7ea83dec20e1a3730a62819c2f1f0.dir
+- md5: 622a8e63917c53b60c0fdaf71c0eb930.dir
   size: 489215
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c62_245d_InTimeDiffCntrlTypes-4/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f03_1d-network/c62_245d_InTimeDiffCntrlTypes-4/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 16c6f00e2871614de076cb6fc7950175.dir
+- md5: 40dc460cb92a23e09ee69a4fe752a0d5.dir
   size: 489222
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f05_restart/c06_f03_c20_171_PIDCntrl-1/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f05_restart/c06_f03_c20_171_PIDCntrl-1/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 6aa6bc8d66ec2be68c5905f2a9f6f984.dir
+- md5: bd5e80391626969668b771658bd999b7.dir
   size: 513355
   nfiles: 35
   hash: md5

--- a/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f05_restart/c07_f03_c20_171_PIDCntrl-1_restart/input.dvc
+++ b/test/deltares_testbench/data/cases/e105_dflowfm-drtc/f05_restart/c07_f03_c20_171_PIDCntrl-1_restart/input.dvc
@@ -1,5 +1,5 @@
 outs:
-- md5: 77d201fc81bb520106f40684c5b5a380.dir
+- md5: ab8b2de17e438542cf0e7276f4afd322.dir
   size: 518570
   nfiles: 40
   hash: md5


### PR DESCRIPTION
# What was done 

Now that we have DVC I wanted to try batch updating a little bit. There were 20 testbench tests that contained for example `"RestartDateTime = 20030105_000000"`. This underscore is not supported by the dflowfm_io library and we want to remove it.

# Issue link

https://issuetracker.deltares.nl/browse/UNST-10106