### PR TITLE
increase timeout to 60 seconds for the general gtest, and 30 for the …

### DIFF
--- a/src/third_party_open/f90tw/f90tw-main/f90tw/CMakeLists.txt
+++ b/src/third_party_open/f90tw/f90tw-main/f90tw/CMakeLists.txt
@@ -163,7 +163,11 @@ function(F90TWTEST NAME)
         )
         
     endif()
-    gtest_discover_tests(${NAME} WORKING_DIRECTORY $<TARGET_FILE_DIR:${NAME}>)
+    gtest_discover_tests(
+        ${NAME}
+        WORKING_DIRECTORY $<TARGET_FILE_DIR:${NAME}>
+        DISCOVERY_TIMEOUT 60
+    )
 endfunction()
 
 # resolve the preprocessor to be used. it is assumed that on unix-based systems

--- a/src/tools_gpl/pre_c_sumo/test/CMakeLists.txt
+++ b/src/tools_gpl/pre_c_sumo/test/CMakeLists.txt
@@ -47,4 +47,4 @@ source_group(TREE ${CMAKE_CURRENT_SOURCE_DIR} FILES ${source_files})
 set_target_properties(test_pre_c_sumo_lib PROPERTIES FOLDER tools_gpl/pre_c_sumo/test)
 
 include(GoogleTest)
-gtest_discover_tests(test_pre_c_sumo_lib)
+gtest_discover_tests(test_pre_c_sumo_lib DISCOVERY_TIMEOUT 30)


### PR DESCRIPTION
…csumo specific ones

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
