### PR TITLE
INCIDENT: Increase maxRunTime amount of several new test cases, that were merged just after maxRunTime was enforced.

### DIFF
--- a/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow.xml
@@ -1573,7 +1573,7 @@
   </testCase>
   <testCase name="e01_f06_c12-vanrijn_temp" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f06_ols/c12-vanrijn_temp</path>
-    <maxRunTime>450</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-T01.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3792,7 +3792,6 @@
   </testCase>
   <testCase name="e01_f27_c02-temperature_sigma_10layers" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c02-temperature_sigma_10layers</path>
-    <maxRunTime>200</maxRunTime>
     <checks>
       <file name="trih-tts.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4481,7 +4480,7 @@
   </testCase>
   <testCase name="e01_f50_c31143_Simple-channel-flow(FP)_Chezy_3D_K10_non-eq2_ke_BCadapt" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f50_validation_analytical/c31143_Simple-channel-flow(FP)_Chezy_3D_K10_non-eq2_ke_BCadapt</path>
-      <maxRunTime>450</maxRunTime>
+      <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trim-chz_3D_K10_non-eq2_ke_BCadapt.dat" type="NEFIS">
         <parameters name="map-series">

--- a/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel.xml
@@ -335,7 +335,6 @@
   </testCase>
   <testCase name="e01_f01_c44_parallel_bed_slope" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f01_general/c44_parallel_bed_slope</path>
-    <maxRunTime>60</maxRunTime>
     <checks>
       <file name="trim-run01.dat" type="NEFIS">
         <parameters name="map-sed-series">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_1d_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_1d_all_cases.xml
@@ -82,7 +82,7 @@
   </testCase>
   <testCase name="e02_f010_c102_T4_refined_customPoints" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f010_structures/c102_custompoints_dambreak/T4_refined_customPoints</path>
-      <maxRunTime>450</maxRunTime>
+      <maxRunTime>540</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Dambreak_refinedGRID_customWLpoints/Dambreak_refinedGRID_customWLpoints_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -3210,7 +3210,7 @@
   </testCase>
   <testCase name="e02_f010_c011_gate_free" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c011_gate_free</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -3261,7 +3261,7 @@
   </testCase>
   <testCase name="e02_f010_c021_gate_free_ini_newkeywords" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c021_gate_free_ini_newkeywords</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -4114,7 +4114,6 @@
   </testCase>
   <testCase name="e02_f011_c098_humidity_netcdf" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f011_wind/c098_humidity_netcdf</path>
-    <maxRunTime>60</maxRunTime>
     <checks>
       <file name="output/FlowFM_map.nc" type="netCDF">
         <parameters>
@@ -6356,7 +6355,6 @@
   </testCase>
   <testCase name="e02_f022_c100_inifieldfile_morphopol" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c100_inifieldfile_morphopol</path>
-    <maxRunTime>60</maxRunTime>
     <checks>
       <file name="dflowfmoutput/r_map.nc" type="netCDF">
         <parameters>
@@ -6367,7 +6365,6 @@
   </testCase>
   <testCase name="e02_f022_c108_settling_mass_balance" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c108_settling_mass_balance</path>
-    <maxRunTime>60</maxRunTime>
     <checks>
       <file name="dflowfmoutput/masscon_his.nc" type="netCDF">
         <parameters>
@@ -9599,7 +9596,7 @@
   </testCase>
   <testCase name="e02_f044_c04_waveforcing_custom_vars" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f044_offline_waves/c04_waveforcing_custom_vars</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="output/Borkum_map.nc" type="netCDF">
         <parameters>
@@ -9614,7 +9611,7 @@
   </testCase>          
   <testCase name="e02_f006_c050_add_operand_ecConverterUniform" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c050_add_operand_ecConverterUniform</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/rainschematic_his.nc" type="netCDF">
         <parameters>
@@ -9626,7 +9623,7 @@
   </testCase>
   <testCase name="e02_f006_c051_add_operand_ecConverterUnimagdir" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c051_add_operand_ecConverterUnimagdir</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/winduni_map.nc" type="netCDF">
         <parameters>
@@ -9638,7 +9635,7 @@
   </testCase>
   <testCase name="e02_f006_c052_add_operand_ecConverterPolytim" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c052_add_operand_ecConverterPolytim</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/tfl_his.nc" type="netCDF">
         <parameters>
@@ -9651,7 +9648,7 @@
   </testCase>
   <testCase name="e02_f006_c053_add_operand_ecConverterArcinfo" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c053_add_operand_ecConverterArcinfo</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/windcase_map.nc" type="netCDF">
         <parameters>
@@ -9665,7 +9662,7 @@
   </testCase>
   <testCase name="e02_f006_c054_add_operand_ecConverterFourier" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c054_add_operand_ecConverterFourier</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/tfl_his.nc" type="netCDF">
         <parameters>
@@ -9678,7 +9675,7 @@
   </testCase>
   <testCase name="e02_f006_c055_add_operand_ecConverterCurvi" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c055_add_operand_ecConverterCurvi</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/windcase_map.nc" type="netCDF">
         <parameters>
@@ -9692,7 +9689,7 @@
   </testCase>
   <testCase name="e02_f006_c057_add_operand_ecConverterNetcdf" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c057_add_operand_ecConverterNetcdf</path>
-    <maxRunTime>600.0000000</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/windcase_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
@@ -114,7 +114,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c02" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c02-FriesianInlet_schematic/dfm</path>
-    <maxRunTime>450</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -159,7 +159,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c05" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c05-california/dfm</path>
-      <maxRunTime>450</maxRunTime>
+      <maxRunTime>480</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/cca_map.nc" type="NETCDF">
@@ -249,7 +249,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c01" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c01-ti_com_dtuser_default</path>
-      <maxRunTime>450</maxRunTime>
+      <maxRunTime>480</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
@@ -206,7 +206,7 @@
   </testCase>
   <testCase name="e02_f014_c042_dad_2dredge1dump_layered_bed_par" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c042_dad_2dredge1dump_layered_bed_par</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
@@ -1596,7 +1596,7 @@
   </testCase>
   <testCase name="e02_f030_c401_Course_tracers" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c401_Course_tracers</path>
-      <maxRunTime>450</maxRunTime>
+      <maxRunTime>480</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>
@@ -1625,7 +1625,7 @@
   </testCase>
   <testCase name="e02_f030_c402_Course_bacteria" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c402_Course_bacteria</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>
@@ -1644,7 +1644,7 @@
   </testCase>
   <testCase name="e02_f030_c403_Course_eutrophication" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c403_Course_eutrophication</path>
-    <maxRunTime>450</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
@@ -143,7 +143,7 @@
   </testCase>
   <testCase name="e02_f039_c08_sediment_ini_3d_uniform_samples" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f039_morphology_3d/c08_sediment_ini_3d_uniform_samples</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfmoutput/massbal_1frac_his.nc" type="netCDF">
         <parameters>
@@ -156,7 +156,7 @@
   </testCase>
   <testCase name="e02_f039_c09_sediment_ini_3d_verticalprofile" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f039_morphology_3d/c09_sediment_ini_3d_verticalprofile</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfmoutput/massbal_1frac_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
@@ -378,7 +378,7 @@
   </testCase>
   <testCase name="e04_f05_c03_nest" ref="dimr_trunk">
     <path version="DVC">e04_wave/f05-nest/c03_nest_xymiss</path>
-    <maxRunTime>120.0</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="wavm-waves-overall_cut_v0.nc" type="NETCDF">
         <parameters>
@@ -398,7 +398,7 @@
   </testCase>
     <testCase name="e04_f05_c04_nest" ref="dimr_trunk">
     <path version="DVC">e04_wave/f05-nest/c04_base_zeeland</path>
-    <maxRunTime>120.0</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="wavm-waves-wave03_strandA.nc" type="NETCDF">
         <parameters>
@@ -418,7 +418,7 @@
   </testCase>
   <testCase name="e04_f05_c05_nest" ref="dimr_trunk">
     <path version="DVC">e04_wave/f05-nest/c05_cutout_zeeland</path>
-    <maxRunTime>120.0</maxRunTime>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="wavm-waves-wave03_strandA.nc" type="NETCDF">
         <parameters>
@@ -439,7 +439,7 @@
   <!-- ================================================================= -->
   <testCase name="e04_f06_c01_write_wavh" ref="dimr_trunk">
     <path version="DVC">e04_wave/f06-io/c01_write_wavh</path>
-    <maxRunTime>360</maxRunTime>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="wavh-marshall_with_nested_grids.nc" type="NETCDF">
         <parameters>


### PR DESCRIPTION
There were some new test cases added that had the 'maxRunTime' property set too low (they time out every time).
Also it doesn't make sense to set the maxRunTime lower than 480. The default is 300 and if any test case needs more time than that it makes sense to set it at least three minutes above five minutes, because the maxRunTime is just there to avoid processes from hanging indefinitely. The timeout is not meant as a check on performance degradation.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
