### PR TITLE
UNST-10193 Fix ClassMapFile erroneously filled during partitioning

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/rest_f90/generatepartitionmdufile.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/rest_f90/generatepartitionmdufile.f90
@@ -126,7 +126,9 @@ contains
          if (len_trim(md_restartfile) > 0) then
             keyword_present(3) = index(keyword, 'restartfile') /= 0
          end if
-         if (len_trim(md_mapfile) > 0) then
+         ! ClassMapFile must be checked before MapFile, since 'classmapfile' also contains the substring 'mapfile'
+         keyword_present(7) = index(keyword, 'classmapfile') /= 0
+         if (len_trim(md_mapfile) > 0 .and. .not. keyword_present(7)) then
             keyword_present(4) = index(keyword, 'mapfile') /= 0
          end if
          if (md_genpolygon == 1) then
@@ -134,9 +136,6 @@ contains
          end if
          if (len_trim(md_flowgeomfile) > 0) then
             keyword_present(6) = index(keyword, 'flowgeomfile') /= 0
-         end if
-         if (len_trim(md_classmap_file) > 0) then
-            keyword_present(7) = index(keyword, 'classmapfile') /= 0
          end if
          if (len_trim(md_1dfiles%structures) > 0) then
             keyword_present(8) = index(keyword, 'structurefile') /= 0
@@ -160,7 +159,11 @@ contains
                mdu_line_partition = trim(keyword)//" "//trim(md_restartfile)//"       # Restart file, only from netcdf-file, hence: either *_rst.nc or *_map.nc"
                write (unit_partition, "(a)") trim(mdu_line_partition)
             else if (keyword_present(7)) then ! Modify ClassMapFile, must be before mapfile as we don't check on whole words
-               mdu_line_partition = trim(keyword)//" "//trim(md_classmap_file)//"       # ClassMapFile name *.nc"
+               if (len_trim(md_classmap_file) > 0) then
+                  mdu_line_partition = trim(keyword)//" "//trim(md_classmap_file)//"       # ClassMapFile name *.nc"
+               else ! Keep the line unchanged, so an empty ClassMapFile stays empty instead of being filled with MapFile's value
+                  mdu_line_partition = mdu_line_main
+               end if
                write (unit_partition, "(a)") trim(mdu_line_partition)
             else if (keyword_present(4)) then ! Modify MapFile
                mdu_line_partition = trim(keyword)//" "//trim(md_mapfile)//"       # MapFile name *_map.nc"

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/CMakeLists.txt
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/CMakeLists.txt
@@ -35,6 +35,7 @@ f90twtest(${test_target}
         src/test_atmospheric_stability.f90
         src/test_precice_adapter.f90
         src/test_fm_external_forcings_utils.f90
+        src/test_generate_partition_mdu_file.f90
     F2HFILES
         ${CMAKE_CURRENT_SOURCE_DIR}/src/test_dflowfm_kernel_example.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/src/test_3d_layer_administration.f90
@@ -55,6 +56,7 @@ f90twtest(${test_target}
         ${CMAKE_CURRENT_SOURCE_DIR}/src/test_atmospheric_stability.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/src/test_precice_adapter.f90
         ${CMAKE_CURRENT_SOURCE_DIR}/src/test_fm_external_forcings_utils.f90
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/test_generate_partition_mdu_file.f90
     OUTDIR "${CMAKE_CURRENT_BINARY_DIR}"
     LIBRARIES dflowfm_kernel test_helpers netCDF::netcdff
     VISUAL_STUDIO_PATH engines_gpl/dflowfm/test

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_generate_partition_mdu_file.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_generate_partition_mdu_file.f90
@@ -1,0 +1,100 @@
+!!  Copyright (C)  Stichting Deltares, 2012-2025.
+!!
+!!  This program is free software: you can redistribute it and/or modify
+!!  it under the terms of the GNU General Public License version 3,
+!!  as published by the Free Software Foundation.
+!!
+!!  This program is distributed in the hope that it will be useful,
+!!  but WITHOUT ANY WARRANTY; without even the implied warranty of
+!!  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+!!  GNU General Public License for more details.
+!!
+!!  You should have received a copy of the GNU General Public License
+!!  along with this program. If not, see <http://www.gnu.org/licenses/>.
+!!
+!!  contact: delft3d.support@deltares.nl
+!!  Stichting Deltares
+!!  P.O. Box 177
+!!  2600 MH Delft, The Netherlands
+!!
+!!  All indications and logos of, and references to registered trademarks
+!!  of Stichting Deltares remain the property of Stichting Deltares. All
+!!  rights reserved.
+module test_generate_partition_mdu_file
+   use assertions_gtest
+   implicit none
+
+contains
+
+   !$f90tw TESTCODE(TEST, test_generate_partition_mdu_file, test_empty_classmapfile_stays_empty, test_empty_classmapfile_stays_empty,
+   !> Regression test for UNST-10193: an empty ClassMapFile must remain empty after partitioning, instead of being
+   !> filled with MapFile's value (which used to happen because 'classmapfile' contains the substring 'mapfile').
+   subroutine test_empty_classmapfile_stays_empty() bind(C)
+      use m_generatepartitionmdufile, only: generate_partition_mdu_file
+      use unstruc_model, only: md_mapfile, md_classmap_file
+      use string_module, only: str_lower
+
+      character(len=*), parameter :: INPUT_FILE = 'test_input_partition.mdu'
+      character(len=*), parameter :: OUTPUT_FILE = 'test_output_partition.mdu'
+      character(len=*), parameter :: MAP_FILE_VALUE = 'test_map_0001.nc'
+
+      integer :: unit_input, unit_output, stat
+      integer :: equal_pos, comment_pos
+      character(len=500) :: line, line_lower, value_str
+      logical :: found_classmapfile, found_mapfile
+
+      ! Arrange: simulate a model where MapFile has a value, but ClassMapFile is left empty (as in UNST-10193)
+      md_mapfile = MAP_FILE_VALUE
+      md_classmap_file = ' '
+
+      open (newunit=unit_input, file=INPUT_FILE, status='replace', action='write')
+      write (unit_input, '(a)') 'MapFile                           = '//trim(MAP_FILE_VALUE)//'        # Map file *_map.nc'
+      write (unit_input, '(a)') 'ClassMapFile                      =                     # Class map file *_clm.nc'
+      close (unit_input)
+
+      ! Act
+      call generate_partition_mdu_file(INPUT_FILE, OUTPUT_FILE)
+
+      ! Assert: read back the generated partition file and check that ClassMapFile remained empty
+      found_classmapfile = .false.
+      found_mapfile = .false.
+
+      open (newunit=unit_output, file=OUTPUT_FILE, status='old', action='read', iostat=stat)
+      call f90_assert_eq(stat, 0, 'Error opening generated partition MDU file.')
+
+      do
+         read (unit_output, '(a)', iostat=stat) line
+         if (stat /= 0) exit
+
+         line_lower = line
+         call str_lower(line_lower)
+
+         comment_pos = index(line_lower, '#')
+         equal_pos = index(line_lower, '=')
+         if (equal_pos == 0) cycle
+
+         if (comment_pos > 0) then
+            value_str = adjustl(line(equal_pos + 1:comment_pos - 1))
+         else
+            value_str = adjustl(line(equal_pos + 1:))
+         end if
+
+         if (index(line_lower, 'classmapfile') /= 0) then
+            found_classmapfile = .true.
+            call f90_expect_eq(len_trim(value_str), 0, 'ClassMapFile was erroneously filled with a value during partitioning.')
+         else if (index(line_lower, 'mapfile') /= 0) then
+            found_mapfile = .true.
+            call f90_expect_true(index(value_str, trim(MAP_FILE_VALUE)) == 1, 'MapFile was not correctly replaced during partitioning.')
+         end if
+      end do
+      close (unit_output, status='delete')
+
+      call f90_assert_true(found_classmapfile, 'ClassMapFile line missing from generated partition MDU file.')
+      call f90_assert_true(found_mapfile, 'MapFile line missing from generated partition MDU file.')
+
+      open (newunit=unit_input, file=INPUT_FILE, status='old', action='read')
+      close (unit_input, status='delete')
+   end subroutine test_empty_classmapfile_stays_empty
+   !$f90tw)
+
+end module test_generate_partition_mdu_file


### PR DESCRIPTION
# What was done

AI SLOP WARNING: SKILL demo. This took Claude Sonnet 5 about 5 minutes cost 137.9 credits. It built and ran the unit test!

- Fixes UNST-10193: `ClassMapFile` was erroneously filled during partitioning when its value was left empty in the main `.mdu` file.
- Root cause: the find-and-replace logic in `generate_partition_mdu_file` matched `MapFile` against lines containing `ClassMapFile`, since `classmapfile` contains the substring `mapfile`. The `ClassMapFile` check was previously only active when `md_classmap_file` was non-empty, so an empty `ClassMapFile` fell through to the `MapFile` replacement branch and got filled with `MapFile`'s value — causing the two output files to overwrite each other during simulation.
- `ClassMapFile` detection is now independent of whether its value is set, and takes precedence over the `MapFile` check. When `ClassMapFile` is empty, its line is now written back unchanged in the partitioned `.mdu` file, instead of being replaced with `MapFile`'s value.

# Evidence of the work done

- [ ] Video/figures
- [x] Clear from the issue description
- [ ] Not applicable

# Tests
- [x] Tests updated \
Added `test_generate_partition_mdu_file.test_empty_classmapfile_stays_empty` (in `test_dflowfm_kernel_gtest`), a regression test that reproduces the bug (fails without the fix) and verifies `ClassMapFile` stays empty while `MapFile` is still correctly replaced during partitioning.

# Documentation
- [x] Not applicable

# Issue link
https://issuetracker.deltares.nl/browse/UNST-10193
