### PR TITLE
don't let dzTop overrule the stretchType for non z-layer models

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/m_flow.f90
@@ -74,9 +74,12 @@ module m_flow ! flow arrays-999
    integer, parameter :: LAYTP_POLYGON_MIXED = 3 !< Mixed layering in polygon regions (layer count + layertype in each polygon's z-values)
    integer, parameter :: LAYTP_DENS_SIGMA = 4 !< Density controlled sigma-layers
 
-   integer :: iStrchType = -1 !< Stretching type for non-uniform layers, 1=user defined, 2=exponential, otherwise=uniform
-   integer, parameter :: STRCH_USER = 1
-   integer, parameter :: STRCH_EXPONENT = 2
+   integer, parameter :: STRETCH_UNI_OVER_EXP = -1 !< uniform over exponential, for backward compatibility (only for layertype = LAYTP_Z)
+   integer, parameter :: STRETCH_UNIFORM = 0 !< uniform layers
+   integer, parameter :: STRETCH_USER = 1 !< user defined layers
+   integer, parameter :: STRETCH_EXPONENT = 2 !< exponential layers
+   integer, parameter :: STRETCH_UNDEFINED = -999 !< undefined stretching type
+   integer :: stretch_type = STRETCH_UNDEFINED !< Stretching type for layers
 
    integer :: iturbulencemodel !< 0=no, 1 = constant, 2 = algebraic, 3 = k-eps
    integer :: ieps !< bottom boundary type eps. eqation, 1=dpmorg, 2 = dpmsandpit, 3=D3D, 4=Dirichlethdzb
@@ -96,8 +99,8 @@ module m_flow ! flow arrays-999
    real(kind=dp), allocatable, dimension(:) :: uuk !< coefficient vertical mom exchange of kmx layers
 
    real(kind=dp), allocatable, dimension(:) :: laycof !< coefficients for sigma layer
-   !    1: Percentages of the layers, user defined, laycof(kmx)
-   !    2: Stretching level, and two coefficients for layers growth, laycof(3)
+   !    if stretch_type = STRETCH_USER: Percentages of the layers, user defined, laycof(kmx)
+   !    if stretch_type = STRETCH_EXPONENT: Stretching level, and two coefficients for layers growth, laycof(3)
    !
    real(kind=dp), allocatable, dimension(:, :) :: dzslay ! the normalized thickness of layer, dim = (: , maxlaydefs)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -773,16 +773,16 @@ contains
       call prop_get(md_ptr, 'geometry', 'ZlayTop', zlaytop)
       call prop_get(md_ptr, 'geometry', 'StretchType', stretch_type)
       
-      if (layertype /= LAYTP_Z) then
-         if (stretch_type == STRETCH_UNDEFINED .or. stretch_type == STRETCH_UNI_OVER_EXP) then
-            stretch_type = STRETCH_UNIFORM
-         end if
-      else
+      if (layertype == LAYTP_Z) then
          if (stretch_type == STRETCH_UNDEFINED) then
             stretch_type = STRETCH_UNI_OVER_EXP
          elseif (dztop > 0.0_dp .and. stretch_type /= STRETCH_UNI_OVER_EXP) then
             call mess(LEVEL_WARN, 'The stretchType is reset to -1 because a strictly positive dzTop is specified.')
             stretch_type = STRETCH_UNI_OVER_EXP
+         end if
+      else
+         if (stretch_type == STRETCH_UNDEFINED .or. stretch_type == STRETCH_UNI_OVER_EXP) then
+            stretch_type = STRETCH_UNIFORM
          end if
       end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -480,7 +480,7 @@ contains
       !                         javakeps,                                                             &
       !                         fixedweirtopwidth, fixedweirtopfrictcoef, fixedweirtalud, ifxedweirfrictscheme,  &
       !                         Tsigma, jarhoxu,                                                      &
-      !                         iStrchType, STRCH_UNIFORM, STRCH_USER, STRCH_EXPONENT, STRCH_FIXLEVEL, laycof
+      !                         stretch_type, STRCH_UNIFORM, STRETCH_USER, STRETCH_EXPONENT, laycof
 
       use m_globalparameters, only: sl
       use m_flowgeom !,              only : wu1Duni, bamin, rrtol, jarenumber, VillemonteCD1, VillemonteCD2
@@ -749,8 +749,8 @@ contains
       kmx = 0
       call prop_get(md_ptr, 'geometry', 'Kmx', kmx)
 
-      call prop_get(md_ptr, 'geometry', 'Layertype', Layertype)
-      if (Layertype /= LAYTP_SIGMA) then
+      call prop_get(md_ptr, 'geometry', 'Layertype', layertype)
+      if (layertype /= LAYTP_SIGMA) then
          mxlayz = kmx
       end if
 
@@ -771,7 +771,20 @@ contains
       call prop_get(md_ptr, 'geometry', 'Tsigma', Tsigma)
       call prop_get(md_ptr, 'geometry', 'ZlayBot', zlaybot)
       call prop_get(md_ptr, 'geometry', 'ZlayTop', zlaytop)
-      call prop_get(md_ptr, 'geometry', 'StretchType', iStrchType)
+      call prop_get(md_ptr, 'geometry', 'StretchType', stretch_type)
+      
+      if (layertype /= LAYTP_Z) then
+         if (stretch_type == STRETCH_UNDEFINED .or. stretch_type == STRETCH_UNI_OVER_EXP) then
+            stretch_type = STRETCH_UNIFORM
+         end if
+      else
+         if (stretch_type == STRETCH_UNDEFINED) then
+            stretch_type = STRETCH_UNI_OVER_EXP
+         elseif (dztop > 0.0_dp .and. stretch_type /= STRETCH_UNI_OVER_EXP) then
+            call mess(LEVEL_WARN, 'The stretchType is reset to -1 because a strictly positive dzTop is specified.')
+            stretch_type = STRETCH_UNI_OVER_EXP
+         end if
+      end if
 
       call prop_get(md_ptr, 'numerics', 'Keepzlayeringatbed', keepzlayeringatbed, success) ! Deprecated, moved to [geometry] block
       call prop_get(md_ptr, 'geometry', 'Keepzlayeringatbed', keepzlayeringatbed, success)
@@ -786,7 +799,7 @@ contains
       call prop_get(md_ptr, 'geometry', 'Zlayeratubybob', jaZlayeratubybob, success)
 
       if (kmx > 0) then
-         if (iStrchType == STRCH_USER) then
+         if (stretch_type == STRETCH_USER) then
             call realloc(laycof, kmx)
             call prop_get(md_ptr, 'geometry', 'StretchCoef', laycof, kmx)
             sumlaycof = sum(laycof)
@@ -806,7 +819,7 @@ contains
                   call mess(LEVEL_ERROR, 'The values specified in "StretchCoef" do not add up to 100! We got: ', sumlaycof)
                end if
             end if
-         else if (iStrchType == STRCH_EXPONENT) then
+         else if (stretch_type == STRETCH_EXPONENT) then
             call realloc(laycof, 3)
             laycof(:) = dmiss
             call prop_get(md_ptr, 'geometry', 'StretchCoef', laycof, 3, success)
@@ -2555,7 +2568,7 @@ contains
       use m_flow ! ,                !  only : kmx, layertype, mxlayz, z_layer_growth_factor, numtopsig, &
       !         Iturbulencemodel, spirbeta, dztopuniabovez, dztop, jahazlayer, Floorlevtoplay ,  &
       !         fixedweirtopwidth, fixedweirtopfrictcoef, fixedweirtalud, ifxedweirfrictscheme,         &
-      !         Tsigma, jarhoxu, iStrchType, STRCH_USER, STRCH_EXPONENT, STRCH_FIXLEVEL, laycof
+      !         Tsigma, jarhoxu, stretch_type, STRETCH_USER, STRETCH_EXPONENT, laycof
       use m_flowgeom ! ,              only : wu1Duni, Bamin, rrtol, jarenumber, VillemonteCD1, VillemonteCD2
       use m_flowtimes
       use m_flowparameters
@@ -2848,10 +2861,10 @@ contains
             call prop_set(prop_ptr, 'geometry', 'Toplayminthick', Toplayminthick, 'Minimum top layer thickness(m), only for Z-layers')
          end if
 
-         call prop_set(prop_ptr, 'geometry', 'StretchType', iStrchType, 'Type of layer stretching, 0 = uniform, 1 = user defined, 2 = fixed level double exponential')
-         if (iStrchType == STRCH_USER) then
+         call prop_set(prop_ptr, 'geometry', 'StretchType', stretch_type, 'Type of layer stretching, 0 = uniform, 1 = user defined, 2 = fixed level double exponential')
+         if (stretch_type == STRETCH_USER) then
             call prop_set(prop_ptr, 'geometry', 'StretchCoef', laycof(1:kmx), 'Layers thickness percentage')
-         else if (iStrchType == STRCH_EXPONENT) then
+         else if (stretch_type == STRETCH_EXPONENT) then
             call prop_set(prop_ptr, 'geometry', 'StretchCoef', laycof(1:3), 'Interface percentage from bed, bottom layers growth fac, top layers growth fac')
          end if
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -480,8 +480,8 @@ contains
       !                         javakeps,                                                             &
       !                         fixedweirtopwidth, fixedweirtopfrictcoef, fixedweirtalud, ifxedweirfrictscheme,  &
       !                         Tsigma, jarhoxu,                                                      &
-      !                         stretch_type, STRETCH_UNDEFINED, STRETCH_UNIFORM, STRETCH_USER, &
-      !                         STRETCH_EXPONENT, STRETCH_UNI_OVER_EXP, laycof
+      !                         stretch_type, STRETCH_UNIFORM, STRETCH_USER, STRETCH_EXPONENT, &
+      !                         STRETCH_UNI_OVER_EXP, laycof
 
       use m_globalparameters, only: sl
       use m_flowgeom !,              only : wu1Duni, bamin, rrtol, jarenumber, VillemonteCD1, VillemonteCD2
@@ -772,17 +772,20 @@ contains
       call prop_get(md_ptr, 'geometry', 'Tsigma', Tsigma)
       call prop_get(md_ptr, 'geometry', 'ZlayBot', zlaybot)
       call prop_get(md_ptr, 'geometry', 'ZlayTop', zlaytop)
-      call prop_get(md_ptr, 'geometry', 'StretchType', stretch_type)
+      call prop_get(md_ptr, 'geometry', 'stretchType', stretch_type, success)
       
       if (layertype == LAYTP_Z) then
-         if (stretch_type == STRETCH_UNDEFINED) then
+         if (.not. success) then
             stretch_type = STRETCH_UNI_OVER_EXP
          elseif (dztop > 0.0_dp .and. stretch_type /= STRETCH_UNI_OVER_EXP) then
-            call mess(LEVEL_WARN, 'The stretchType is reset to -1 because a strictly positive dzTop is specified.')
+            write (msgbuf, '(a,a,i0,a)'), &
+                'A positive dzTop value requires stretchType = -1 (uniform over exponential). ', &
+                'Input stretchType = ', stretch_type,' is ignored.'
+            call warn_flush()
             stretch_type = STRETCH_UNI_OVER_EXP
          end if
       else
-         if (stretch_type == STRETCH_UNDEFINED .or. stretch_type == STRETCH_UNI_OVER_EXP) then
+         if (.not. success .or. stretch_type == STRETCH_UNI_OVER_EXP) then
             stretch_type = STRETCH_UNIFORM
          end if
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -773,10 +773,6 @@ contains
       call prop_get(md_ptr, 'geometry', 'ZlayTop', zlaytop)
       call prop_get(md_ptr, 'geometry', 'StretchType', iStrchType)
 
-      if (Dztop > 0.0_dp) then ! hk claims back original functionality
-         iStrchType = -1
-      end if
-
       call prop_get(md_ptr, 'numerics', 'Keepzlayeringatbed', keepzlayeringatbed, success) ! Deprecated, moved to [geometry] block
       call prop_get(md_ptr, 'geometry', 'Keepzlayeringatbed', keepzlayeringatbed, success)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -480,7 +480,8 @@ contains
       !                         javakeps,                                                             &
       !                         fixedweirtopwidth, fixedweirtopfrictcoef, fixedweirtalud, ifxedweirfrictscheme,  &
       !                         Tsigma, jarhoxu,                                                      &
-      !                         stretch_type, STRCH_UNIFORM, STRETCH_USER, STRETCH_EXPONENT, laycof
+      !                         stretch_type, STRETCH_UNDEFINED, STRETCH_UNIFORM, STRETCH_USER, &
+      !                         STRETCH_EXPONENT, STRETCH_UNI_OVER_EXP, laycof
 
       use m_globalparameters, only: sl
       use m_flowgeom !,              only : wu1Duni, bamin, rrtol, jarenumber, VillemonteCD1, VillemonteCD2

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getlayerindices.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/getlayerindices.f90
@@ -35,7 +35,7 @@ contains
    !> Gets the local layer numbers for a given grid cell.
  !! Note: works both for sigma and z, but for sigma, the return values are trivial: nlayb==1, nrlay==kmx.
    subroutine getlayerindices(n, nlayb, nrlay)
-      use m_flow, only: laydefnr, laytyp, laymx
+      use m_flow, only: laydefnr, laytyp, laymx, LAYTP_SIGMA
       use m_get_zlayer_indices, only: getzlayerindices
 
       integer, intent(in) :: n !< Flow node/grid cell number
@@ -45,7 +45,7 @@ contains
       integer :: Ltn
 
       Ltn = laydefnr(n)
-      if (laytyp(Ltn) == 1) then ! sigma
+      if (laytyp(Ltn) == LAYTP_SIGMA) then ! sigma
          nlayb = 1 ! Bottom layers always the first
          nrlay = laymx(Ltn) ! Sigma: always all layers
       else ! z-layers

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/set_kbot_ktop.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/set_kbot_ktop.f90
@@ -65,7 +65,7 @@ contains
       ktop0 = ktop
       vol1 = 0.0_dp
 
-      if (Layertype == LAYTP_SIGMA) then ! sigma-layers
+      if (layertype == LAYTP_SIGMA) then ! sigma-layers
          do n = 1, ndx
             kb = kbot(n)
 
@@ -84,7 +84,7 @@ contains
          end do
          return
 
-      else if (Layertype == LAYTP_Z) then ! z- or z-sigma-layers
+      else if (layertype == LAYTP_Z) then ! z- or z-sigma-layers
          do n = 1, ndx
             kb = kbot(n)
 
@@ -133,20 +133,20 @@ contains
             end if
          end do
 
-      else if (Layertype == LAYTP_POLYGON_MIXED) then ! polygon defined z-layers
+      else if (layertype == LAYTP_POLYGON_MIXED) then ! polygon defined z-layers
          do n = 1, ndx
             kb = kbot(n)
 
             Ldn = laydefnr(n)
             if (Ldn > 0) then
-               if (Laytyp(Ldn) == 1) then ! sigma
+               if (laytyp(Ldn) == LAYTP_SIGMA) then ! sigma
                   h0 = s1(n) - zws(kb - 1)
                   do k = 1, kmxn(n) - 1
                      zws(kb + k - 1) = zws(kb - 1) + h0 * zslay(k, Ldn)
                   end do
                   ktop(n) = kb + kmxn(n) - 1
                   zws(ktop(n)) = s1(n)
-               else if (Laytyp(Ldn) == 2) then ! z
+               else if (laytyp(Ldn) == LAYTP_Z) then ! z
 
                   ktx = kb + kmxn(n) - 1
                   call getzlayerindices(n, nlayb, nrlay)
@@ -168,7 +168,7 @@ contains
             end if
          end do
 
-      else if (Layertype == LAYTP_DENS_SIGMA) then ! density controlled sigma-layers
+      else if (layertype == LAYTP_DENS_SIGMA) then ! density controlled sigma-layers
          dkx = 0.5_dp
          do n = 1, ndx
             drhok = 0.01_dp
@@ -302,7 +302,7 @@ contains
          return
       end if
 
-      if (Layertype == LAYTP_SIGMA) then ! sigma only
+      if (layertype == LAYTP_SIGMA) then ! sigma only
          do i_bnd = 1, nbndz
             n = kbndz(1, i_bnd)
             if (n <= 0 .or. n > ndx) then
@@ -327,7 +327,7 @@ contains
          end do
          return ! Early exit - no link updates needed for sigma layers, volumes already calculated
 
-      else if (Layertype == LAYTP_Z) then ! z or z-sigma
+      else if (layertype == LAYTP_Z) then ! z or z-sigma
          do i_bnd = 1, nbndz
             n = kbndz(1, i_bnd)
             if (n <= 0 .or. n > ndx) then
@@ -387,7 +387,7 @@ contains
             end if
          end do
 
-      else if (Layertype == LAYTP_POLYGON_MIXED) then ! polygon defined z-layers
+      else if (layertype == LAYTP_POLYGON_MIXED) then ! polygon defined z-layers
          do i_bnd = 1, nbndz
             n = kbndz(1, i_bnd)
             if (n <= 0 .or. n > ndx) then
@@ -399,14 +399,14 @@ contains
 
             Ldn = laydefnr(n)
             if (Ldn > 0) then
-               if (Laytyp(Ldn) == 1) then ! sigma
+               if (laytyp(Ldn) == LAYTP_SIGMA) then ! sigma
                   h0 = s0(n) - zws(kb - 1)
                   do k = 1, kmxn(n) - 1
                      zws(kb + k - 1) = zws(kb - 1) + h0 * zslay(k, Ldn)
                   end do
                   ktop(n) = kb + kmxn(n) - 1
                   zws(ktop(n)) = s0(n)
-               else if (Laytyp(Ldn) == 2) then ! z
+               else if (laytyp(Ldn) == LAYTP_Z) then ! z
                   ktx = kb + kmxn(n) - 1
                   call getzlayerindices(n, nlayb, nrlay)
                   do k = kb, ktx
@@ -432,7 +432,7 @@ contains
             end if
          end do
 
-      else if (Layertype == LAYTP_DENS_SIGMA) then ! density controlled sigma-layers
+      else if (layertype == LAYTP_DENS_SIGMA) then ! density controlled sigma-layers
          ! Simplified version for boundary nodes only - skip the global smoothing,
          ! because looping over all nodes would be too expensive for updating boundary nodes only.
          numbd = 0.5_dp * kmx

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
@@ -319,7 +319,7 @@ contains
             mx = max(mx, laymx(k))
          end do
 
-         call realloc(zslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, keepexisting=.false.)
+         call realloc(zslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, fill=dmiss, keepexisting=.false.)
          call realloc(dzslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, fill=0.0_dp, keepexisting=.false.)
 
          if (stretch_type == STRETCH_USER) then
@@ -377,8 +377,6 @@ contains
                end do
 
             else if (laytyp(j) == LAYTP_Z) then
-
-               call realloc(zslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, keepexisting=.false.) ! nr of layer distributions
 
                if (stretch_type == STRETCH_UNI_OVER_EXP) then
                   zslay(0, j) = zmn

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_allocflow.f90
@@ -45,9 +45,9 @@ contains
       use m_flow, only: s0, s00, s1, hs, a0, a1, cfs, negativedepths, negativedepths_cum, noiterations, noiterations_cum, &
                         limitingTimestepEstimation, limitingTimestepEstimation_cum, flowCourantNumber, kbot, ktop, ktop0, kmxn, Lbot, Ltop, &
                         kmxL, ustb, ustw, laydefnr, laytyp, laymx, nlaybn, nrlayn, map_write_settings, mxlaydefs, kmx, kbotc, kmxc, layertype, &
-                        LAYTP_SIGMA, LAYTP_DENS_SIGMA, LAYTP_Z, LAYTP_POLYGON_MIXED, numvertdis, mxlays, sdkx, dkx, zlaybot, iStrchType, &
+                        LAYTP_SIGMA, LAYTP_DENS_SIGMA, LAYTP_Z, LAYTP_POLYGON_MIXED, numvertdis, mxlays, sdkx, dkx, zlaybot, stretch_type, &
                         zlaytop, Floorlevtoplay, dztop, dztopuniabovez, sini, z_layer_growth_factor, numtopsig, janumtopsiguniform, mxlayz, kmxx, &
-                        zslay, dzslay, strch_user, laycof, strch_exponent, indlaynod, wflaynod, ndkx, jazlayeratubybob, lnkx, ln0, ucx, squ, &
+                        zslay, dzslay, STRETCH_USER, laycof, STRETCH_EXPONENT, indlaynod, wflaynod, ndkx, jazlayeratubybob, lnkx, ln0, ucx, squ, &
                         sqi, dvyc, uqcx, uqcy, vol0, ucyq, vol1, ucy, qin, ucxq, vih, dvxc, vol1_f, sqa, volerror, sq, ucmag, jatrt, ucx_mor, &
                         ucy_mor, uc1d, u1du, japure1d, alpha_mom_1d, alpha_ene_1d, q1d, au1d, wu1d, sar1d, volu1d, freeboard, hsonground, &
                         volonground, qcur1d2d, vtot1d2d, qcurlat, vtotlat, s1gradient, squ2d, squcor, icorio, hus, ucz, rho, rhomean, rhowat, &
@@ -59,7 +59,7 @@ contains
                         tureps0, vicwws, turkin1, vicwwu, tureps1, tke_min, eps_min, turkinws, turepsws, sqcu, tqcu, eqcu, epsz0, z0ucur, &
                         z0urou, taus, taubxu, taubu, cfuhi, frcu, ifrcutp, u0, u1, q1, qa, map_fixed_weir_energy_loss, v, ucxu, ucyu, hu, huvli, &
                         au, au_nostrucs, viu, vius, viclu, suu, advi, adve, plotlin, frcu_bkp, frcu_mor, jacali, ifrctypuni, jafrculin, frculin, &
-                        u_to_umain, q1_main, cfclval, cftrt, czs, jarhoxu, rhou, fu, czu, bb, ru, dd, &
+                        u_to_umain, q1_main, cfclval, cftrt, czs, jarhoxu, rhou, fu, czu, bb, ru, dd, STRETCH_UNI_OVER_EXP, &
                         sa1, salini, sam0, sam1, same, tem1, temini, background_air_temperature, background_humidity, background_cloudiness, &
                         soiltempthick, his_write_settings, qtotmap, qevamap, qfrevamap, qconmap, qfrconmap, qsunmap, qlongmap, ustbc, &
                         idensform, jarichardsononoutput, q1waq, qwwaq, itstep, sqwave, infiltrationmodel, dfm_hyd_noinfilt, infilt, &
@@ -237,7 +237,7 @@ contains
 
          if (layertype == LAYTP_SIGMA .or. layertype == LAYTP_DENS_SIGMA) then ! pure and density controlled sigma-layers
             mxlaydefs = 1
-            laytyp(1) = 1
+            laytyp(1) = LAYTP_SIGMA
             laymx(1) = kmx
             if (layertype == LAYTP_DENS_SIGMA) then
                call realloc(sdkx, ndx, stat=ierr, keepexisting=.false.)
@@ -247,7 +247,7 @@ contains
             end if
          else if (layertype == LAYTP_Z) then ! all z
             mxlaydefs = 1
-            laytyp(1) = 2
+            laytyp(1) = LAYTP_Z
 
             if (zlaybot == dmiss) then
                zmn = bl(1)
@@ -262,13 +262,7 @@ contains
                call reduce_double_min(zmn)
             end if
 
-            if (iStrchType >= 0) then
-               if (zlaytop == dmiss) then
-                  zmx = sini
-               else
-                  zmx = zlaytop
-               end if
-            else
+            if (stretch_type == STRETCH_UNI_OVER_EXP) then
                if (Floorlevtoplay == dmiss) then
                   zmx = sini
                else
@@ -277,6 +271,12 @@ contains
                   else
                      zmx = Floorlevtoplay + dztop
                   end if
+               end if
+            else
+               if (zlaytop == dmiss) then
+                  zmx = sini
+               else
+                  zmx = zlaytop
                end if
             end if
 
@@ -322,7 +322,7 @@ contains
          call realloc(zslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, keepexisting=.false.)
          call realloc(dzslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, fill=0.0_dp, keepexisting=.false.)
 
-         if (iStrchType == STRCH_USER) then
+         if (stretch_type == STRETCH_USER) then
             do j = 1, mxlaydefs
                mx = laymx(j)
                do k = 1, mx
@@ -330,7 +330,7 @@ contains
                end do
             end do
 
-         elseif (iStrchType == STRCH_EXPONENT) then
+         elseif (stretch_type == STRETCH_EXPONENT) then
             gfi = 1.0_dp / laycof(2)
             gf = laycof(3)
             do j = 1, mxlaydefs
@@ -359,45 +359,50 @@ contains
                   end do
                end if
             end do
-         else
+         else ! default: fill as uniform layers
             do j = 1, mxlaydefs
                mx = laymx(j)
-               do k = 1, mx
-                  dzslay(k, j) = 1.0_dp / mx
-               end do
+               dzslay(1:mx, j) = 1.0_dp / mx
             end do
          end if
 
          do j = 1, mxlaydefs
             mx = laymx(j)
-            if (laytyp(j) == 1) then
+            if (laytyp(j) == LAYTP_SIGMA) then
 
+               ! Fill layers based on dzslay computed above
                zslay(0, j) = 0.0_dp
                do k = 1, mx
                   zslay(k, j) = zslay(k - 1, j) + dzslay(k, j)
                end do
 
-            else if (laytyp(j) == 2) then
+            else if (laytyp(j) == LAYTP_Z) then
 
                call realloc(zslay, uindex=[mx, mxlaydefs], lindex=[0, 1], stat=ierr, keepexisting=.false.) ! nr of layer distributions
 
-               if (iStrchType >= 0) then
-                  zslay(0, j) = zmn
-                  do k = 1, mx
-                     zslay(k, j) = zslay(k - 1, j) + dzslay(k, j) * (zmx - zmn)
-                  end do
-               else
+               if (stretch_type == STRETCH_UNI_OVER_EXP) then
                   zslay(0, j) = zmn
                   zslay(mx, j) = zmx
+                  
+                  ! Fill top uniform layers, thickness equal to dzm
                   do k = mx - 1, mx - kuni, -1
                      zslay(k, j) = zslay(k + 1, j) - dzm
                   end do
 
+                  ! Fill bottom layers with exponential growth factor
                   dzb = dzm
                   do k = mx - kuni - 1, 1, -1
                      dzb = dzb * z_layer_growth_factor
                      zslay(k, j) = zslay(k + 1, j) - dzb
                   end do
+                  
+               else
+                  ! Fill layers based on dzslay computed above, scaled to the actual depth range
+                  zslay(0, j) = zmn
+                  do k = 1, mx
+                     zslay(k, j) = zslay(k - 1, j) + dzslay(k, j) * (zmx - zmn)
+                  end do
+                  
                end if
             end if
          end do
@@ -410,10 +415,10 @@ contains
 
             Ldn = laydefnr(n)
             if (Ldn >= 1) then
-               if (laytyp(Ldn) == 1) then
+               if (laytyp(Ldn) == LAYTP_SIGMA) then
                   mx = laymx(Ldn)
                   kmxn(n) = mx
-               else if (laytyp(Ldn) == 2) then
+               else if (laytyp(Ldn) == LAYTP_Z) then
                   call getzlayerindices(n, nlayb, nrlay)
                   kmxn(n) = nrlay
                end if
@@ -505,8 +510,7 @@ contains
                Lt2 = laytyp(laydefnr(n2))
             end if
 
-            if (Lt1 == 2 .and. Lt2 == 2) then
-
+            if (Lt1 == LAYTP_Z .and. Lt2 == LAYTP_Z) then
                call getzlayerindices(n1, nlayb1, nrlay1) ! connection to be made at bedcell of highest adjacent cell
                call getzlayerindices(n2, nlayb2, nrlay2)
                kb1 = max(0, nlayb2 - nlayb1)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fourier_analysis.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/fourier_analysis.f90
@@ -220,7 +220,7 @@ contains
    !> allocate the arrays for fourier and min/max
    subroutine alloc_fourier_analysis_arrays()
       use m_flowgeom, only: bl, bl_min, ndx
-      use m_flow, only: s1, s1max, kmx, laytyp, numtopsig
+      use m_flow, only: s1, s1max, kmx, laytyp, numtopsig, LAYTP_SIGMA
       use precision
       implicit none
 
@@ -324,7 +324,7 @@ contains
       end if
 
       ! Create fourier specific bl and s1 array, only if required
-      if (kmx > 0 .and. (laytyp(1) == 1 .or. numtopsig > 0)) then
+      if (kmx > 0 .and. (laytyp(1) == LAYTP_SIGMA .or. numtopsig > 0)) then
          call realloc(bl_min, ndx, keepExisting=.false., stat=istat)
          call realloc(s1max, ndx, keepExisting=.false., stat=istat)
          bl_min = bl
@@ -1554,7 +1554,7 @@ contains
       dtw = dts / dt_user
 
       !Update fourier specific bl and s1 array, only if required
-      if (kmx > 0 .and. (laytyp(1) == 1 .or. numtopsig > 0)) then
+      if (kmx > 0 .and. (laytyp(1) == LAYTP_SIGMA .or. numtopsig > 0)) then
          bl_min = min(bl, bl_min) ! lowest bed level
          s1max = max(s1, s1max) ! highest water level
       end if


### PR DESCRIPTION
# What was done 

D-Flow FM distinguishes for the vertical layer distribution the following options:
- `STRETCH_UNIFORM` (0)
- `STRETCH_USER` (1)
- `STRETCH_EXPONENTIAL` (2) and
- `STRETCH_UNI_OVER_EXP` (-1) -- undocumented.
The last one was the default initialization and was enforced whenever `dzTop` was specified, even though it's not compatible with sigma-layers where it effectively fell back to `STRETCH_UNIFORM`.

In the new situation, `STRETCH_UNIFORM` is the default for all non z-layer models; the `STRETCH_UNI_OVER_EXP` option cannot be selected.
The `STRETCH_UNI_OVER_EXP` option is the default for z-layer models and is also used (for z-layer models) when `STRETCH_UNIFORM` is requested (if we change this behaviour, we will have to update test case e02_f018_c030 whicih specifies `STRETCH_UNIFORM` but uses `STRETCH_UNI_OVER_EXP`).

Some refactoring of the code related to the processing of the `stretchType` for the vertical layer distribution -- effectively no code change except for the change mentioned above. Renamed the variable `iStrchTyp` to `stretch_type` and consistently used parameters for the different options. `STRETCH_UNDEFINED` (-999) added to allow for initialization depending on user selected layer-type.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link

UNST-10265