### PR TITLE
fix: temporary disable dvc diff job

### DIFF
--- a/ci/teamcity/Delft3D/trigger.kt
+++ b/ci/teamcity/Delft3D/trigger.kt
@@ -281,6 +281,12 @@ object Trigger : BuildType({
             conditions {
                 doesNotContain("teamcity.build.triggeredBy", "Snapshot dependency")
                 startsWith("teamcity.build.branch", "pull")
+
+		// only way to disable a step as far as I'm aware
+		// it's taking up too many TC resources, so this is disabled until we can 
+		// diagnose and fix that
+		equals("env.disabled", "false") 
+		
             }
 
             scriptContent = """

--- a/ci/teamcity/Delft3D/trigger.kt
+++ b/ci/teamcity/Delft3D/trigger.kt
@@ -278,15 +278,13 @@ object Trigger : BuildType({
         script {
             name = "Start DVC diff report build"
 
+	    // it's taking up too many TC resources, so this is disabled until we can 
+	    // diagnose and fix that
+	    enabled = false
             conditions {
                 doesNotContain("teamcity.build.triggeredBy", "Snapshot dependency")
                 startsWith("teamcity.build.branch", "pull")
 
-		// only way to disable a step as far as I'm aware
-		// it's taking up too many TC resources, so this is disabled until we can 
-		// diagnose and fix that
-		equals("env.disabled", "false") 
-		
             }
 
             scriptContent = """

--- a/ci/teamcity/Delft3D/trigger.kt
+++ b/ci/teamcity/Delft3D/trigger.kt
@@ -278,13 +278,12 @@ object Trigger : BuildType({
         script {
             name = "Start DVC diff report build"
 
-	    // it's taking up too many TC resources, so this is disabled until we can 
-	    // diagnose and fix that
-	    enabled = false
+            // it's taking up too many TC resources, so this is disabled until we can 
+            // diagnose and fix that
+            enabled = false
             conditions {
                 doesNotContain("teamcity.build.triggeredBy", "Snapshot dependency")
                 startsWith("teamcity.build.branch", "pull")
-
             }
 
             scriptContent = """


### PR DESCRIPTION
the DVC diff job is taking up too many TC resources, so we need to disable it until we can diagonse and fix that. 
This PR disables this job by adding a condition that should never be true (so we don't lose the trigger logic etc)


# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSDSC-989 / DEVOPSCICD-24