### PR TITLE
DEVOPSDSC-917: Add ssl_verify to dvc config

### DIFF
--- a/.dvc/config
+++ b/.dvc/config
@@ -5,3 +5,4 @@
     url = s3://delft3d-testbench
     endpointurl = https://s3.deltares.nl
     read_timeout = 300
+    ssl_verify = /etc/pki/tls/certs/ca-bundle.crt


### PR DESCRIPTION
# What was done 
Add ssl_verify to dvc config

# Error
The following error occurs when build the dvc cache: https://dpcbuild.deltares.nl/buildConfiguration/Maintenance_Maintenance_ScheduledMaintenance_DvcCache/7748599?buildTab=log&focusLine=457&logView=linear&linesState=410


# Successful tests
This change was tested successfully in the branch `all/task/DEVOPSDSC-917_run-dvc-testbench-from-cache`. 
See commit: https://github.com/Deltares/Delft3D/commit/959f21566e19cd9392337190d877738e136751cb

and successful build: https://dpcbuild.deltares.nl/buildConfiguration/Maintenance_Maintenance_ScheduledMaintenance_DvcCache/7748421?buildTab=log&logView=linear&focusLine=0&linesState=668

# Issue link
DEVOPSDSC-917
