### PR TITLE
Speed up big enclosure polygons using binning algorithm

### DIFF
--- a/.github/instructions/fortran.instructions.md
+++ b/.github/instructions/fortran.instructions.md
@@ -35,6 +35,13 @@ pain.
   discourage use of `implicit none` in functions and subroutines.
 - Modules should use `private` by default, exposing only what is needed with `public ::`.
 
+## Declarations
+
+- Declare array shapes with the `dimension` attribute before `::`, for dummy arguments,
+  local variables, derived-type components, allocatables, pointers, and fixed-size arrays.
+  For example, use `real(kind=dp), dimension(:), intent(in) :: values` instead of
+  `real(kind=dp), intent(in) :: values(:)`.
+
 ## Documentation
 
 - Flag missing docstrings for *new* public functions, submodules, module variables, types,

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
@@ -39,10 +39,11 @@ contains
 
       use network_data, only: cellmask, nump1d2d
       use m_samples, only: ns, xs, ys
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
       use m_alloc, only: realloc
 
       integer :: i, k
+      type(t_polygon_set_cache) :: polygon_cache
 
       ! Allocate and initialize cellmask
       call realloc(cellmask, nump1d2d, keepexisting=.false., fill=0)
@@ -54,21 +55,18 @@ contains
 
       ! Initialize the spatial index for all netcells
       ! This builds bounding boxes and polygon data structures for fast point-in-polygon tests
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       ! Loop over samples (much fewer than cells)
       !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(k)
       do i = 1, ns
-         k = point_find_netcell(xs(i), ys(i))
+         k = polygon_cache%find_netcell(xs(i), ys(i))
          if (k > 0) then
             cellmask(k) = 1 ! Safe without ATOMIC - all threads write same value
          end if
       end do
       !$OMP END PARALLEL DO
-
-      ! Cleanup spatial index
-      call cleanup_cell_geom_polylines()
 
       return
    end subroutine samples_to_cellmask

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
@@ -39,11 +39,11 @@ contains
 
       use network_data, only: cellmask, nump1d2d
       use m_samples, only: ns, xs, ys
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
       use m_alloc, only: realloc
 
       integer :: i, k
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       ! Allocate and initialize cellmask
       call realloc(cellmask, nump1d2d, keepexisting=.false., fill=0)
@@ -55,7 +55,7 @@ contains
 
       ! Initialize the spatial index for all netcells
       ! This builds bounding boxes and polygon data structures for fast point-in-polygon tests
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       ! Loop over samples (much fewer than cells)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
@@ -43,7 +43,7 @@ contains
       use m_alloc, only: realloc
 
       integer :: i, k
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       ! Allocate and initialize cellmask
       call realloc(cellmask, nump1d2d, keepexisting=.false., fill=0)
@@ -55,13 +55,13 @@ contains
 
       ! Initialize the spatial index for all netcells
       ! This builds bounding boxes and polygon data structures for fast point-in-polygon tests
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       ! Loop over samples (much fewer than cells)
       !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(k)
       do i = 1, ns
-         k = polygon_cache%find_netcell(xs(i), ys(i))
+         k = netcell_cache%find_netcell(xs(i), ys(i))
          if (k > 0) then
             cellmask(k) = 1 ! Safe without ATOMIC - all threads write same value
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_gui/m_samples_to_cellmask.f90
@@ -39,11 +39,11 @@ contains
 
       use network_data, only: cellmask, nump1d2d
       use m_samples, only: ns, xs, ys
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
       use m_alloc, only: realloc
 
       integer :: i, k
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       ! Allocate and initialize cellmask
       call realloc(cellmask, nump1d2d, keepexisting=.false., fill=0)
@@ -55,7 +55,7 @@ contains
 
       ! Initialize the spatial index for all netcells
       ! This builds bounding boxes and polygon data structures for fast point-in-polygon tests
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       ! Loop over samples (much fewer than cells)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_drypoints_from_netgeom.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/delete_drypoints_from_netgeom.f90
@@ -161,7 +161,9 @@ contains
                   ! if you know why this is the case it would be nice to change the behaviour so that cellmask only has nump entries
                   ! and get rid of local_cell_mask
                   call realloc(cellmask, nump1d2d, keepexisting=.false., fill=0)
-                  local_cell_mask = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw) ! third column in pol-file may be used to specify inside (1), or outside (0) mode, only 0 or 1 allowed.
+                  ! Enclosures cover most of the model, so bounding-box rejection cannot avoid their expensive polygon scans.
+                  local_cell_mask = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw, &
+                                                    enable_binning=jinside == -1)
                   cellmask(1:nump) = local_cell_mask(1:nump)
                   call delpol()
                   call restorepol()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
@@ -50,7 +50,7 @@ contains
 !>    it is assumed that kc has been allocated
 !>    it is assumed that findcells has already been called (for 2d cells)
    subroutine find1dcells()
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
 
       implicit none
 
@@ -60,12 +60,12 @@ contains
       logical :: Lisnew
       integer :: ierror
       integer :: nump1d
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       ierror = 1
 
       allocate (left_2D_cells(NUML1D), right_2D_cells(NUML1D))
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do L = 1, NUML1D

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
@@ -50,7 +50,7 @@ contains
 !>    it is assumed that kc has been allocated
 !>    it is assumed that findcells has already been called (for 2d cells)
    subroutine find1dcells()
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
 
       implicit none
 
@@ -60,22 +60,21 @@ contains
       logical :: Lisnew
       integer :: ierror
       integer :: nump1d
+      type(t_polygon_set_cache) :: polygon_cache
 
       ierror = 1
 
       allocate (left_2D_cells(NUML1D), right_2D_cells(NUML1D))
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do L = 1, NUML1D
          if (KN(1, L) /= 0 .and. kn(3, L) /= LINK_1D .and. kn(3, L) /= LINK_1D_MAINBRANCH) then
-            left_2D_cells(L) = point_find_netcell(Xk(KN(1, L)), Yk(KN(1, L)))
-            right_2D_cells(L) = point_find_netcell(Xk(KN(2, L)), Yk(KN(2, L)))
+            left_2D_cells(L) = polygon_cache%find_netcell(Xk(KN(1, L)), Yk(KN(1, L)))
+            right_2D_cells(L) = polygon_cache%find_netcell(Xk(KN(2, L)), Yk(KN(2, L)))
          end if
       end do
       !$OMP END PARALLEL DO
-      call cleanup_cell_geom_polylines()
-
 !     BEGIN COPY from flow_geominit
       KC = 2 ! ONDERSCHEID 1d EN 2d NETNODES
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
@@ -60,18 +60,18 @@ contains
       logical :: Lisnew
       integer :: ierror
       integer :: nump1d
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       ierror = 1
 
       allocate (left_2D_cells(NUML1D), right_2D_cells(NUML1D))
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do L = 1, NUML1D
          if (KN(1, L) /= 0 .and. kn(3, L) /= LINK_1D .and. kn(3, L) /= LINK_1D_MAINBRANCH) then
-            left_2D_cells(L) = polygon_cache%find_netcell(Xk(KN(1, L)), Yk(KN(1, L)))
-            right_2D_cells(L) = polygon_cache%find_netcell(Xk(KN(2, L)), Yk(KN(2, L)))
+            left_2D_cells(L) = netcell_cache%find_netcell(Xk(KN(1, L)), Yk(KN(1, L)))
+            right_2D_cells(L) = netcell_cache%find_netcell(Xk(KN(2, L)), Yk(KN(2, L)))
          end if
       end do
       !$OMP END PARALLEL DO

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/find1dcells.f90
@@ -50,7 +50,7 @@ contains
 !>    it is assumed that kc has been allocated
 !>    it is assumed that findcells has already been called (for 2d cells)
    subroutine find1dcells()
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
 
       implicit none
 
@@ -60,12 +60,12 @@ contains
       logical :: Lisnew
       integer :: ierror
       integer :: nump1d
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       ierror = 1
 
       allocate (left_2D_cells(NUML1D), right_2D_cells(NUML1D))
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do L = 1, NUML1D

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -28,6 +28,7 @@
 !-------------------------------------------------------------------------------
 
 module m_cellmask_from_polygon_set
+   use iso_fortran_env, only: int64
    use m_missing, only: jins, dmiss
    use precision, only: dp
 
@@ -49,19 +50,30 @@ module m_cellmask_from_polygon_set
    real(kind=dp), allocatable :: x_poly_max(:), y_poly_max(:) !< Polygon bounding box max coordinates, (dim = polygons)
    real(kind=dp), allocatable :: polygon_type(:) !< Polygon type, positive or dmiss = drypoint , negative = enclosure (dim = polygons)
    integer, allocatable :: i_poly_start(:), i_poly_end(:) !< Polygon start and end indices in coordinate arrays (dim = polygons)
+   logical, allocatable :: edge_index_enabled(:) !< Whether each polygon uses the binned edge index.
+   integer, allocatable :: i_poly_bin_start(:), i_poly_num_bins(:) !< Start and number of bins for each polygon.
+   integer, allocatable :: edge_bin_offsets(:), edge_indices(:) !< CSR offsets and ordered local edge indices.
+   real(kind=dp), allocatable :: y_poly_bin_scale(:) !< Scale from polygon y-coordinate to bin index.
    logical :: cellmask_initialized = .false. !< Flag indicating if cellmask data structures have been initialized for safety
    logical :: enclosures_present = .false. !< Flag indicating if any enclosures are present in the polygon dataset
+
+   integer, parameter :: min_edges_for_index = 256 !< Small polygons are cheaper to scan directly.
+   integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
+   integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
+   real(kind=dp), parameter :: min_predicted_speedup = 2.0_dp !< Required estimated improvement before indexing.
 
 contains
 
    !> Initialize module-level cellmask polygon data structures, such as the bounding boxes, cache and iistart/iiend
    ! this keeps the actual calculation routines elemental.
-   subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly)
+   subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, num_query_points, x_query, y_query)
       use m_alloc
       use geometry_module, only: get_startend
 
       integer, intent(in) :: polygon_points !< Number of polygon points
       real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinate arrays
+      integer, intent(in), optional :: num_query_points !< Number of points that will be classified.
+      real(kind=dp), intent(in), optional :: x_query(:), y_query(:) !< Points that will be classified, used to estimate index benefit.
 
       integer :: i_point, i_start, i_end, i_poly
 
@@ -122,6 +134,10 @@ contains
       call realloc(i_poly_start, polygons, keepExisting=.true.)
       call realloc(i_poly_end, polygons, keepExisting=.true.)
       call realloc(polygon_type, polygons, keepExisting=.true.)
+
+      if (present(num_query_points) .and. present(x_query) .and. present(y_query)) then
+         call init_polygon_edge_index(num_query_points, x_query, y_query)
+      end if
 
       ! check if there are any enclosure polygons
       do i_poly = 1, polygons
@@ -220,6 +236,24 @@ contains
       if (allocated(i_poly_end)) then
          deallocate (i_poly_end)
       end if
+      if (allocated(edge_index_enabled)) then
+         deallocate (edge_index_enabled)
+      end if
+      if (allocated(i_poly_bin_start)) then
+         deallocate (i_poly_bin_start)
+      end if
+      if (allocated(i_poly_num_bins)) then
+         deallocate (i_poly_num_bins)
+      end if
+      if (allocated(edge_bin_offsets)) then
+         deallocate (edge_bin_offsets)
+      end if
+      if (allocated(edge_indices)) then
+         deallocate (edge_indices)
+      end if
+      if (allocated(y_poly_bin_scale)) then
+         deallocate (y_poly_bin_scale)
+      end if
 
       polygons = 0
       cellmask_initialized = .false.
@@ -235,17 +269,199 @@ contains
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
 
-      integer :: i_start, i_end, n_points
+      integer :: i_bin, i_start, i_end, n_points
+      logical :: use_edge_index
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
-      ! Call the shared optimized algorithm with array slice
-      is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points)
+      use_edge_index = .false.
+      if (allocated(edge_index_enabled)) then
+         use_edge_index = edge_index_enabled(i_poly)
+      end if
+
+      if (use_edge_index) then
+         i_bin = i_poly_bin_start(i_poly) + get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly)) - 1
+         is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
+                                   edge_indices(edge_bin_offsets(i_bin):edge_bin_offsets(i_bin + 1) - 1))
+      else
+         is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points)
+      end if
 
    end function pinpok_elemental
+
+   !> Build latitude-bin edge indices only where the observed query distribution predicts a worthwhile reduction.
+   subroutine init_polygon_edge_index(num_query_points, x_query, y_query)
+      integer, intent(in) :: num_query_points !< Number of points that will be classified.
+      real(kind=dp), intent(in) :: x_query(:), y_query(:) !< Points that will be classified.
+
+      integer :: bin_edge_counts(max_edge_bins), bin_query_counts(max_edge_bins), bin_write_positions(max_edge_bins)
+      integer :: bins, edge, edge_end, edge_start, i_bin, i_poly, point
+      integer :: total_bins, write_position
+      integer(kind=int64) :: memberships, total_memberships
+      real(kind=dp) :: candidate_work, direct_work, indexed_work
+
+      allocate (edge_index_enabled(polygons), i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
+      edge_index_enabled = .false.
+      i_poly_bin_start = 0
+      i_poly_num_bins = 0
+      y_poly_bin_scale = 0.0_dp
+
+      total_bins = 0
+      total_memberships = 0_int64
+
+      do i_poly = 1, polygons
+         edge_start = i_poly_start(i_poly)
+         edge_end = i_poly_end(i_poly)
+         edge = edge_end - edge_start + 1
+         if (edge < min_edges_for_index .or. y_poly_max(i_poly) <= y_poly_min(i_poly)) then
+            cycle
+         end if
+
+         bins = min(max_edge_bins, max(16, edge / 4))
+         y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
+
+         memberships = count_edge_memberships(i_poly, bins)
+         if (memberships > max_memberships_per_edge * int(edge, int64)) then
+            cycle
+         end if
+
+         call count_edges_per_bin(i_poly, bins, bin_edge_counts)
+         bin_query_counts(1:bins) = 0
+         do point = 1, min(num_query_points, size(x_query), size(y_query))
+            if (x_query(point) < x_poly_min(i_poly) .or. x_query(point) > x_poly_max(i_poly) .or. &
+                y_query(point) < y_poly_min(i_poly) .or. y_query(point) > y_poly_max(i_poly)) then
+               cycle
+            end if
+            i_bin = get_edge_bin(y_query(point), y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
+            bin_query_counts(i_bin) = bin_query_counts(i_bin) + 1
+         end do
+
+         direct_work = real(sum(bin_query_counts(1:bins)), dp) * real(edge, dp)
+         candidate_work = 0.0_dp
+         do i_bin = 1, bins
+            candidate_work = candidate_work + real(bin_query_counts(i_bin), dp) * real(bin_edge_counts(i_bin), dp)
+         end do
+         indexed_work = real(edge + sum(bin_query_counts(1:bins)), dp) + 2.0_dp * real(memberships, dp) + candidate_work
+
+         if (direct_work < min_predicted_speedup * indexed_work) then
+            cycle
+         end if
+
+         edge_index_enabled(i_poly) = .true.
+         i_poly_num_bins(i_poly) = bins
+         total_bins = total_bins + bins
+         total_memberships = total_memberships + memberships
+      end do
+
+      if (total_bins == 0) then
+         deallocate (edge_index_enabled, i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
+         return
+      end if
+
+      allocate (edge_bin_offsets(total_bins + 1), edge_indices(int(total_memberships)))
+      i_bin = 1
+      write_position = 1
+      do i_poly = 1, polygons
+         if (.not. edge_index_enabled(i_poly)) then
+            cycle
+         end if
+         bins = i_poly_num_bins(i_poly)
+         call count_edges_per_bin(i_poly, bins, bin_edge_counts)
+         i_poly_bin_start(i_poly) = i_bin
+         do edge = 1, bins
+            edge_bin_offsets(i_bin) = write_position
+            write_position = write_position + bin_edge_counts(edge)
+            i_bin = i_bin + 1
+         end do
+      end do
+      edge_bin_offsets(total_bins + 1) = write_position
+
+      do i_poly = 1, polygons
+         if (.not. edge_index_enabled(i_poly)) then
+            cycle
+         end if
+         bins = i_poly_num_bins(i_poly)
+         do i_bin = 1, bins
+            bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
+         end do
+
+         edge_start = i_poly_start(i_poly)
+         edge_end = i_poly_end(i_poly)
+         do edge = 1, edge_end - edge_start + 1
+            call edge_bin_range(i_poly, edge, bins, bin_edge_counts(1), bin_edge_counts(2))
+            do i_bin = bin_edge_counts(1), bin_edge_counts(2)
+               edge_indices(bin_write_positions(i_bin)) = edge
+               bin_write_positions(i_bin) = bin_write_positions(i_bin) + 1
+            end do
+         end do
+      end do
+
+   end subroutine init_polygon_edge_index
+
+   !> Count the storage needed by a polygon edge index without allocating or iterating over memberships.
+   function count_edge_memberships(i_poly, bins) result(memberships)
+      integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
+      integer(kind=int64) :: memberships !< Total edge-to-bin memberships.
+
+      integer :: bin_first, bin_last, edge, num_edges
+
+      memberships = 0_int64
+      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      do edge = 1, num_edges
+         call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         memberships = memberships + int(bin_last - bin_first + 1, int64)
+         if (memberships > max_memberships_per_edge * int(num_edges, int64)) then
+            return
+         end if
+      end do
+   end function count_edge_memberships
+
+   !> Count candidate edges in each latitude bin for one polygon.
+   subroutine count_edges_per_bin(i_poly, bins, bin_counts)
+      integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
+      integer, intent(out) :: bin_counts(:) !< Edge count per bin.
+
+      integer :: bin_first, bin_last, edge, i_bin, num_edges
+
+      bin_counts(1:bins) = 0
+      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      do edge = 1, num_edges
+         call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         do i_bin = bin_first, bin_last
+            bin_counts(i_bin) = bin_counts(i_bin) + 1
+         end do
+      end do
+   end subroutine count_edges_per_bin
+
+   !> Get the inclusive bin range intersected by an edge.
+   pure subroutine edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+      integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
+      integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
+
+      integer :: current_point, previous_point
+
+      current_point = i_poly_start(i_poly) + edge - 1
+      previous_point = current_point - 1
+      if (edge == 1) then
+         previous_point = i_poly_end(i_poly)
+      end if
+      bin_first = get_edge_bin(min(ypl_cache(previous_point), ypl_cache(current_point)), y_poly_min(i_poly), &
+                               y_poly_bin_scale(i_poly), bins)
+      bin_last = get_edge_bin(max(ypl_cache(previous_point), ypl_cache(current_point)), y_poly_min(i_poly), &
+                              y_poly_bin_scale(i_poly), bins)
+   end subroutine edge_bin_range
+
+   !> Map a y-coordinate to a clamped one-based latitude bin.
+   pure integer function get_edge_bin(y, y_min, bin_scale, bins) result(i_bin)
+      real(kind=dp), intent(in) :: y, y_min, bin_scale !< Coordinate, polygon minimum and bin scale.
+      integer, intent(in) :: bins !< Number of bins.
+
+      i_bin = int((y - y_min) * bin_scale) + 1
+      i_bin = max(1, min(bins, i_bin))
+   end function get_edge_bin
 
    !> Manually init geometry cache (used for dry points, test_pol_to_cellmask)
    subroutine init_geom_cache(npl_init, xpl_init, ypl_init, zpl_init)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -79,7 +79,7 @@ module m_cellmask_from_polygon_set
       type(t_polygon_geometry) :: geometry
       type(t_binned_edge_index) :: edge_index
    contains
-      procedure :: point_mask => polygon_set_point_mask
+      procedure :: is_masked => polygon_set_is_masked
       procedure :: polygon_contains_point => polygon_set_polygon_contains_point
       procedure :: find_netcell => polygon_set_find_netcell
       procedure :: find_cells_crossed_by_polyline => polygon_set_find_cells_crossed_by_polyline
@@ -205,7 +205,7 @@ contains
    end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
-   elemental function polygon_set_point_mask(this, x, y) result(mask)
+   elemental function polygon_set_is_masked(this, x, y) result(mask)
       class(t_polygon_set), intent(in) :: this
       integer :: mask
       real(kind=dp), intent(in) :: x, y !< Point coordinates
@@ -256,7 +256,7 @@ contains
          end if
       end associate
 
-   end function polygon_set_point_mask
+   end function polygon_set_is_masked
 
    !> Test whether a point lies inside one cached polygon.
    elemental function polygon_set_polygon_contains_point(this, x, y, i_poly) result(is_inside)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -87,7 +87,7 @@ module m_cellmask_from_polygon_set
 
    interface t_polygon_set
       module procedure construct_polygon_set
-      module procedure construct_netcell_polygon_cache
+      module procedure construct_netcell_polygon_set
    end interface t_polygon_set
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
@@ -452,7 +452,7 @@ contains
    end function binned_edge_index_get_bin
 
    !> Construct a polygon cache containing all net-cell geometries.
-   function construct_netcell_polygon_cache() result(cache)
+   function construct_netcell_polygon_set() result(cache)
       use network_data
       use m_alloc
 
@@ -492,7 +492,7 @@ contains
 
       cache = t_polygon_set(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
-   end function construct_netcell_polygon_cache
+   end function construct_netcell_polygon_set
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
    elemental function polygon_set_find_netcell(this, x, y) result(k)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -50,7 +50,7 @@ module m_cellmask_from_polygon_set
    real(kind=dp), allocatable :: x_poly_max(:), y_poly_max(:) !< Polygon bounding box max coordinates, (dim = polygons)
    real(kind=dp), allocatable :: polygon_type(:) !< Polygon type, positive or dmiss = drypoint , negative = enclosure (dim = polygons)
    integer, allocatable :: i_poly_start(:), i_poly_end(:) !< Polygon start and end indices in coordinate arrays (dim = polygons)
-   logical, allocatable :: edge_index_enabled(:) !< Whether each polygon uses the binned edge index.
+   logical, allocatable :: polygon_uses_binned_edges(:) !< Whether each polygon uses the binned edge index.
    integer, allocatable :: i_poly_bin_start(:), i_poly_num_bins(:) !< Start and number of bins for each polygon.
    integer, allocatable :: edge_bin_offsets(:), edge_indices(:) !< CSR offsets and ordered local edge indices.
    real(kind=dp), allocatable :: y_poly_bin_scale(:) !< Scale from polygon y-coordinate to bin index.
@@ -136,7 +136,7 @@ contains
       call realloc(polygon_type, polygons, keepExisting=.true.)
 
       if (present(num_query_points) .and. present(x_query) .and. present(y_query)) then
-         call init_polygon_edge_index(num_query_points, x_query, y_query)
+         call init_binned_polygon_edges(num_query_points, x_query, y_query)
       end if
 
       ! check if there are any enclosure polygons
@@ -236,8 +236,8 @@ contains
       if (allocated(i_poly_end)) then
          deallocate (i_poly_end)
       end if
-      if (allocated(edge_index_enabled)) then
-         deallocate (edge_index_enabled)
+      if (allocated(polygon_uses_binned_edges)) then
+         deallocate (polygon_uses_binned_edges)
       end if
       if (allocated(i_poly_bin_start)) then
          deallocate (i_poly_bin_start)
@@ -270,20 +270,21 @@ contains
       logical :: is_inside !< Result
 
       integer :: i_bin, i_start, i_end, n_points
-      logical :: use_edge_index
+      logical :: use_binned_edges
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
-      use_edge_index = .false.
-      if (allocated(edge_index_enabled)) then
-         use_edge_index = edge_index_enabled(i_poly)
+      use_binned_edges = .false.
+      if (allocated(polygon_uses_binned_edges)) then
+         use_binned_edges = polygon_uses_binned_edges(i_poly)
       end if
 
-      if (use_edge_index) then
-         i_bin = i_poly_bin_start(i_poly) + get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly)) - 1
+      if (use_binned_edges) then
+         i_bin = get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly))
+         i_bin = i_poly_bin_start(i_poly) + i_bin - 1
          is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
                                    edge_indices(edge_bin_offsets(i_bin):edge_bin_offsets(i_bin + 1) - 1))
       else
@@ -292,19 +293,20 @@ contains
 
    end function pinpok_elemental
 
-   !> Build latitude-bin edge indices only where the observed query distribution predicts a worthwhile reduction.
-   subroutine init_polygon_edge_index(num_query_points, x_query, y_query)
+   !> Select polygons that benefit from latitude bins and build their shared edge index.
+   !!
+   !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
+   !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
+   !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
+   subroutine init_binned_polygon_edges(num_query_points, x_query, y_query)
       integer, intent(in) :: num_query_points !< Number of points that will be classified.
       real(kind=dp), intent(in) :: x_query(:), y_query(:) !< Points that will be classified.
 
-      integer :: bin_edge_counts(max_edge_bins), bin_query_counts(max_edge_bins), bin_write_positions(max_edge_bins)
-      integer :: bins, edge, edge_end, edge_start, i_bin, i_poly, point
-      integer :: total_bins, write_position
+      integer :: bins, i_poly, num_edges, total_bins
       integer(kind=int64) :: memberships, total_memberships
-      real(kind=dp) :: candidate_work, direct_work, indexed_work
 
-      allocate (edge_index_enabled(polygons), i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
-      edge_index_enabled = .false.
+      allocate (polygon_uses_binned_edges(polygons), i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
+      polygon_uses_binned_edges = .false.
       i_poly_bin_start = 0
       i_poly_num_bins = 0
       y_poly_bin_scale = 0.0_dp
@@ -313,74 +315,108 @@ contains
       total_memberships = 0_int64
 
       do i_poly = 1, polygons
-         edge_start = i_poly_start(i_poly)
-         edge_end = i_poly_end(i_poly)
-         edge = edge_end - edge_start + 1
-         if (edge < min_edges_for_index .or. y_poly_max(i_poly) <= y_poly_min(i_poly)) then
+         num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+         if (num_edges < min_edges_for_index .or. y_poly_max(i_poly) <= y_poly_min(i_poly)) then
             cycle
          end if
 
-         bins = min(max_edge_bins, max(16, edge / 4))
-         y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
-
-         memberships = count_edge_memberships(i_poly, bins)
-         if (memberships > max_memberships_per_edge * int(edge, int64)) then
+         bins = min(max_edge_bins, max(16, num_edges / 4))
+         if (.not. polygon_binning_is_worthwhile(i_poly, bins, num_query_points, x_query, y_query, memberships)) then
             cycle
          end if
 
-         call count_edges_per_bin(i_poly, bins, bin_edge_counts)
-         bin_query_counts(1:bins) = 0
-         do point = 1, min(num_query_points, size(x_query), size(y_query))
-            if (x_query(point) < x_poly_min(i_poly) .or. x_query(point) > x_poly_max(i_poly) .or. &
-                y_query(point) < y_poly_min(i_poly) .or. y_query(point) > y_poly_max(i_poly)) then
-               cycle
-            end if
-            i_bin = get_edge_bin(y_query(point), y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
-            bin_query_counts(i_bin) = bin_query_counts(i_bin) + 1
-         end do
-
-         direct_work = real(sum(bin_query_counts(1:bins)), dp) * real(edge, dp)
-         candidate_work = 0.0_dp
-         do i_bin = 1, bins
-            candidate_work = candidate_work + real(bin_query_counts(i_bin), dp) * real(bin_edge_counts(i_bin), dp)
-         end do
-         indexed_work = real(edge + sum(bin_query_counts(1:bins)), dp) + 2.0_dp * real(memberships, dp) + candidate_work
-
-         if (direct_work < min_predicted_speedup * indexed_work) then
-            cycle
-         end if
-
-         edge_index_enabled(i_poly) = .true.
+         polygon_uses_binned_edges(i_poly) = .true.
          i_poly_num_bins(i_poly) = bins
          total_bins = total_bins + bins
          total_memberships = total_memberships + memberships
       end do
 
       if (total_bins == 0) then
-         deallocate (edge_index_enabled, i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
+         deallocate (polygon_uses_binned_edges, i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
          return
       end if
 
+      call build_binned_edge_index(total_bins, total_memberships)
+
+   end subroutine init_binned_polygon_edges
+
+   !> Decide whether indexing one polygon will repay its construction cost for the supplied queries.
+   function polygon_binning_is_worthwhile(i_poly, bins, num_query_points, x_query, y_query, memberships) result(is_worthwhile)
+      integer, intent(in) :: i_poly, bins, num_query_points !< Polygon, proposed bin count and number of queries.
+      real(kind=dp), intent(in) :: x_query(:), y_query(:) !< Points that will be classified.
+      integer(kind=int64), intent(out) :: memberships !< Number of edge entries needed by the proposed index.
+      logical :: is_worthwhile
+
+      integer :: bin_edge_counts(max_edge_bins), bin_query_counts(max_edge_bins)
+      integer :: i_bin, num_edges, num_relevant_queries, point
+      real(kind=dp) :: candidate_work, direct_work, indexed_work
+
+      is_worthwhile = .false.
+      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
+
+      ! Long, near-vertical edges can occur in many bins. Reject such an index before allocating it.
+      memberships = count_edge_memberships(i_poly, bins)
+      if (memberships > max_memberships_per_edge * int(num_edges, int64)) then
+         return
+      end if
+
+      call count_edges_per_bin(i_poly, bins, bin_edge_counts)
+      bin_query_counts(1:bins) = 0
+      do point = 1, min(num_query_points, size(x_query), size(y_query))
+         if (x_query(point) < x_poly_min(i_poly) .or. x_query(point) > x_poly_max(i_poly) .or. &
+             y_query(point) < y_poly_min(i_poly) .or. y_query(point) > y_poly_max(i_poly)) then
+            cycle
+         end if
+         i_bin = get_edge_bin(y_query(point), y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
+         bin_query_counts(i_bin) = bin_query_counts(i_bin) + 1
+      end do
+
+      num_relevant_queries = sum(bin_query_counts(1:bins))
+      direct_work = real(num_relevant_queries, dp) * real(num_edges, dp)
+      candidate_work = 0.0_dp
+      do i_bin = 1, bins
+         candidate_work = candidate_work + real(bin_query_counts(i_bin), dp) * real(bin_edge_counts(i_bin), dp)
+      end do
+
+      ! Indexed work includes assessment, two membership passes, query lookup and the remaining ray-cast edges.
+      indexed_work = real(num_edges + num_relevant_queries, dp) + 2.0_dp * real(memberships, dp) + candidate_work
+      is_worthwhile = direct_work >= min_predicted_speedup * indexed_work
+
+   end function polygon_binning_is_worthwhile
+
+   !> Allocate and populate the shared compressed-row storage for all selected polygons.
+   subroutine build_binned_edge_index(total_bins, total_memberships)
+      integer, intent(in) :: total_bins !< Total number of bins over selected polygons.
+      integer(kind=int64), intent(in) :: total_memberships !< Total edge entries over selected polygons.
+
+      integer :: bin_edge_counts(max_edge_bins), bin_write_positions(max_edge_bins)
+      integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
+      integer :: next_bin, next_edge_entry
+
+      ! edge_bin_offsets/edge_indices use compressed-row storage: each bin owns one contiguous slice.
       allocate (edge_bin_offsets(total_bins + 1), edge_indices(int(total_memberships)))
-      i_bin = 1
-      write_position = 1
+      next_bin = 1
+      next_edge_entry = 1
       do i_poly = 1, polygons
-         if (.not. edge_index_enabled(i_poly)) then
+         if (.not. polygon_uses_binned_edges(i_poly)) then
             cycle
          end if
          bins = i_poly_num_bins(i_poly)
          call count_edges_per_bin(i_poly, bins, bin_edge_counts)
-         i_poly_bin_start(i_poly) = i_bin
-         do edge = 1, bins
-            edge_bin_offsets(i_bin) = write_position
-            write_position = write_position + bin_edge_counts(edge)
-            i_bin = i_bin + 1
+         i_poly_bin_start(i_poly) = next_bin
+         do i_bin = 1, bins
+            edge_bin_offsets(next_bin) = next_edge_entry
+            next_edge_entry = next_edge_entry + bin_edge_counts(i_bin)
+            next_bin = next_bin + 1
          end do
       end do
-      edge_bin_offsets(total_bins + 1) = write_position
+      edge_bin_offsets(total_bins + 1) = next_edge_entry
 
+      ! Insert local edge numbers in polygon order. The indexed ray cast therefore sums crossings
+      ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
       do i_poly = 1, polygons
-         if (.not. edge_index_enabled(i_poly)) then
+         if (.not. polygon_uses_binned_edges(i_poly)) then
             cycle
          end if
          bins = i_poly_num_bins(i_poly)
@@ -388,18 +424,17 @@ contains
             bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
          end do
 
-         edge_start = i_poly_start(i_poly)
-         edge_end = i_poly_end(i_poly)
-         do edge = 1, edge_end - edge_start + 1
-            call edge_bin_range(i_poly, edge, bins, bin_edge_counts(1), bin_edge_counts(2))
-            do i_bin = bin_edge_counts(1), bin_edge_counts(2)
+         num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+         do edge = 1, num_edges
+            call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+            do i_bin = bin_first, bin_last
                edge_indices(bin_write_positions(i_bin)) = edge
                bin_write_positions(i_bin) = bin_write_positions(i_bin) + 1
             end do
          end do
       end do
 
-   end subroutine init_polygon_edge_index
+   end subroutine build_binned_edge_index
 
    !> Count the storage needed by a polygon edge index without allocating or iterating over memberships.
    function count_edge_memberships(i_poly, bins) result(memberships)
@@ -437,6 +472,9 @@ contains
    end subroutine count_edges_per_bin
 
    !> Get the inclusive bin range intersected by an edge.
+   !! Both edge endpoints and queries use get_edge_bin, so equal y-coordinates always map to the same
+   !! bin. Filling every bin from the lower endpoint through the upper endpoint preserves all edges
+   !! that the full ray cast could inspect at a query's y-coordinate.
    pure subroutine edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
       integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -36,7 +36,7 @@ module m_cellmask_from_polygon_set
 
    private
 
-   public :: t_polygon_set
+   public :: t_netcell_set, t_polygon_set
 
    !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
    type, private :: t_polygon_geometry
@@ -80,15 +80,25 @@ module m_cellmask_from_polygon_set
       type(t_binned_edge_index) :: edge_index
    contains
       procedure :: is_masked => polygon_set_is_masked
-      procedure :: polygon_contains_point => polygon_set_polygon_contains_point
-      procedure :: find_netcell => polygon_set_find_netcell
-      procedure :: find_cells_crossed_by_polyline => polygon_set_find_cells_crossed_by_polyline
+      procedure, private :: polygon_contains_point => polygon_set_polygon_contains_point
    end type t_polygon_set
 
    interface t_polygon_set
       module procedure construct_polygon_set
-      module procedure construct_netcell_polygon_set
    end interface t_polygon_set
+
+   !> Net-cell polygons and operations that rely on polygon indices matching net-cell indices.
+   type :: t_netcell_set
+      private
+      type(t_polygon_set) :: polygons
+   contains
+      procedure :: find_netcell => netcell_set_find_netcell
+      procedure :: find_cells_crossed_by_polyline => netcell_set_find_cells_crossed_by_polyline
+   end type t_netcell_set
+
+   interface t_netcell_set
+      module procedure construct_netcell_set
+   end interface t_netcell_set
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
@@ -280,7 +290,6 @@ contains
    end function polygon_set_polygon_contains_point
 
    !> Build a latitude-binned edge index for the complete polygon set.
-
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
@@ -447,11 +456,11 @@ contains
    end function binned_edge_index_get_bin
 
    !> Construct a polygon cache containing all net-cell geometries.
-   function construct_netcell_polygon_set() result(cache)
+   function construct_netcell_set() result(netcells)
       use network_data
       use m_alloc
 
-      type(t_polygon_set) :: cache
+      type(t_netcell_set) :: netcells
       integer :: k, n, k1, total_points, ipoint
       real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init
 
@@ -485,14 +494,14 @@ contains
          zpl_init(ipoint) = dmiss
       end do
 
-      cache = t_polygon_set(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
+      netcells%polygons = t_polygon_set(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
-   end function construct_netcell_polygon_set
+   end function construct_netcell_set
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
-   elemental function polygon_set_find_netcell(this, x, y) result(k)
+   elemental function netcell_set_find_netcell(this, x, y) result(k)
 
-      class(t_polygon_set), intent(in) :: this
+      class(t_netcell_set), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
@@ -501,7 +510,7 @@ contains
 
       k = 0
 
-      associate (geometry => this%geometry)
+      associate (geometry => this%polygons%geometry)
          ! Loop over all netcell polygons with fast bounding box checks
          do i_poly = 1, geometry%polygon_count
 
@@ -512,7 +521,7 @@ contains
             end if
 
             ! Detailed point-in-polygon check
-            is_inside = this%polygon_contains_point(x, y, i_poly)
+            is_inside = this%polygons%polygon_contains_point(x, y, i_poly)
 
             if (is_inside) then
                ! cell index equals polygon index
@@ -522,17 +531,17 @@ contains
          end do
       end associate
 
-   end function polygon_set_find_netcell
+   end function netcell_set_find_netcell
 
 !> Find all cells crossed by polyline using brute force on cached geometry. The routine is inclusive of edge cases (touching edges or vertices).
-   subroutine polygon_set_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
+   subroutine netcell_set_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
       use m_alloc, only: realloc
       use network_data, only: nump
       use m_missing, only: dmiss
 
       implicit none
 
-      class(t_polygon_set), intent(in) :: this
+      class(t_netcell_set), intent(in) :: this
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
       integer, dimension(:), allocatable, intent(out) :: crossed_cells !> Indices of crossed cells in network_data::netcells
@@ -553,7 +562,7 @@ contains
 
       ! Process each segment and put the result in cellmask
       do i = 1, npoly - 1
-         call find_cells_for_segment(this, xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
+         call find_cells_for_segment(this%polygons, xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
       end do
 
       crossed_cells = pack([(i, i=1, nump)], mask=(cellmask == 1))
@@ -564,7 +573,7 @@ contains
          end if
       end if
 
-   end subroutine polygon_set_find_cells_crossed_by_polyline
+   end subroutine netcell_set_find_cells_crossed_by_polyline
 
 !> Find all cells that a segment crosses and mark them in cellmask
    subroutine find_cells_for_segment(cache, xa, ya, xb, yb, cellmask)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -264,13 +264,19 @@ contains
       logical :: is_inside !< Result
 
       integer :: i_bin, i_start, i_end, n_points
+      logical :: use_binned_edges
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
+      use_binned_edges = .false.
       if (allocated(edge_indices)) then
+         use_binned_edges = i_poly_num_bins(i_poly) > 1
+      end if
+
+      if (use_binned_edges) then
          i_bin = get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly))
          i_bin = i_poly_bin_start(i_poly) + i_bin - 1
          is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
@@ -287,41 +293,39 @@ contains
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
    subroutine init_binned_polygon_edges()
-      integer :: bins, i_poly, num_edges, total_bins, total_edges
+      integer :: bins, binned_edges, i_poly, num_edges, total_bins
       integer(kind=int64) :: memberships, total_memberships
 
-      total_edges = 0
-      do i_poly = 1, polygons
-         total_edges = total_edges + i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-      end do
-      if (total_edges < min_edges_for_binning) then
-         return
-      end if
-
       allocate (i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
+      binned_edges = 0
       total_bins = 0
       total_memberships = 0_int64
 
       do i_poly = 1, polygons
          num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-         if (y_poly_max(i_poly) > y_poly_min(i_poly)) then
+         if (num_edges >= min_edges_for_binning .and. y_poly_max(i_poly) > y_poly_min(i_poly)) then
             bins = min(max_edge_bins, max(1, num_edges / 4))
             y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
+            binned_edges = binned_edges + num_edges
          else
             bins = 1
             y_poly_bin_scale(i_poly) = 0.0_dp
          end if
          i_poly_num_bins(i_poly) = bins
+         if (bins == 1) then
+            cycle
+         end if
          total_bins = total_bins + bins
 
          memberships = count_edge_memberships(i_poly, bins)
          total_memberships = total_memberships + memberships
-         ! Reject before allocation if edges span too many bins across the polygon set.
-         if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
-            deallocate (i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
-            return
-         end if
       end do
+
+      ! Keep the direct scan if no individual polygon benefits, or if long edges make the index too large.
+      if (total_bins == 0 .or. total_memberships > max_memberships_per_edge * int(binned_edges, int64)) then
+         deallocate (i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
+         return
+      end if
 
       call build_binned_edge_index(total_bins, total_memberships)
 
@@ -342,6 +346,9 @@ contains
       next_edge_entry = 1
       do i_poly = 1, polygons
          bins = i_poly_num_bins(i_poly)
+         if (bins == 1) then
+            cycle
+         end if
          call count_edges_per_bin(i_poly, bins, bin_edge_counts)
          i_poly_bin_start(i_poly) = next_bin
          do i_bin = 1, bins
@@ -356,6 +363,9 @@ contains
       ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
       do i_poly = 1, polygons
          bins = i_poly_num_bins(i_poly)
+         if (bins == 1) then
+            cycle
+         end if
          do i_bin = 1, bins
             bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
          end do
@@ -413,16 +423,22 @@ contains
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
 
       integer :: current_point, previous_point
+      real(kind=dp) :: lower_tolerance, lower_y, upper_tolerance, upper_y
 
       current_point = i_poly_start(i_poly) + edge - 1
       previous_point = current_point - 1
       if (edge == 1) then
          previous_point = i_poly_end(i_poly)
       end if
-      bin_first = get_edge_bin(min(ypl_cache(previous_point), ypl_cache(current_point)), y_poly_min(i_poly), &
-                               y_poly_bin_scale(i_poly), bins)
-      bin_last = get_edge_bin(max(ypl_cache(previous_point), ypl_cache(current_point)), y_poly_min(i_poly), &
-                              y_poly_bin_scale(i_poly), bins)
+      lower_y = min(ypl_cache(previous_point), ypl_cache(current_point))
+      upper_y = max(ypl_cache(previous_point), ypl_cache(current_point))
+
+      ! pinpok_raycast treats y-coordinates within 2 epsilon as equal. Use a larger halo so an edge
+      ! remains a candidate when a near-equal query falls in the neighboring bin.
+      lower_tolerance = 4.0_dp * epsilon(lower_y) * max(abs(lower_y), 1.0_dp)
+      upper_tolerance = 4.0_dp * epsilon(upper_y) * max(abs(upper_y), 1.0_dp)
+      bin_first = get_edge_bin(lower_y - lower_tolerance, y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
+      bin_last = get_edge_bin(upper_y + upper_tolerance, y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
    end subroutine edge_bin_range
 
    !> Map a y-coordinate to a clamped one-based latitude bin.

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -194,15 +194,15 @@ contains
    end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
-   elemental function polygon_set_is_masked(this, x, y) result(is_masked)
-      class(t_polygon_set), intent(in) :: this
+   elemental function polygon_set_is_masked(self, x, y) result(is_masked)
+      class(t_polygon_set), intent(in) :: self
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       logical :: is_masked !< Whether the point should be masked.
 
       integer :: count_drypoint, i_poly
       logical :: found_inside_enclosure, is_inside
 
-      associate (geometry => this%geometry)
+      associate (geometry => self%geometry)
          count_drypoint = 0
          found_inside_enclosure = .false.
 
@@ -215,7 +215,7 @@ contains
             end if
 
             ! Point-in-polygon test
-            is_inside = this%polygon_contains_point(x, y, i_poly)
+            is_inside = self%polygon_contains_point(x, y, i_poly)
 
             if (is_inside) then
                if (geometry%is_enclosure(i_poly)) then
@@ -243,10 +243,10 @@ contains
    end function polygon_set_is_masked
 
    !> Test whether a point lies inside one cached polygon.
-   elemental function polygon_set_polygon_contains_point(this, x, y, i_poly) result(is_inside)
+   elemental function polygon_set_polygon_contains_point(self, x, y, i_poly) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
-      class(t_polygon_set), intent(in) :: this
+      class(t_polygon_set), intent(in) :: self
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
@@ -259,8 +259,8 @@ contains
          i_end = geometry%polygon_end(i_poly)
          n_points = i_end - i_start + 1
 
-         if (allocated(this%edge_index%edge_indices)) then
-            is_inside = this%edge_index%point_is_inside(x, y, i_poly, geometry)
+         if (allocated(self%edge_index%edge_indices)) then
+            is_inside = self%edge_index%point_is_inside(x, y, i_poly, geometry)
          else
             is_inside = pinpok_raycast(x, y, geometry%x(i_start:i_end), geometry%y(i_start:i_end), n_points)
          end if
@@ -317,8 +317,8 @@ contains
    !! First count the edge numbers in each bin and convert those counts into offsets in `edge_indices`.
    !! Then visit the polygon edges in polygon order and append each edge number to every bin crossed
    !! by its vertical range. Polygon order is preserved to maintain ray-casting boundary behavior.
-   subroutine binned_edge_index_populate_bin_storage(this, geometry, total_bins, total_memberships)
-      class(t_binned_edge_index), intent(inout) :: this
+   subroutine binned_edge_index_populate_bin_storage(self, geometry, total_bins, total_memberships)
+      class(t_binned_edge_index), intent(inout) :: self
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
       integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
@@ -328,34 +328,34 @@ contains
       integer :: next_bin, next_edge_entry
 
       ! Reserve one contiguous slice of edge_indices for every bin.
-      allocate (this%bin_offsets(total_bins + 1), this%edge_indices(int(total_memberships)))
+      allocate (self%bin_offsets(total_bins + 1), self%edge_indices(int(total_memberships)))
       next_bin = 1
       next_edge_entry = 1
       do i_poly = 1, geometry%polygon_count
-         bins = this%polygon_num_bins(i_poly)
-         call this%count_edges_per_bin(geometry, i_poly, bins, bin_edge_counts)
-         this%polygon_bin_start(i_poly) = next_bin
+         bins = self%polygon_num_bins(i_poly)
+         call self%count_edges_per_bin(geometry, i_poly, bins, bin_edge_counts)
+         self%polygon_bin_start(i_poly) = next_bin
          do i_bin = 1, bins
-            this%bin_offsets(next_bin) = next_edge_entry
+            self%bin_offsets(next_bin) = next_edge_entry
             next_edge_entry = next_edge_entry + bin_edge_counts(i_bin)
             next_bin = next_bin + 1
          end do
       end do
-      this%bin_offsets(total_bins + 1) = next_edge_entry
+      self%bin_offsets(total_bins + 1) = next_edge_entry
 
       ! Insert local edge numbers into their reserved bin slices in polygon order.
       do i_poly = 1, geometry%polygon_count
-         bins = this%polygon_num_bins(i_poly)
+         bins = self%polygon_num_bins(i_poly)
          do i_bin = 1, bins
             bin_write_positions(i_bin) = &
-               this%bin_offsets(this%polygon_bin_start(i_poly) + i_bin - 1)
+               self%bin_offsets(self%polygon_bin_start(i_poly) + i_bin - 1)
          end do
 
          num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
          do edge = 1, num_edges
-            call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
+            call self%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
             do i_bin = bin_first, bin_last
-               this%edge_indices(bin_write_positions(i_bin)) = edge
+               self%edge_indices(bin_write_positions(i_bin)) = edge
                bin_write_positions(i_bin) = bin_write_positions(i_bin) + 1
             end do
          end do
@@ -367,8 +367,8 @@ contains
    !! For each edge, find the first and last bin crossed by its vertical extent. Count every bin from
    !! the first through the last, including both, because the edge number is stored once in each of
    !! those bins. Sum these counts over all polygon edges.
-   function binned_edge_index_count_edge_memberships(this, geometry, i_poly, bins) result(memberships)
-      class(t_binned_edge_index), intent(in) :: this
+   function binned_edge_index_count_edge_memberships(self, geometry, i_poly, bins) result(memberships)
+      class(t_binned_edge_index), intent(in) :: self
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer(kind=int64) :: memberships !< Total edge-to-bin memberships.
@@ -378,7 +378,7 @@ contains
       memberships = 0_int64
       num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
+         call self%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
          memberships = memberships + int(bin_last - bin_first + 1, int64)
       end do
    end function binned_edge_index_count_edge_memberships
@@ -387,8 +387,8 @@ contains
    !! Initialize all bin counts to zero. For every edge, find its first and last bin and increment the
    !! count of each bin from the first through the last. These counts determine the CSR slice reserved
    !! for every bin.
-   subroutine binned_edge_index_count_edges_per_bin(this, geometry, i_poly, bins, bin_counts)
-      class(t_binned_edge_index), intent(in) :: this
+   subroutine binned_edge_index_count_edges_per_bin(self, geometry, i_poly, bins, bin_counts)
+      class(t_binned_edge_index), intent(in) :: self
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer, dimension(:), intent(out) :: bin_counts !< Edge count per bin.
@@ -398,7 +398,7 @@ contains
       bin_counts(1:bins) = 0
       num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
+         call self%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
          do i_bin = bin_first, bin_last
             bin_counts(i_bin) = bin_counts(i_bin) + 1
          end do
@@ -409,8 +409,8 @@ contains
    !! Obtain the edge endpoints from its polygon-local edge number, expand their minimum and maximum
    !! y-coordinates by a floating-point tolerance, and map both values to bin numbers. The tolerance
    !! includes an adjacent bin when a query and endpoint are numerically equal across a bin boundary.
-   pure subroutine binned_edge_index_edge_bin_range(this, geometry, i_poly, edge, bins, bin_first, bin_last)
-      class(t_binned_edge_index), intent(in) :: this
+   pure subroutine binned_edge_index_edge_bin_range(self, geometry, i_poly, edge, bins, bin_first, bin_last)
+      class(t_binned_edge_index), intent(in) :: self
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
@@ -430,8 +430,8 @@ contains
       ! remains a candidate when a near-equal query falls in the neighboring bin.
       lower_tolerance = 4.0_dp * epsilon(lower_y) * max(abs(lower_y), 1.0_dp)
       upper_tolerance = 4.0_dp * epsilon(upper_y) * max(abs(upper_y), 1.0_dp)
-      bin_first = this%get_bin(lower_y - lower_tolerance, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
-      bin_last = this%get_bin(upper_y + upper_tolerance, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
+      bin_first = self%get_bin(lower_y - lower_tolerance, geometry%y_min(i_poly), self%polygon_bin_scale(i_poly), bins)
+      bin_last = self%get_bin(upper_y + upper_tolerance, geometry%y_min(i_poly), self%polygon_bin_scale(i_poly), bins)
    end subroutine binned_edge_index_edge_bin_range
 
    !> Map a y-coordinate to a one-based bin within one polygon.
@@ -448,10 +448,10 @@ contains
    !> Classify a point using the polygon edges listed in its horizontal bin.
    !! Convert the point's y-coordinate to a polygon-local bin, translate that bin to its position in
    !! the shared CSR storage, and pass the corresponding ordered edge-number slice to `pinpok_raycast`.
-   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
+   pure function binned_edge_index_point_is_inside(self, x, y, i_poly, geometry) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
-      class(t_binned_edge_index), intent(in) :: this
+      class(t_binned_edge_index), intent(in) :: self
       real(kind=dp), intent(in) :: x, y !< Query coordinates.
       integer, intent(in) :: i_poly !< Polygon index in this index.
       type(t_polygon_geometry), intent(in) :: geometry !< Cached polygon coordinates and metadata.
@@ -463,14 +463,14 @@ contains
       last_point = geometry%polygon_end(i_poly)
       num_points = last_point - first_point + 1
 
-      local_bin = this%get_bin(y, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
-      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
+      local_bin = self%get_bin(y, geometry%y_min(i_poly), self%polygon_bin_scale(i_poly), self%polygon_num_bins(i_poly))
+      global_bin = self%polygon_bin_start(i_poly) + local_bin - 1
 
-      candidate_first = this%bin_offsets(global_bin)
-      candidate_last = this%bin_offsets(global_bin + 1) - 1
+      candidate_first = self%bin_offsets(global_bin)
+      candidate_last = self%bin_offsets(global_bin + 1) - 1
 
       is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
-                                 this%edge_indices(candidate_first:candidate_last))
+                                 self%edge_indices(candidate_first:candidate_last))
    end function binned_edge_index_point_is_inside
 
    !> Construct a polygon cache containing all net-cell geometries.
@@ -517,10 +517,10 @@ contains
    end function construct_netcell_set
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
-   elemental function netcell_set_find_netcell(this, x, y) result(k)
+   elemental function netcell_set_find_netcell(self, x, y) result(k)
    use geometry_module, only: pinpok_raycast
 
-      class(t_netcell_set), intent(in) :: this
+      class(t_netcell_set), intent(in) :: self
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
@@ -529,7 +529,7 @@ contains
 
       k = 0
 
-      associate (geometry => this%polygons%geometry)
+      associate (geometry => self%polygons%geometry)
          ! Loop over all netcell polygons with fast bounding box checks
          do i_poly = 1, geometry%polygon_count
 
@@ -557,14 +557,14 @@ contains
    end function netcell_set_find_netcell
 
 !> Find all cells crossed by polyline using brute force on cached geometry. The routine is inclusive of edge cases (touching edges or vertices).
-   subroutine netcell_set_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
+   subroutine netcell_set_find_cells_crossed_by_polyline(self, xpoly, ypoly, crossed_cells, error)
       use m_alloc, only: realloc
       use network_data, only: nump
       use m_missing, only: dmiss
 
       implicit none
 
-      class(t_netcell_set), intent(in) :: this
+      class(t_netcell_set), intent(in) :: self
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
       integer, dimension(:), allocatable, intent(out) :: crossed_cells !> Indices of crossed cells in network_data::netcells
@@ -585,12 +585,12 @@ contains
 
       ! Process each segment and put the result in cellmask
       do i = 1, npoly - 1
-         call find_cells_for_segment(this%polygons, xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
+         call find_cells_for_segment(self%polygons, xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
       end do
 
       crossed_cells = pack([(i, i=1, nump)], mask=(cellmask == 1))
       if (size(crossed_cells) == 0) then !> check whether the whole polyline lies in a single cell if no boundaries were crossed
-         i = this%find_netcell(xpoly(1), ypoly(1))
+         i = self%find_netcell(xpoly(1), ypoly(1))
          if (i > 0) then
             crossed_cells = [i]
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -27,6 +27,7 @@
 !
 !-------------------------------------------------------------------------------
 
+!> module containing various functions that test whether a point or a line lie inside polygons.
 module m_cellmask_from_polygon_set
    use iso_fortran_env, only: int64
    use m_missing, only: jins, dmiss
@@ -38,28 +39,29 @@ module m_cellmask_from_polygon_set
 
    public :: t_netcell_set, t_polygon_set
 
-   !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
+   !> Type describing geometry of a polygon set. Contains coordinates, bounding boxes, and enclosure flags.
    type, private :: t_polygon_geometry
-      real(kind=dp), allocatable :: x(:), y(:)
-      real(kind=dp), allocatable :: x_min(:), y_min(:), x_max(:), y_max(:)
-      logical, allocatable :: is_enclosure(:)
-      integer, allocatable :: polygon_start(:), polygon_end(:)
-      integer :: polygon_count = 0
-      logical :: enclosures_present = .false.
+      real(kind=dp), dimension(:), allocatable :: x, y !< polygon x and y coordinates, separated by dmiss.
+      real(kind=dp), dimension(:), allocatable :: x_min, y_min, x_max, y_max !< Polygon bounds; size `polygon_count`.
+      logical, dimension(:), allocatable :: is_enclosure !< Whether each polygon defines an enclosure; size `polygon_count`.
+      integer, dimension(:), allocatable :: polygon_start, polygon_end !< Inclusive packed-array bounds; size `polygon_count`.
+      integer :: polygon_count = 0 !< Number of polygons in the geometry.
+      logical :: enclosures_present = .false. !< Whether the geometry contains at least one enclosure polygon.
    end type t_polygon_geometry
 
    interface t_polygon_geometry
       module procedure construct_polygon_geometry
    end interface t_polygon_geometry
 
-   !> Latitude-binned lookup table containing ordered candidate polygon edges for ray casting.
+   !> Latitude-binned lookup table containing binned polygon edges for ray-casting. T
+   ! The bins contain only edges the ray might intersect, reducing raycasting work significantly for large polygons. 
    type, private :: t_binned_edge_index
       private
-      integer, allocatable :: polygon_bin_start(:) !< First global bin for each polygon.
-      integer, allocatable :: polygon_num_bins(:) !< Number of latitude bins for each polygon.
-      integer, allocatable :: bin_offsets(:) !< CSR offsets into edge_indices for each global bin.
-      integer, allocatable :: edge_indices(:) !< Ordered local edge indices for all bins.
-      real(kind=dp), allocatable :: polygon_bin_scale(:) !< Scale from polygon y-coordinate to local bin.
+      integer, dimension(:), allocatable :: polygon_bin_start !< First global bin per polygon; size `polygon_count`.
+      integer, dimension(:), allocatable :: polygon_num_bins !< Number of latitude bins per polygon; size `polygon_count`.
+      integer, dimension(:), allocatable :: bin_offsets !< CSR offsets; size is the total number of bins plus one.
+      integer, dimension(:), allocatable :: edge_indices !< Ordered local edge indices; size is the total number of memberships.
+      real(kind=dp), dimension(:), allocatable :: polygon_bin_scale !< Coordinate-to-bin scale per polygon; size `polygon_count`.
    contains
       procedure :: point_is_inside => binned_edge_index_point_is_inside
       procedure, private :: populate_bin_storage => binned_edge_index_populate_bin_storage
@@ -73,11 +75,11 @@ module m_cellmask_from_polygon_set
       module procedure construct_binned_edge_index
    end interface t_binned_edge_index
 
-   !> Complete cached polygon set, including optional acceleration data and lifecycle state.
+   !> polygon set including geometry and optional latitude-binned edge index for fast point-in-polygon tests.
    type :: t_polygon_set
       private
-      type(t_polygon_geometry) :: geometry
-      type(t_binned_edge_index) :: edge_index
+      type(t_polygon_geometry) :: geometry !< polygon coordinates and metadata.
+      type(t_binned_edge_index) :: edge_index !< Optional latitude-binned ray-casting index for enclosure polygon sets.
    contains
       procedure :: is_masked => polygon_set_is_masked
       procedure, private :: polygon_contains_point => polygon_set_polygon_contains_point
@@ -87,10 +89,10 @@ module m_cellmask_from_polygon_set
       module procedure construct_polygon_set
    end interface t_polygon_set
 
-   !> Net-cell polygons and operations that rely on polygon indices matching net-cell indices.
+   !> Special version of a polygon set where every netcell becomes a polygon. Used for finding netcells based on coordinates.
    type :: t_netcell_set
       private
-      type(t_polygon_set) :: polygons
+      type(t_polygon_set) :: polygons !< Polygon set created from netcell geometry.
    contains
       procedure :: find_netcell => netcell_set_find_netcell
       procedure :: find_cells_crossed_by_polyline => netcell_set_find_cells_crossed_by_polyline
@@ -100,40 +102,14 @@ module m_cellmask_from_polygon_set
       module procedure construct_netcell_set
    end interface t_netcell_set
 
-   integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
-   integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
+   integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon, capped to prevent excessive memory usage.
+   integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges, to prevent excessive memory usage.
 
 contains
 
-   !> Classify a point using only the ordered polygon edges in its latitude bin.
-   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
-      use geometry_module, only: pinpok_raycast
-
-      class(t_binned_edge_index), intent(in) :: this
-      real(kind=dp), intent(in) :: x, y !< Query coordinates.
-      integer, intent(in) :: i_poly !< Polygon index in this index.
-      type(t_polygon_geometry), intent(in) :: geometry !< Cached polygon coordinates and metadata.
-      logical :: is_inside
-
-      integer :: candidate_first, candidate_last, first_point, global_bin, last_point, local_bin, num_points
-
-      first_point = geometry%polygon_start(i_poly)
-      last_point = geometry%polygon_end(i_poly)
-      num_points = last_point - first_point + 1
-
-      local_bin = this%get_bin(y, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
-      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
-
-      candidate_first = this%bin_offsets(global_bin)
-      candidate_last = this%bin_offsets(global_bin + 1) - 1
-
-      is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
-                                 this%edge_indices(candidate_first:candidate_last))
-   end function binned_edge_index_point_is_inside
-
    !> Construct a consistent polygon cache from packed coordinates separated by missing values.
    function construct_polygon_set(x_poly, y_poly, z_poly, enable_binning) result(cache)
-      real(kind=dp), intent(in) :: x_poly(:), y_poly(:), z_poly(:) !< Packed polygon coordinate arrays.
+      real(kind=dp), dimension(:), intent(in) :: x_poly, y_poly, z_poly !< Packed polygon coordinate arrays.
       logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index for large polygon sets.
       type(t_polygon_set) :: cache
 
@@ -149,7 +125,7 @@ contains
       use m_alloc
       use geometry_module, only: get_startend
 
-      real(kind=dp), intent(in) :: x_poly(:), y_poly(:), z_poly(:) !< Packed polygon coordinate arrays.
+      real(kind=dp), dimension(:), intent(in) :: x_poly, y_poly, z_poly !< Packed polygon coordinate arrays.
       type(t_polygon_geometry) :: geometry
 
       integer :: i_point, i_start, i_end, i_poly, polygon_points
@@ -340,7 +316,7 @@ contains
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
       integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
 
-      integer :: bin_edge_counts(max_edge_bins), bin_write_positions(max_edge_bins)
+      integer, dimension(max_edge_bins) :: bin_edge_counts, bin_write_positions
       integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
       integer :: next_bin, next_edge_entry
 
@@ -403,7 +379,7 @@ contains
       class(t_binned_edge_index), intent(in) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
-      integer, intent(out) :: bin_counts(:) !< Edge count per bin.
+      integer, dimension(:), intent(out) :: bin_counts !< Edge count per bin.
 
       integer :: bin_first, bin_last, edge, i_bin, num_edges
 
@@ -454,6 +430,32 @@ contains
       i_bin = int((y - y_min) * bin_scale) + 1
       i_bin = max(1, min(bins, i_bin))
    end function binned_edge_index_get_bin
+
+   !> Classify a point using only the ordered polygon edges in its latitude bin.
+   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
+      use geometry_module, only: pinpok_raycast
+
+      class(t_binned_edge_index), intent(in) :: this
+      real(kind=dp), intent(in) :: x, y !< Query coordinates.
+      integer, intent(in) :: i_poly !< Polygon index in this index.
+      type(t_polygon_geometry), intent(in) :: geometry !< Cached polygon coordinates and metadata.
+      logical :: is_inside
+
+      integer :: candidate_first, candidate_last, first_point, global_bin, last_point, local_bin, num_points
+
+      first_point = geometry%polygon_start(i_poly)
+      last_point = geometry%polygon_end(i_poly)
+      num_points = last_point - first_point + 1
+
+      local_bin = this%get_bin(y, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
+      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
+
+      candidate_first = this%bin_offsets(global_bin)
+      candidate_last = this%bin_offsets(global_bin + 1) - 1
+
+      is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
+                                 this%edge_indices(candidate_first:candidate_last))
+   end function binned_edge_index_point_is_inside
 
    !> Construct a polygon cache containing all net-cell geometries.
    function construct_netcell_set() result(netcells)
@@ -553,7 +555,7 @@ contains
       character, dimension(:), allocatable, intent(out) :: error !> Error message, empty if no error, to be handled at call site
 
       integer :: npoly, i
-      integer, allocatable :: cellmask(:) !< (nump) Mask array for net cells
+      integer, dimension(:), allocatable :: cellmask !< (nump) Mask array for net cells
 
       error = ''
 
@@ -587,7 +589,7 @@ contains
 
       class(t_polygon_set), intent(in) :: cache
       real(kind=dp), intent(in) :: xa, ya, xb, yb !< Segment endpoints
-      integer, intent(inout) :: cellmask(:) !< Cell mask array: 1=crossed, 0=not crossed
+      integer, dimension(:), intent(inout) :: cellmask !< Cell mask array: 1=crossed, 0=not crossed
 
       real(kind=dp) :: seg_xmin, seg_xmax, seg_ymin, seg_ymax
       integer :: i_poly, i_point, i_start, i_end, n_points

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -56,7 +56,6 @@ module m_cellmask_from_polygon_set
    logical :: cellmask_initialized = .false. !< Flag indicating if cellmask data structures have been initialized for safety
    logical :: enclosures_present = .false. !< Flag indicating if any enclosures are present in the polygon dataset
 
-   integer, parameter :: min_edges_for_binning = 256 !< Small polygon sets are cheaper to scan directly.
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
 
@@ -264,19 +263,13 @@ contains
       logical :: is_inside !< Result
 
       integer :: i_bin, i_start, i_end, n_points
-      logical :: use_binned_edges
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
-      use_binned_edges = .false.
       if (allocated(edge_indices)) then
-         use_binned_edges = i_poly_num_bins(i_poly) > 1
-      end if
-
-      if (use_binned_edges) then
          i_bin = get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly))
          i_bin = i_poly_bin_start(i_poly) + i_bin - 1
          is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
@@ -287,42 +280,39 @@ contains
 
    end function pinpok_elemental
 
-   !> Build a latitude-binned edge index if it benefits the complete polygon set.
+   !> Build a latitude-binned edge index for the complete polygon set.
    !!
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
    subroutine init_binned_polygon_edges()
-      integer :: bins, binned_edges, i_poly, num_edges, total_bins
+      integer :: bins, i_poly, num_edges, total_bins, total_edges
       integer(kind=int64) :: memberships, total_memberships
 
       allocate (i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
-      binned_edges = 0
+      total_edges = 0
       total_bins = 0
       total_memberships = 0_int64
 
       do i_poly = 1, polygons
          num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-         if (num_edges >= min_edges_for_binning .and. y_poly_max(i_poly) > y_poly_min(i_poly)) then
+         if (y_poly_max(i_poly) > y_poly_min(i_poly)) then
             bins = min(max_edge_bins, max(1, num_edges / 4))
             y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
-            binned_edges = binned_edges + num_edges
          else
             bins = 1
             y_poly_bin_scale(i_poly) = 0.0_dp
          end if
          i_poly_num_bins(i_poly) = bins
-         if (bins == 1) then
-            cycle
-         end if
+         total_edges = total_edges + num_edges
          total_bins = total_bins + bins
 
          memberships = count_edge_memberships(i_poly, bins)
          total_memberships = total_memberships + memberships
       end do
 
-      ! Keep the direct scan if no individual polygon benefits, or if long edges make the index too large.
-      if (total_bins == 0 .or. total_memberships > max_memberships_per_edge * int(binned_edges, int64)) then
+      ! Keep the direct scan if long edges make the index too large.
+      if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
          deallocate (i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
          return
       end if
@@ -346,9 +336,6 @@ contains
       next_edge_entry = 1
       do i_poly = 1, polygons
          bins = i_poly_num_bins(i_poly)
-         if (bins == 1) then
-            cycle
-         end if
          call count_edges_per_bin(i_poly, bins, bin_edge_counts)
          i_poly_bin_start(i_poly) = next_bin
          do i_bin = 1, bins
@@ -363,9 +350,6 @@ contains
       ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
       do i_poly = 1, polygons
          bins = i_poly_num_bins(i_poly)
-         if (bins == 1) then
-            cycle
-         end if
          do i_bin = 1, bins
             bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
          end do

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -50,6 +50,10 @@ module m_cellmask_from_polygon_set
       logical :: enclosures_present = .false.
    end type t_polygon_geometry
 
+   interface t_polygon_geometry
+      module procedure construct_polygon_geometry
+   end interface t_polygon_geometry
+
    !> Latitude-binned lookup table containing ordered candidate polygon edges for ray casting.
    type, private :: t_binned_edge_index
       private
@@ -59,42 +63,34 @@ module m_cellmask_from_polygon_set
       integer, allocatable :: edge_indices(:) !< Ordered local edge indices for all bins.
       real(kind=dp), allocatable :: polygon_bin_scale(:) !< Scale from polygon y-coordinate to local bin.
    contains
-      procedure :: initialize => binned_edge_index_initialize
-      procedure :: clear => binned_edge_index_clear
       procedure :: point_is_inside => binned_edge_index_point_is_inside
-      procedure, private :: build => binned_edge_index_build
+      procedure, private :: populate_bin_storage => binned_edge_index_populate_bin_storage
       procedure, private :: count_edge_memberships => binned_edge_index_count_edge_memberships
       procedure, private :: count_edges_per_bin => binned_edge_index_count_edges_per_bin
       procedure, private :: edge_bin_range => binned_edge_index_edge_bin_range
       procedure, nopass, private :: get_bin => binned_edge_index_get_bin
    end type t_binned_edge_index
 
+   interface t_binned_edge_index
+      module procedure construct_binned_edge_index
+   end interface t_binned_edge_index
+
    !> Complete cached polygon set, including optional acceleration data and lifecycle state.
    type, private :: t_polygon_set_cache
       type(t_polygon_geometry) :: geometry
       type(t_binned_edge_index) :: edge_index
-      logical :: initialized = .false.
-   contains
-      procedure :: clear => polygon_set_cache_clear
    end type t_polygon_set_cache
 
-   type(t_polygon_set_cache) :: polygon_cache
+   interface t_polygon_set_cache
+      module procedure construct_polygon_set_cache
+   end interface t_polygon_set_cache
+
+   type(t_polygon_set_cache), allocatable :: polygon_cache
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
 
 contains
-
-   !> Release all storage owned by a binned edge index.
-   subroutine binned_edge_index_clear(this)
-      class(t_binned_edge_index), intent(inout) :: this
-
-      if (allocated(this%polygon_bin_start)) deallocate (this%polygon_bin_start)
-      if (allocated(this%polygon_num_bins)) deallocate (this%polygon_num_bins)
-      if (allocated(this%bin_offsets)) deallocate (this%bin_offsets)
-      if (allocated(this%edge_indices)) deallocate (this%edge_indices)
-      if (allocated(this%polygon_bin_scale)) deallocate (this%polygon_bin_scale)
-   end subroutine binned_edge_index_clear
 
    !> Classify a point using only the ordered polygon edges in its latitude bin.
    pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
@@ -121,84 +117,96 @@ contains
 
    !> Populate the module-level polygon cache and optional acceleration data.
    subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
+      integer, intent(in) :: polygon_points !< Number of polygon points.
+      real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinates.
+      logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index.
+
+      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning)
+
+   end subroutine cellmask_from_polygon_set_init
+
+   !> Construct a consistent polygon cache from packed coordinates separated by missing values.
+   function construct_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning) result(cache)
+      real(kind=dp), intent(in) :: x_poly(:), y_poly(:), z_poly(:) !< Packed polygon coordinate arrays.
+      logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index for large polygon sets.
+      type(t_polygon_set_cache) :: cache
+
+      cache%geometry = t_polygon_geometry(x_poly, y_poly, z_poly)
+      if (enable_binning .and. cache%geometry%polygon_count > 0) then
+         cache%edge_index = t_binned_edge_index(cache%geometry)
+      end if
+
+   end function construct_polygon_set_cache
+
+   !> Construct polygon geometry and metadata from packed coordinates separated by missing values.
+   function construct_polygon_geometry(x_poly, y_poly, z_poly) result(geometry)
       use m_alloc
       use geometry_module, only: get_startend
 
-      integer, intent(in) :: polygon_points !< Number of polygon points
-      real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinate arrays
-      logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index for large polygon sets.
+      real(kind=dp), intent(in) :: x_poly(:), y_poly(:), z_poly(:) !< Packed polygon coordinate arrays.
+      type(t_polygon_geometry) :: geometry
 
-      integer :: i_point, i_start, i_end, i_poly
+      integer :: i_point, i_start, i_end, i_poly, polygon_points
 
-      call polygon_cache%clear()
-      associate (geometry => polygon_cache%geometry)
+      polygon_points = size(x_poly)
+      call realloc(geometry%x, polygon_points, keepExisting=.false.)
+      call realloc(geometry%y, polygon_points, keepExisting=.false.)
+      geometry%x = x_poly
+      geometry%y = y_poly
 
-         call realloc(geometry%x, polygon_points, keepExisting=.false.)
-         call realloc(geometry%y, polygon_points, keepExisting=.false.)
-         geometry%x = x_poly
-         geometry%y = y_poly
+      if (polygon_points == 0) then
+         return
+      end if
 
-         if (polygon_points == 0) then
-            polygon_cache%initialized = .true.
-            return
+      !> allocate maximum size arrays
+      call realloc(geometry%x_min, polygon_points, keepExisting=.false.)
+      call realloc(geometry%x_max, polygon_points, keepExisting=.false.)
+      call realloc(geometry%y_min, polygon_points, keepExisting=.false.)
+      call realloc(geometry%y_max, polygon_points, keepExisting=.false.)
+      call realloc(geometry%polygon_start, polygon_points, keepExisting=.false.)
+      call realloc(geometry%polygon_end, polygon_points, keepExisting=.false.)
+      call realloc(geometry%is_enclosure, polygon_points, keepExisting=.false.)
+
+      i_point = 1
+      i_poly = 0
+
+      do while (i_point < polygon_points)
+         i_poly = i_poly + 1
+
+         !> obtain start and end indices of polygon with generic subarray extraction routine, then correct them
+         call get_startend(polygon_points - i_point + 1, x_poly(i_point:polygon_points), y_poly(i_point:polygon_points), i_start, i_end, dmiss)
+         i_start = i_start + i_point - 1
+         i_end = i_end + i_point - 1
+
+         if (i_start >= i_end .or. i_end > polygon_points) then
+            exit
          end if
 
-         !> allocate maximum size arrays
-         call realloc(geometry%x_min, polygon_points, keepExisting=.false.)
-         call realloc(geometry%x_max, polygon_points, keepExisting=.false.)
-         call realloc(geometry%y_min, polygon_points, keepExisting=.false.)
-         call realloc(geometry%y_max, polygon_points, keepExisting=.false.)
-         call realloc(geometry%polygon_start, polygon_points, keepExisting=.false.)
-         call realloc(geometry%polygon_end, polygon_points, keepExisting=.false.)
-         call realloc(geometry%is_enclosure, polygon_points, keepExisting=.false.)
+         geometry%x_min(i_poly) = minval(x_poly(i_start:i_end))
+         geometry%x_max(i_poly) = maxval(x_poly(i_start:i_end))
+         geometry%y_min(i_poly) = minval(y_poly(i_start:i_end))
+         geometry%y_max(i_poly) = maxval(y_poly(i_start:i_end))
 
-         i_point = 1
-         i_poly = 0
+         geometry%polygon_start(i_poly) = i_start
+         geometry%polygon_end(i_poly) = i_end
+         geometry%is_enclosure(i_poly) = z_poly(i_start) /= dmiss .and. z_poly(i_start) <= 0.0_dp
 
-         do while (i_point < polygon_points)
-            i_poly = i_poly + 1
+         i_point = i_end + 2
+      end do
 
-            !> obtain start and end indices of polygon with generic subarray extraction routine, then correct them
-            call get_startend(polygon_points - i_point + 1, x_poly(i_point:polygon_points), y_poly(i_point:polygon_points), i_start, i_end, dmiss)
-            i_start = i_start + i_point - 1
-            i_end = i_end + i_point - 1
+      geometry%polygon_count = i_poly
 
-            if (i_start >= i_end .or. i_end > polygon_points) then
-               exit
-            end if
+      !> resize arrays to actual number of polygons
+      call realloc(geometry%x_min, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%x_max, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%y_min, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%y_max, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%polygon_start, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%polygon_end, geometry%polygon_count, keepExisting=.true.)
+      call realloc(geometry%is_enclosure, geometry%polygon_count, keepExisting=.true.)
+      geometry%enclosures_present = any(geometry%is_enclosure)
 
-            geometry%x_min(i_poly) = minval(x_poly(i_start:i_end))
-            geometry%x_max(i_poly) = maxval(x_poly(i_start:i_end))
-            geometry%y_min(i_poly) = minval(y_poly(i_start:i_end))
-            geometry%y_max(i_poly) = maxval(y_poly(i_start:i_end))
-
-            geometry%polygon_start(i_poly) = i_start
-            geometry%polygon_end(i_poly) = i_end
-            geometry%is_enclosure(i_poly) = z_poly(i_start) /= dmiss .and. z_poly(i_start) <= 0.0_dp
-
-            i_point = i_end + 2
-         end do
-
-         geometry%polygon_count = i_poly
-
-         !> resize arrays to actual number of polygons
-         call realloc(geometry%x_min, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%x_max, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%y_min, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%y_max, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%polygon_start, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%polygon_end, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%is_enclosure, geometry%polygon_count, keepExisting=.true.)
-
-         if (enable_binning) then
-            call polygon_cache%edge_index%initialize(geometry)
-         end if
-
-         geometry%enclosures_present = any(geometry%is_enclosure)
-         polygon_cache%initialized = .true.
-      end associate
-
-   end subroutine cellmask_from_polygon_set_init
+   end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
    elemental function cellmask_from_polygon_set(x, y) result(mask)
@@ -209,11 +217,11 @@ contains
       logical :: found_inside_enclosure, is_inside
 
       mask = 0
-      associate (geometry => polygon_cache%geometry)
-         if (.not. polygon_cache%initialized) then
-            return
-         end if
+      if (.not. allocated(polygon_cache)) then
+         return
+      end if
 
+      associate (geometry => polygon_cache%geometry)
          count_drypoint = 0
          found_inside_enclosure = .false.
 
@@ -260,31 +268,11 @@ contains
    !> Clean up module-level cellmask polygon data structures.
    subroutine cellmask_from_polygon_set_cleanup()
 
-      call polygon_cache%clear()
+      if (allocated(polygon_cache)) then
+         deallocate (polygon_cache)
+      end if
+
    end subroutine cellmask_from_polygon_set_cleanup
-
-   !> Release all coordinates, metadata and acceleration data owned by a polygon cache.
-   subroutine polygon_set_cache_clear(this)
-      class(t_polygon_set_cache), intent(inout) :: this
-
-      associate (geometry => this%geometry)
-         if (allocated(geometry%x)) deallocate (geometry%x)
-         if (allocated(geometry%y)) deallocate (geometry%y)
-         if (allocated(geometry%x_min)) deallocate (geometry%x_min)
-         if (allocated(geometry%x_max)) deallocate (geometry%x_max)
-         if (allocated(geometry%y_min)) deallocate (geometry%y_min)
-         if (allocated(geometry%y_max)) deallocate (geometry%y_max)
-         if (allocated(geometry%is_enclosure)) deallocate (geometry%is_enclosure)
-         if (allocated(geometry%polygon_start)) deallocate (geometry%polygon_start)
-         if (allocated(geometry%polygon_end)) deallocate (geometry%polygon_end)
-         call this%edge_index%clear()
-
-         geometry%polygon_count = 0
-         geometry%enclosures_present = .false.
-         this%initialized = .false.
-      end associate
-
-   end subroutine polygon_set_cache_clear
 
    !> Test whether a point lies inside one cached polygon.
    elemental function pinpok_elemental(x, y, i_poly) result(is_inside)
@@ -316,16 +304,15 @@ contains
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
-   subroutine binned_edge_index_initialize(this, geometry)
-      class(t_binned_edge_index), intent(inout) :: this
+   function construct_binned_edge_index(geometry) result(index)
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry to index.
+      type(t_binned_edge_index) :: index
 
       integer :: bins, i_poly, num_edges, total_bins, total_edges
       integer(kind=int64) :: memberships, total_memberships
 
-      call this%clear()
-      allocate (this%polygon_bin_start(geometry%polygon_count), this%polygon_num_bins(geometry%polygon_count), &
-                this%polygon_bin_scale(geometry%polygon_count))
+      allocate (index%polygon_bin_start(geometry%polygon_count), index%polygon_num_bins(geometry%polygon_count), &
+                index%polygon_bin_scale(geometry%polygon_count))
       total_edges = 0
       total_bins = 0
       total_memberships = 0_int64
@@ -334,31 +321,31 @@ contains
          num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
          if (geometry%y_max(i_poly) > geometry%y_min(i_poly)) then
             bins = min(max_edge_bins, max(1, num_edges / 4))
-            this%polygon_bin_scale(i_poly) = real(bins, dp) / (geometry%y_max(i_poly) - geometry%y_min(i_poly))
+            index%polygon_bin_scale(i_poly) = real(bins, dp) / (geometry%y_max(i_poly) - geometry%y_min(i_poly))
          else
             bins = 1
-            this%polygon_bin_scale(i_poly) = 0.0_dp
+            index%polygon_bin_scale(i_poly) = 0.0_dp
          end if
-         this%polygon_num_bins(i_poly) = bins
+         index%polygon_num_bins(i_poly) = bins
          total_edges = total_edges + num_edges
          total_bins = total_bins + bins
 
-         memberships = this%count_edge_memberships(geometry, i_poly, bins)
+         memberships = index%count_edge_memberships(geometry, i_poly, bins)
          total_memberships = total_memberships + memberships
       end do
 
       ! Keep the direct scan if long edges make the index too large.
       if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
-         call this%clear()
+         deallocate (index%polygon_bin_start, index%polygon_num_bins, index%polygon_bin_scale)
          return
       end if
 
-      call this%build(geometry, total_bins, total_memberships)
+      call index%populate_bin_storage(geometry, total_bins, total_memberships)
 
-   end subroutine binned_edge_index_initialize
+   end function construct_binned_edge_index
 
    !> Allocate and populate the shared compressed-row storage for the complete polygon set.
-   subroutine binned_edge_index_build(this, geometry, total_bins, total_memberships)
+   subroutine binned_edge_index_populate_bin_storage(this, geometry, total_bins, total_memberships)
       class(t_binned_edge_index), intent(inout) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
@@ -403,7 +390,7 @@ contains
          end do
       end do
 
-   end subroutine binned_edge_index_build
+   end subroutine binned_edge_index_populate_bin_storage
 
    !> Count memberships in O(edges), without visiting every bin that an edge spans.
    function binned_edge_index_count_edge_memberships(this, geometry, i_poly, bins) result(memberships)
@@ -486,10 +473,6 @@ contains
 
       integer :: k, n, k1, total_points, ipoint
       real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init
-
-      if (polygon_cache%initialized) then
-         call cleanup_cell_geom_polylines()
-      end if
 
       ! calculate total points needed: sum(netcell(k)%n + 1) for all cells
       ! +1 for dmiss separator after each polygon

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -40,22 +40,28 @@ module m_cellmask_from_polygon_set
    public :: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
    public :: find_cells_crossed_by_polyline
 
+   !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
+   type, private :: t_polygon_geometry
+      real(kind=dp), allocatable :: x(:), y(:), z(:)
+      real(kind=dp), allocatable :: x_min(:), y_min(:), x_max(:), y_max(:)
+      real(kind=dp), allocatable :: polygon_type(:)
+      integer, allocatable :: polygon_start(:), polygon_end(:)
+      integer :: polygon_count = 0
+      logical :: enclosures_present = .false.
+   end type t_polygon_geometry
+
    !> Latitude-binned lookup table containing ordered candidate polygon edges for ray casting.
-   type, public :: t_binned_edge_index
+   type, private :: t_binned_edge_index
       private
       integer, allocatable :: polygon_bin_start(:) !< First global bin for each polygon.
       integer, allocatable :: polygon_num_bins(:) !< Number of latitude bins for each polygon.
       integer, allocatable :: bin_offsets(:) !< CSR offsets into edge_indices for each global bin.
       integer, allocatable :: edge_indices(:) !< Ordered local edge indices for all bins.
       real(kind=dp), allocatable :: polygon_bin_scale(:) !< Scale from polygon y-coordinate to local bin.
-      integer, allocatable :: polygon_start(:), polygon_end(:) !< Point ranges of indexed polygons.
-      real(kind=dp), allocatable :: polygon_y_min(:), y_points(:) !< Geometry needed to assign edges and queries to bins.
    contains
       procedure :: initialize => binned_edge_index_initialize
       procedure :: clear => binned_edge_index_clear
-      procedure :: is_initialized => binned_edge_index_is_initialized
       procedure :: point_is_inside => binned_edge_index_point_is_inside
-      procedure, private :: get_candidate_bounds => binned_edge_index_get_candidate_bounds
       procedure, private :: build => binned_edge_index_build
       procedure, private :: count_edge_memberships => binned_edge_index_count_edge_memberships
       procedure, private :: count_edges_per_bin => binned_edge_index_count_edges_per_bin
@@ -63,19 +69,16 @@ module m_cellmask_from_polygon_set
       procedure, nopass, private :: get_bin => binned_edge_index_get_bin
    end type t_binned_edge_index
 
-   real(kind=dp), allocatable, dimension(:) :: xpl_cache
-   real(kind=dp), allocatable, dimension(:) :: ypl_cache
-   real(kind=dp), allocatable, dimension(:) :: zpl_cache
-   integer :: npl_cache = 0 !< Number of points in the cached polygon arrays, including dmiss separators
+   !> Complete cached polygon set, including optional acceleration data and lifecycle state.
+   type, private :: t_polygon_set_cache
+      type(t_polygon_geometry) :: geometry
+      type(t_binned_edge_index) :: edge_index
+      logical :: initialized = .false.
+   contains
+      procedure :: clear => polygon_set_cache_clear
+   end type t_polygon_set_cache
 
-   integer :: polygons = 0 !< Number of polygons stored in module arrays xpl, ypl, zpl
-   real(kind=dp), allocatable :: x_poly_min(:), y_poly_min(:) !< Polygon bounding box min coordinates, (dim = polygons)
-   real(kind=dp), allocatable :: x_poly_max(:), y_poly_max(:) !< Polygon bounding box max coordinates, (dim = polygons)
-   real(kind=dp), allocatable :: polygon_type(:) !< Polygon type, positive or dmiss = drypoint , negative = enclosure (dim = polygons)
-   integer, allocatable :: i_poly_start(:), i_poly_end(:) !< Polygon start and end indices in coordinate arrays (dim = polygons)
-   type(t_binned_edge_index) :: binned_edge_index
-   logical :: cellmask_initialized = .false. !< Flag indicating if cellmask data structures have been initialized for safety
-   logical :: enclosures_present = .false. !< Flag indicating if any enclosures are present in the polygon dataset
+   type(t_polygon_set_cache) :: polygon_cache
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
@@ -91,54 +94,32 @@ contains
       if (allocated(this%bin_offsets)) deallocate (this%bin_offsets)
       if (allocated(this%edge_indices)) deallocate (this%edge_indices)
       if (allocated(this%polygon_bin_scale)) deallocate (this%polygon_bin_scale)
-      if (allocated(this%polygon_start)) deallocate (this%polygon_start)
-      if (allocated(this%polygon_end)) deallocate (this%polygon_end)
-      if (allocated(this%polygon_y_min)) deallocate (this%polygon_y_min)
-      if (allocated(this%y_points)) deallocate (this%y_points)
    end subroutine binned_edge_index_clear
 
-   !> Whether this index contains candidate edges and can be queried.
-   pure logical function binned_edge_index_is_initialized(this) result(is_initialized)
-      class(t_binned_edge_index), intent(in) :: this
-
-      is_initialized = allocated(this%edge_indices)
-   end function binned_edge_index_is_initialized
-
-   !> Return the contiguous edge_indices slice belonging to a polygon at a query y-coordinate.
-   pure subroutine binned_edge_index_get_candidate_bounds(this, i_poly, y, candidate_first, candidate_last)
-      class(t_binned_edge_index), intent(in) :: this
-      integer, intent(in) :: i_poly !< Polygon index.
-      real(kind=dp), intent(in) :: y !< Query y-coordinate.
-      integer, intent(out) :: candidate_first, candidate_last !< First and last candidate positions in edge_indices.
-
-      integer :: global_bin, local_bin
-
-      local_bin = this%get_bin(y, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
-      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
-      candidate_first = this%bin_offsets(global_bin)
-      candidate_last = this%bin_offsets(global_bin + 1) - 1
-   end subroutine binned_edge_index_get_candidate_bounds
-
    !> Classify a point using only the ordered polygon edges in its latitude bin.
-   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, x_polygon, y_polygon, num_points) result(is_inside)
+   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
       class(t_binned_edge_index), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< Query coordinates.
       integer, intent(in) :: i_poly !< Polygon index in this index.
-      integer, intent(in) :: num_points !< Number of polygon points.
-      real(kind=dp), intent(in) :: x_polygon(num_points), y_polygon(num_points) !< Polygon coordinates.
+      type(t_polygon_geometry), intent(in) :: geometry !< Cached polygon coordinates and metadata.
       logical :: is_inside
 
-      integer :: candidate_first, candidate_last
+      integer :: candidate_first, candidate_last, first_point, global_bin, last_point, local_bin, num_points
 
-      call this%get_candidate_bounds(i_poly, y, candidate_first, candidate_last)
-      is_inside = pinpok_raycast(x, y, x_polygon, y_polygon, num_points, &
+      first_point = geometry%polygon_start(i_poly)
+      last_point = geometry%polygon_end(i_poly)
+      num_points = last_point - first_point + 1
+      local_bin = this%get_bin(y, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
+      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
+      candidate_first = this%bin_offsets(global_bin)
+      candidate_last = this%bin_offsets(global_bin + 1) - 1
+      is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
                                  this%edge_indices(candidate_first:candidate_last))
    end function binned_edge_index_point_is_inside
 
-   !> Initialize module-level cellmask polygon data structures, such as the bounding boxes, cache and iistart/iiend
-   ! this keeps the actual calculation routines elemental.
+   !> Populate the module-level polygon cache and optional acceleration data.
    subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
       use m_alloc
       use geometry_module, only: get_startend
@@ -149,174 +130,176 @@ contains
 
       integer :: i_point, i_start, i_end, i_poly
 
-      if (cellmask_initialized) then
-         call cellmask_from_polygon_set_cleanup()
-      end if
+      call polygon_cache%clear()
+      associate (geometry => polygon_cache%geometry)
 
-      call init_geom_cache(polygon_points, x_poly, y_poly, z_poly)
+         call realloc(geometry%x, polygon_points, keepExisting=.false.)
+         call realloc(geometry%y, polygon_points, keepExisting=.false.)
+         call realloc(geometry%z, polygon_points, keepExisting=.false.)
+         geometry%x = x_poly
+         geometry%y = y_poly
+         geometry%z = z_poly
 
-      if (polygon_points == 0) then
-         cellmask_initialized = .true.
-         return
-      end if
-
-      !> allocate maximum size arrays
-      call realloc(x_poly_min, polygon_points, keepExisting=.false.)
-      call realloc(x_poly_max, polygon_points, keepExisting=.false.)
-      call realloc(y_poly_min, polygon_points, keepExisting=.false.)
-      call realloc(y_poly_max, polygon_points, keepExisting=.false.)
-      call realloc(i_poly_start, polygon_points, keepExisting=.false.)
-      call realloc(i_poly_end, polygon_points, keepExisting=.false.)
-      call realloc(polygon_type, polygon_points, keepExisting=.false.)
-
-      i_point = 1
-      i_poly = 0
-
-      do while (i_point < polygon_points)
-         i_poly = i_poly + 1
-
-         !> obtain start and end indices of polygon with generic subarray extraction routine, then correct them
-         call get_startend(polygon_points - i_point + 1, x_poly(i_point:polygon_points), y_poly(i_point:polygon_points), i_start, i_end, dmiss)
-         i_start = i_start + i_point - 1
-         i_end = i_end + i_point - 1
-
-         if (i_start >= i_end .or. i_end > polygon_points) then
-            exit
+         if (polygon_points == 0) then
+            polygon_cache%initialized = .true.
+            return
          end if
 
-         x_poly_min(i_poly) = minval(x_poly(i_start:i_end))
-         x_poly_max(i_poly) = maxval(x_poly(i_start:i_end))
-         y_poly_min(i_poly) = minval(y_poly(i_start:i_end))
-         y_poly_max(i_poly) = maxval(y_poly(i_start:i_end))
+         !> allocate maximum size arrays
+         call realloc(geometry%x_min, polygon_points, keepExisting=.false.)
+         call realloc(geometry%x_max, polygon_points, keepExisting=.false.)
+         call realloc(geometry%y_min, polygon_points, keepExisting=.false.)
+         call realloc(geometry%y_max, polygon_points, keepExisting=.false.)
+         call realloc(geometry%polygon_start, polygon_points, keepExisting=.false.)
+         call realloc(geometry%polygon_end, polygon_points, keepExisting=.false.)
+         call realloc(geometry%polygon_type, polygon_points, keepExisting=.false.)
 
-         i_poly_start(i_poly) = i_start
-         i_poly_end(i_poly) = i_end
-         polygon_type(i_poly) = z_poly(i_start)
+         i_point = 1
+         i_poly = 0
 
-         i_point = i_end + 2
-      end do
+         do while (i_point < polygon_points)
+            i_poly = i_poly + 1
 
-      polygons = i_poly
+            !> obtain start and end indices of polygon with generic subarray extraction routine, then correct them
+            call get_startend(polygon_points - i_point + 1, x_poly(i_point:polygon_points), y_poly(i_point:polygon_points), i_start, i_end, dmiss)
+            i_start = i_start + i_point - 1
+            i_end = i_end + i_point - 1
 
-      !> resize arrays to actual number of polygons
-      call realloc(x_poly_min, polygons, keepExisting=.true.)
-      call realloc(x_poly_max, polygons, keepExisting=.true.)
-      call realloc(y_poly_min, polygons, keepExisting=.true.)
-      call realloc(y_poly_max, polygons, keepExisting=.true.)
-      call realloc(i_poly_start, polygons, keepExisting=.true.)
-      call realloc(i_poly_end, polygons, keepExisting=.true.)
-      call realloc(polygon_type, polygons, keepExisting=.true.)
+            if (i_start >= i_end .or. i_end > polygon_points) then
+               exit
+            end if
 
-      if (enable_binning) then
-         call binned_edge_index%initialize(polygons, ypl_cache, i_poly_start, i_poly_end, y_poly_min, y_poly_max)
-      end if
+            geometry%x_min(i_poly) = minval(x_poly(i_start:i_end))
+            geometry%x_max(i_poly) = maxval(x_poly(i_start:i_end))
+            geometry%y_min(i_poly) = minval(y_poly(i_start:i_end))
+            geometry%y_max(i_poly) = maxval(y_poly(i_start:i_end))
 
-      ! check if there are any enclosure polygons
-      do i_poly = 1, polygons
-         if (polygon_type(i_poly) < 0.0_dp .and. polygon_type(i_poly) /= dmiss) then
-            enclosures_present = .true.
-            exit
+            geometry%polygon_start(i_poly) = i_start
+            geometry%polygon_end(i_poly) = i_end
+            geometry%polygon_type(i_poly) = z_poly(i_start)
+
+            i_point = i_end + 2
+         end do
+
+         geometry%polygon_count = i_poly
+
+         !> resize arrays to actual number of polygons
+         call realloc(geometry%x_min, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%x_max, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%y_min, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%y_max, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%polygon_start, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%polygon_end, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%polygon_type, geometry%polygon_count, keepExisting=.true.)
+
+         if (enable_binning) then
+            call polygon_cache%edge_index%initialize(geometry)
          end if
-      end do
-      cellmask_initialized = .true.
+
+         ! check if there are any enclosure polygons
+         do i_poly = 1, geometry%polygon_count
+            if (geometry%polygon_type(i_poly) < 0.0_dp .and. geometry%polygon_type(i_poly) /= dmiss) then
+               geometry%enclosures_present = .true.
+               exit
+            end if
+         end do
+         polygon_cache%initialized = .true.
+      end associate
 
    end subroutine cellmask_from_polygon_set_init
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
    elemental function cellmask_from_polygon_set(x, y) result(mask)
-
       integer :: mask
       real(kind=dp), intent(in) :: x, y !< Point coordinates
 
-      integer :: count_drypoint, i_poly, num_enclosures
+      integer :: count_drypoint, i_poly
       logical :: found_inside_enclosure, is_inside
       real(kind=dp) :: z_poly_val
 
       mask = 0
-      if (.not. cellmask_initialized) then
-         return
-      end if
-
-      num_enclosures = 0
-      count_drypoint = 0
-      found_inside_enclosure = .false.
-      is_inside = .false.
-
-      ! Single loop over all polygons
-      do i_poly = 1, polygons
-         z_poly_val = polygon_type(i_poly)
-
-         ! Bounding box check
-         if (x < x_poly_min(i_poly) .or. x > x_poly_max(i_poly) .or. &
-             y < y_poly_min(i_poly) .or. y > y_poly_max(i_poly)) then
-            cycle
+      associate (geometry => polygon_cache%geometry)
+         if (.not. polygon_cache%initialized) then
+            return
          end if
 
-         ! Point-in-polygon test
-         is_inside = pinpok_elemental(x, y, i_poly)
+         count_drypoint = 0
+         found_inside_enclosure = .false.
 
-         if (z_poly_val == dmiss .or. z_poly_val > 0.0_dp) then
-            ! Dry point polygon
-            if (is_inside) then
-               count_drypoint = count_drypoint + 1
+         ! Single loop over all polygons
+         do i_poly = 1, geometry%polygon_count
+            z_poly_val = geometry%polygon_type(i_poly)
+
+            ! Bounding box check
+            if (x < geometry%x_min(i_poly) .or. x > geometry%x_max(i_poly) .or. &
+                y < geometry%y_min(i_poly) .or. y > geometry%y_max(i_poly)) then
+               cycle
             end if
-         else if (z_poly_val < 0.0_dp .and. is_inside) then
-            found_inside_enclosure = .true.
-         end if
-      end do
 
-      ! Apply odd-even rule only if counting was needed
-      if (jins == 1) then
-         if (mod(count_drypoint, 2) == 1) then
+            ! Point-in-polygon test
+            is_inside = pinpok_elemental(x, y, i_poly)
+
+            if (z_poly_val == dmiss .or. z_poly_val > 0.0_dp) then
+               ! Dry point polygon
+               if (is_inside) then
+                  count_drypoint = count_drypoint + 1
+               end if
+            else if (z_poly_val < 0.0_dp .and. is_inside) then
+               found_inside_enclosure = .true.
+            end if
+         end do
+
+         ! Apply odd-even rule only if counting was needed
+         if (jins == 1) then
+            if (mod(count_drypoint, 2) == 1) then
+               mask = 1
+            end if
+         else
+            if (mod(count_drypoint, 2) == 0) then
+               mask = 1
+            end if
+         end if
+
+         ! if an enclosure is present, the point must lie is_inside at least one
+         ! NOTE: this means we do not handle nested enclosure polygons.
+         if (geometry%enclosures_present .and. .not. found_inside_enclosure) then
             mask = 1
          end if
-      else
-         if (mod(count_drypoint, 2) == 0) then
-            mask = 1
-         end if
-      end if
-
-      ! if an enclosure is present, the point must lie is_inside at least one
-      ! NOTE: this means we do not handle nested enclosure polygons.
-      if (enclosures_present .and. .not. found_inside_enclosure) then
-         mask = 1
-      end if
+      end associate
 
    end function cellmask_from_polygon_set
 
    !> Clean up module-level cellmask polygon data structures.
    subroutine cellmask_from_polygon_set_cleanup()
 
-      if (allocated(x_poly_min)) then
-         deallocate (x_poly_min)
-      end if
-      if (allocated(x_poly_max)) then
-         deallocate (x_poly_max)
-      end if
-      if (allocated(y_poly_min)) then
-         deallocate (y_poly_min)
-      end if
-      if (allocated(y_poly_max)) then
-         deallocate (y_poly_max)
-      end if
-      if (allocated(polygon_type)) then
-         deallocate (polygon_type)
-      end if
-      if (allocated(i_poly_start)) then
-         deallocate (i_poly_start)
-      end if
-      if (allocated(i_poly_end)) then
-         deallocate (i_poly_end)
-      end if
-      call binned_edge_index%clear()
-
-      polygons = 0
-      cellmask_initialized = .false.
-      enclosures_present = .false.
-
+      call polygon_cache%clear()
    end subroutine cellmask_from_polygon_set_cleanup
 
-!> Elemental wrapper for cellmask operations using module-level polygon arrays
+   !> Release all coordinates, metadata and acceleration data owned by a polygon cache.
+   subroutine polygon_set_cache_clear(this)
+      class(t_polygon_set_cache), intent(inout) :: this
+
+      associate (geometry => this%geometry)
+         if (allocated(geometry%x)) deallocate (geometry%x)
+         if (allocated(geometry%y)) deallocate (geometry%y)
+         if (allocated(geometry%z)) deallocate (geometry%z)
+         if (allocated(geometry%x_min)) deallocate (geometry%x_min)
+         if (allocated(geometry%x_max)) deallocate (geometry%x_max)
+         if (allocated(geometry%y_min)) deallocate (geometry%y_min)
+         if (allocated(geometry%y_max)) deallocate (geometry%y_max)
+         if (allocated(geometry%polygon_type)) deallocate (geometry%polygon_type)
+         if (allocated(geometry%polygon_start)) deallocate (geometry%polygon_start)
+         if (allocated(geometry%polygon_end)) deallocate (geometry%polygon_end)
+         call this%edge_index%clear()
+
+         geometry%polygon_count = 0
+         geometry%enclosures_present = .false.
+         this%initialized = .false.
+      end associate
+
+   end subroutine polygon_set_cache_clear
+
+   !> Test whether a point lies inside one cached polygon.
    elemental function pinpok_elemental(x, y, i_poly) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
@@ -327,16 +310,17 @@ contains
       integer :: i_start, i_end, n_points
 
       ! Get bounds for this polygon from module arrays
-      i_start = i_poly_start(i_poly)
-      i_end = i_poly_end(i_poly)
-      n_points = i_end - i_start + 1
+      associate (geometry => polygon_cache%geometry)
+         i_start = geometry%polygon_start(i_poly)
+         i_end = geometry%polygon_end(i_poly)
+         n_points = i_end - i_start + 1
 
-      if (binned_edge_index%is_initialized()) then
-         is_inside = binned_edge_index%point_is_inside(x, y, i_poly, xpl_cache(i_start:i_end), &
-                                                       ypl_cache(i_start:i_end), n_points)
-      else
-         is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points)
-      end if
+         if (allocated(polygon_cache%edge_index%edge_indices)) then
+            is_inside = polygon_cache%edge_index%point_is_inside(x, y, i_poly, geometry)
+         else
+            is_inside = pinpok_raycast(x, y, geometry%x(i_start:i_end), geometry%y(i_start:i_end), n_points)
+         end if
+      end associate
 
    end function pinpok_elemental
 
@@ -345,32 +329,25 @@ contains
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
-   subroutine binned_edge_index_initialize(this, polygon_count, y_points, polygon_start, polygon_end, polygon_y_min, polygon_y_max)
+   subroutine binned_edge_index_initialize(this, geometry)
       class(t_binned_edge_index), intent(inout) :: this
-      integer, intent(in) :: polygon_count
-      real(kind=dp), intent(in) :: y_points(:), polygon_y_min(:), polygon_y_max(:)
-      integer, intent(in) :: polygon_start(:), polygon_end(:)
+      type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry to index.
 
       integer :: bins, i_poly, num_edges, total_bins, total_edges
       integer(kind=int64) :: memberships, total_memberships
 
       call this%clear()
-      allocate (this%polygon_bin_start(polygon_count), this%polygon_num_bins(polygon_count), &
-                this%polygon_bin_scale(polygon_count), this%polygon_start(polygon_count), &
-                this%polygon_end(polygon_count), this%polygon_y_min(polygon_count), this%y_points(size(y_points)))
-      this%polygon_start = polygon_start
-      this%polygon_end = polygon_end
-      this%polygon_y_min = polygon_y_min
-      this%y_points = y_points
+      allocate (this%polygon_bin_start(geometry%polygon_count), this%polygon_num_bins(geometry%polygon_count), &
+                this%polygon_bin_scale(geometry%polygon_count))
       total_edges = 0
       total_bins = 0
       total_memberships = 0_int64
 
-      do i_poly = 1, polygon_count
-         num_edges = polygon_end(i_poly) - polygon_start(i_poly) + 1
-         if (polygon_y_max(i_poly) > polygon_y_min(i_poly)) then
+      do i_poly = 1, geometry%polygon_count
+         num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
+         if (geometry%y_max(i_poly) > geometry%y_min(i_poly)) then
             bins = min(max_edge_bins, max(1, num_edges / 4))
-            this%polygon_bin_scale(i_poly) = real(bins, dp) / (polygon_y_max(i_poly) - polygon_y_min(i_poly))
+            this%polygon_bin_scale(i_poly) = real(bins, dp) / (geometry%y_max(i_poly) - geometry%y_min(i_poly))
          else
             bins = 1
             this%polygon_bin_scale(i_poly) = 0.0_dp
@@ -379,7 +356,7 @@ contains
          total_edges = total_edges + num_edges
          total_bins = total_bins + bins
 
-         memberships = this%count_edge_memberships(i_poly, bins)
+         memberships = this%count_edge_memberships(geometry, i_poly, bins)
          total_memberships = total_memberships + memberships
       end do
 
@@ -389,17 +366,16 @@ contains
          return
       end if
 
-      call this%build(total_bins, total_memberships, polygon_count)
-      deallocate (this%polygon_start, this%polygon_end, this%y_points)
+      call this%build(geometry, total_bins, total_memberships)
 
    end subroutine binned_edge_index_initialize
 
    !> Allocate and populate the shared compressed-row storage for the complete polygon set.
-   subroutine binned_edge_index_build(this, total_bins, total_memberships, polygon_count)
+   subroutine binned_edge_index_build(this, geometry, total_bins, total_memberships)
       class(t_binned_edge_index), intent(inout) :: this
+      type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
       integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
-      integer, intent(in) :: polygon_count
 
       integer :: bin_edge_counts(max_edge_bins), bin_write_positions(max_edge_bins)
       integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
@@ -409,9 +385,9 @@ contains
       allocate (this%bin_offsets(total_bins + 1), this%edge_indices(int(total_memberships)))
       next_bin = 1
       next_edge_entry = 1
-      do i_poly = 1, polygon_count
+      do i_poly = 1, geometry%polygon_count
          bins = this%polygon_num_bins(i_poly)
-         call this%count_edges_per_bin(i_poly, bins, bin_edge_counts)
+         call this%count_edges_per_bin(geometry, i_poly, bins, bin_edge_counts)
          this%polygon_bin_start(i_poly) = next_bin
          do i_bin = 1, bins
             this%bin_offsets(next_bin) = next_edge_entry
@@ -423,16 +399,16 @@ contains
 
       ! Insert local edge numbers in polygon order. The indexed ray cast therefore sums crossings
       ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
-      do i_poly = 1, polygon_count
+      do i_poly = 1, geometry%polygon_count
          bins = this%polygon_num_bins(i_poly)
          do i_bin = 1, bins
             bin_write_positions(i_bin) = &
                this%bin_offsets(this%polygon_bin_start(i_poly) + i_bin - 1)
          end do
 
-         num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
+         num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
          do edge = 1, num_edges
-            call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+            call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
             do i_bin = bin_first, bin_last
                this%edge_indices(bin_write_positions(i_bin)) = edge
                bin_write_positions(i_bin) = bin_write_positions(i_bin) + 1
@@ -442,34 +418,36 @@ contains
 
    end subroutine binned_edge_index_build
 
-   !> Count the storage needed by a polygon edge index without allocating or iterating over memberships.
-   function binned_edge_index_count_edge_memberships(this, i_poly, bins) result(memberships)
+   !> Count memberships in O(edges), without visiting every bin that an edge spans.
+   function binned_edge_index_count_edge_memberships(this, geometry, i_poly, bins) result(memberships)
       class(t_binned_edge_index), intent(in) :: this
+      type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer(kind=int64) :: memberships !< Total edge-to-bin memberships.
 
       integer :: bin_first, bin_last, edge, num_edges
 
       memberships = 0_int64
-      num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
+      num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
          memberships = memberships + int(bin_last - bin_first + 1, int64)
       end do
    end function binned_edge_index_count_edge_memberships
 
    !> Count candidate edges in each latitude bin for one polygon.
-   subroutine binned_edge_index_count_edges_per_bin(this, i_poly, bins, bin_counts)
+   subroutine binned_edge_index_count_edges_per_bin(this, geometry, i_poly, bins, bin_counts)
       class(t_binned_edge_index), intent(in) :: this
+      type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer, intent(out) :: bin_counts(:) !< Edge count per bin.
 
       integer :: bin_first, bin_last, edge, i_bin, num_edges
 
       bin_counts(1:bins) = 0
-      num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
+      num_edges = geometry%polygon_end(i_poly) - geometry%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         call this%edge_bin_range(geometry, i_poly, edge, bins, bin_first, bin_last)
          do i_bin = bin_first, bin_last
             bin_counts(i_bin) = bin_counts(i_bin) + 1
          end do
@@ -480,28 +458,29 @@ contains
    !! Both edge endpoints and queries use get_edge_bin, so equal y-coordinates always map to the same
    !! bin. Filling every bin from the lower endpoint through the upper endpoint preserves all edges
    !! that the full ray cast could inspect at a query's y-coordinate.
-   pure subroutine binned_edge_index_edge_bin_range(this, i_poly, edge, bins, bin_first, bin_last)
+   pure subroutine binned_edge_index_edge_bin_range(this, geometry, i_poly, edge, bins, bin_first, bin_last)
       class(t_binned_edge_index), intent(in) :: this
+      type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
 
       integer :: current_point, previous_point
       real(kind=dp) :: lower_tolerance, lower_y, upper_tolerance, upper_y
 
-      current_point = this%polygon_start(i_poly) + edge - 1
+      current_point = geometry%polygon_start(i_poly) + edge - 1
       previous_point = current_point - 1
       if (edge == 1) then
-         previous_point = this%polygon_end(i_poly)
+         previous_point = geometry%polygon_end(i_poly)
       end if
-      lower_y = min(this%y_points(previous_point), this%y_points(current_point))
-      upper_y = max(this%y_points(previous_point), this%y_points(current_point))
+      lower_y = min(geometry%y(previous_point), geometry%y(current_point))
+      upper_y = max(geometry%y(previous_point), geometry%y(current_point))
 
       ! pinpok_raycast treats y-coordinates within 2 epsilon as equal. Use a larger halo so an edge
       ! remains a candidate when a near-equal query falls in the neighboring bin.
       lower_tolerance = 4.0_dp * epsilon(lower_y) * max(abs(lower_y), 1.0_dp)
       upper_tolerance = 4.0_dp * epsilon(upper_y) * max(abs(upper_y), 1.0_dp)
-      bin_first = this%get_bin(lower_y - lower_tolerance, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
-      bin_last = this%get_bin(upper_y + upper_tolerance, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
+      bin_first = this%get_bin(lower_y - lower_tolerance, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
+      bin_last = this%get_bin(upper_y + upper_tolerance, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
    end subroutine binned_edge_index_edge_bin_range
 
    !> Map a y-coordinate to a clamped one-based latitude bin.
@@ -513,34 +492,15 @@ contains
       i_bin = max(1, min(bins, i_bin))
    end function binned_edge_index_get_bin
 
-   !> Manually init geometry cache (used for dry points, test_pol_to_cellmask)
-   subroutine init_geom_cache(npl_init, xpl_init, ypl_init, zpl_init)
-      use m_alloc
-
-      integer, intent(in) :: npl_init
-      real(kind=dp), intent(in) :: xpl_init(npl_init), ypl_init(npl_init), zpl_init(npl_init)
-
-      call realloc(xpl_cache, npl_init, keepExisting=.false.)
-      call realloc(ypl_cache, npl_init, keepExisting=.false.)
-      call realloc(zpl_cache, npl_init, keepExisting=.false.)
-
-      xpl_cache = xpl_init
-      ypl_cache = ypl_init
-      zpl_cache = zpl_init
-      npl_cache = npl_init
-
-
-   end subroutine init_geom_cache
-
    !> Initialize xpl, ypl, zpl arrays with all netcell geometries (called once)
    subroutine init_cell_geom_as_polylines()
       use network_data
       use m_alloc
 
       integer :: k, n, k1, total_points, ipoint
-      real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init      
+      real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init
 
-      if (cellmask_initialized) then !> reuse cellmask cache boolean
+      if (polygon_cache%initialized) then
          call cleanup_cell_geom_polylines()
       end if
 
@@ -574,11 +534,9 @@ contains
          zpl_init(ipoint) = dmiss
       end do
 
-      npl_cache = ipoint
-
       ! initialize the cellmask module with these polygons
       ! this builds bounding boxes and polygon indices
-      call cellmask_from_polygon_set_init(npl_cache, xpl_init, ypl_init, zpl_init, enable_binning=.false.)
+      call cellmask_from_polygon_set_init(ipoint, xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
    end subroutine init_cell_geom_as_polylines
 
@@ -598,24 +556,26 @@ contains
 
       k = 0
 
-      ! Loop over all netcell polygons with fast bounding box checks
-      do i_poly = 1, polygons
+      associate (geometry => polygon_cache%geometry)
+         ! Loop over all netcell polygons with fast bounding box checks
+         do i_poly = 1, geometry%polygon_count
 
-         ! Quick bbox rejection
-         if (x < x_poly_min(i_poly) .or. x > x_poly_max(i_poly) .or. &
-             y < y_poly_min(i_poly) .or. y > y_poly_max(i_poly)) then
-            cycle
-         end if
+            ! Quick bbox rejection
+            if (x < geometry%x_min(i_poly) .or. x > geometry%x_max(i_poly) .or. &
+                y < geometry%y_min(i_poly) .or. y > geometry%y_max(i_poly)) then
+               cycle
+            end if
 
-         ! Detailed point-in-polygon check
-         is_inside = pinpok_elemental(x, y, i_poly)
+            ! Detailed point-in-polygon check
+            is_inside = pinpok_elemental(x, y, i_poly)
 
-         if (is_inside) then
-            ! cell index equals polygon index
-            k = i_poly
-            return
-         end if
-      end do
+            if (is_inside) then
+               ! cell index equals polygon index
+               k = i_poly
+               return
+            end if
+         end do
+      end associate
 
    end function point_find_netcell
 
@@ -642,7 +602,7 @@ contains
          error = 'Invalid polyline input'
          return
       end if
-      
+
       call realloc(cellmask, nump, keepexisting=.false., fill=0)
 
       ! Process each segment and put the result in cellmask
@@ -652,7 +612,7 @@ contains
 
       crossed_cells = pack([(i, i=1, nump)], mask=(cellmask == 1))
       if (size(crossed_cells) == 0) then !> check whether the whole polyline lies in a single cell if no boundaries were crossed
-         i = point_find_netcell(xpoly(1),ypoly(1))
+         i = point_find_netcell(xpoly(1), ypoly(1))
          if (i > 0) then
             crossed_cells = [i]
          end if
@@ -679,39 +639,42 @@ contains
       seg_ymin = min(ya, yb)
       seg_ymax = max(ya, yb)
 
-      !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(i_start, i_end, n_points, i, i_point, ip1, intersects)
-      do i_poly = 1, polygons
-         ! Skip if already marked
-         if (cellmask(i_poly) == 1) then
-            cycle
-         end if
-
-         ! Quick bbox rejection
-         if (seg_xmax < x_poly_min(i_poly) .or. seg_xmin > x_poly_max(i_poly) .or. &
-             seg_ymax < y_poly_min(i_poly) .or. seg_ymin > y_poly_max(i_poly)) then
-            cycle
-         end if
-
-         ! Get cached polygon geometry
-         i_start = i_poly_start(i_poly)
-         i_end = i_poly_end(i_poly)
-         n_points = i_end - i_start + 1
-
-         ! Check if segment crosses ANY edge of this cached polygon
-         do i = 0, n_points - 1
-            i_point = i_start + i
-            ip1 = i_point + 1
-            if (ip1 > i_end) ip1 = i_start ! Wrap around
-
-            intersects = line_segments_intersect(xa, ya, xb, yb, xpl_cache(i_point), ypl_cache(i_point), xpl_cache(ip1), ypl_cache(ip1))
-
-            if (intersects) then
-               cellmask(i_poly) = 1
-               exit ! No need to check other edges
+      associate (geometry => polygon_cache%geometry)
+         !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(i_start, i_end, n_points, i, i_point, ip1, intersects)
+         do i_poly = 1, geometry%polygon_count
+            ! Skip if already marked
+            if (cellmask(i_poly) == 1) then
+               cycle
             end if
+
+            ! Quick bbox rejection
+            if (seg_xmax < geometry%x_min(i_poly) .or. seg_xmin > geometry%x_max(i_poly) .or. &
+                seg_ymax < geometry%y_min(i_poly) .or. seg_ymin > geometry%y_max(i_poly)) then
+               cycle
+            end if
+
+            ! Get cached polygon geometry
+            i_start = geometry%polygon_start(i_poly)
+            i_end = geometry%polygon_end(i_poly)
+            n_points = i_end - i_start + 1
+
+            ! Check if segment crosses ANY edge of this cached polygon
+            do i = 0, n_points - 1
+               i_point = i_start + i
+               ip1 = i_point + 1
+               if (ip1 > i_end) ip1 = i_start ! Wrap around
+
+               intersects = line_segments_intersect(xa, ya, xb, yb, geometry%x(i_point), geometry%y(i_point), &
+                                                    geometry%x(ip1), geometry%y(ip1))
+
+               if (intersects) then
+                  cellmask(i_poly) = 1
+                  exit ! No need to check other edges
+               end if
+            end do
          end do
-      end do
-      !$OMP END PARALLEL DO
+         !$OMP END PARALLEL DO
+      end associate
 
    end subroutine find_cells_for_segment
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -42,9 +42,9 @@ module m_cellmask_from_polygon_set
 
    !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
    type, private :: t_polygon_geometry
-      real(kind=dp), allocatable :: x(:), y(:), z(:)
+      real(kind=dp), allocatable :: x(:), y(:)
       real(kind=dp), allocatable :: x_min(:), y_min(:), x_max(:), y_max(:)
-      real(kind=dp), allocatable :: polygon_type(:)
+      logical, allocatable :: is_enclosure(:)
       integer, allocatable :: polygon_start(:), polygon_end(:)
       integer :: polygon_count = 0
       logical :: enclosures_present = .false.
@@ -135,10 +135,8 @@ contains
 
          call realloc(geometry%x, polygon_points, keepExisting=.false.)
          call realloc(geometry%y, polygon_points, keepExisting=.false.)
-         call realloc(geometry%z, polygon_points, keepExisting=.false.)
          geometry%x = x_poly
          geometry%y = y_poly
-         geometry%z = z_poly
 
          if (polygon_points == 0) then
             polygon_cache%initialized = .true.
@@ -152,7 +150,7 @@ contains
          call realloc(geometry%y_max, polygon_points, keepExisting=.false.)
          call realloc(geometry%polygon_start, polygon_points, keepExisting=.false.)
          call realloc(geometry%polygon_end, polygon_points, keepExisting=.false.)
-         call realloc(geometry%polygon_type, polygon_points, keepExisting=.false.)
+         call realloc(geometry%is_enclosure, polygon_points, keepExisting=.false.)
 
          i_point = 1
          i_poly = 0
@@ -176,7 +174,7 @@ contains
 
             geometry%polygon_start(i_poly) = i_start
             geometry%polygon_end(i_poly) = i_end
-            geometry%polygon_type(i_poly) = z_poly(i_start)
+            geometry%is_enclosure(i_poly) = z_poly(i_start) /= dmiss .and. z_poly(i_start) <= 0.0_dp
 
             i_point = i_end + 2
          end do
@@ -190,19 +188,13 @@ contains
          call realloc(geometry%y_max, geometry%polygon_count, keepExisting=.true.)
          call realloc(geometry%polygon_start, geometry%polygon_count, keepExisting=.true.)
          call realloc(geometry%polygon_end, geometry%polygon_count, keepExisting=.true.)
-         call realloc(geometry%polygon_type, geometry%polygon_count, keepExisting=.true.)
+         call realloc(geometry%is_enclosure, geometry%polygon_count, keepExisting=.true.)
 
          if (enable_binning) then
             call polygon_cache%edge_index%initialize(geometry)
          end if
 
-         ! check if there are any enclosure polygons
-         do i_poly = 1, geometry%polygon_count
-            if (geometry%polygon_type(i_poly) < 0.0_dp .and. geometry%polygon_type(i_poly) /= dmiss) then
-               geometry%enclosures_present = .true.
-               exit
-            end if
-         end do
+         geometry%enclosures_present = any(geometry%is_enclosure)
          polygon_cache%initialized = .true.
       end associate
 
@@ -215,7 +207,6 @@ contains
 
       integer :: count_drypoint, i_poly
       logical :: found_inside_enclosure, is_inside
-      real(kind=dp) :: z_poly_val
 
       mask = 0
       associate (geometry => polygon_cache%geometry)
@@ -228,8 +219,6 @@ contains
 
          ! Single loop over all polygons
          do i_poly = 1, geometry%polygon_count
-            z_poly_val = geometry%polygon_type(i_poly)
-
             ! Bounding box check
             if (x < geometry%x_min(i_poly) .or. x > geometry%x_max(i_poly) .or. &
                 y < geometry%y_min(i_poly) .or. y > geometry%y_max(i_poly)) then
@@ -239,13 +228,12 @@ contains
             ! Point-in-polygon test
             is_inside = pinpok_elemental(x, y, i_poly)
 
-            if (z_poly_val == dmiss .or. z_poly_val > 0.0_dp) then
-               ! Dry point polygon
-               if (is_inside) then
+            if (is_inside) then
+               if (geometry%is_enclosure(i_poly)) then
+                  found_inside_enclosure = .true.
+               else
                   count_drypoint = count_drypoint + 1
                end if
-            else if (z_poly_val < 0.0_dp .and. is_inside) then
-               found_inside_enclosure = .true.
             end if
          end do
 
@@ -282,12 +270,11 @@ contains
       associate (geometry => this%geometry)
          if (allocated(geometry%x)) deallocate (geometry%x)
          if (allocated(geometry%y)) deallocate (geometry%y)
-         if (allocated(geometry%z)) deallocate (geometry%z)
          if (allocated(geometry%x_min)) deallocate (geometry%x_min)
          if (allocated(geometry%x_max)) deallocate (geometry%x_max)
          if (allocated(geometry%y_min)) deallocate (geometry%y_min)
          if (allocated(geometry%y_max)) deallocate (geometry%y_max)
-         if (allocated(geometry%polygon_type)) deallocate (geometry%polygon_type)
+         if (allocated(geometry%is_enclosure)) deallocate (geometry%is_enclosure)
          if (allocated(geometry%polygon_start)) deallocate (geometry%polygon_start)
          if (allocated(geometry%polygon_end)) deallocate (geometry%polygon_end)
          call this%edge_index%clear()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -44,7 +44,7 @@ module m_cellmask_from_polygon_set
       real(kind=dp), dimension(:), allocatable :: x, y !< polygon x and y coordinates, separated by dmiss.
       real(kind=dp), dimension(:), allocatable :: x_min, y_min, x_max, y_max !< Polygon bounds; size `polygon_count`.
       logical, dimension(:), allocatable :: is_enclosure !< Whether each polygon defines an enclosure; size `polygon_count`.
-      integer, dimension(:), allocatable :: polygon_start, polygon_end !< Inclusive packed-array bounds; size `polygon_count`.
+      integer, dimension(:), allocatable :: polygon_start, polygon_end !< Start and end packed-array index; size `polygon_count`.
       integer :: polygon_count = 0 !< Number of polygons in the geometry.
       logical :: enclosures_present = .false. !< Whether the geometry contains at least one enclosure polygon.
    end type t_polygon_geometry
@@ -53,15 +53,18 @@ module m_cellmask_from_polygon_set
       module procedure construct_polygon_geometry
    end interface t_polygon_geometry
 
-   !> Latitude-binned lookup table containing binned polygon edges for ray-casting. T
-   ! The bins contain only edges the ray might intersect, reducing raycasting work significantly for large polygons. 
+   !> Index of polygon edges grouped into horizontal bands for point-in-polygon ray casting.
+   !! Each polygon's y-range is divided into its own set of latitude bins. The number of each edge is
+   !! stored in every bin between its lowest and highest y-coordinate. A point query then ray-casts
+   !! against the edges listed in the bin containing the point, instead of scanning the whole polygon.
+   !! All polygons share a single flat CSR storage; global bin indices identify positions in that storage.
    type, private :: t_binned_edge_index
       private
-      integer, dimension(:), allocatable :: polygon_bin_start !< First global bin per polygon; size `polygon_count`.
-      integer, dimension(:), allocatable :: polygon_num_bins !< Number of latitude bins per polygon; size `polygon_count`.
-      integer, dimension(:), allocatable :: bin_offsets !< CSR offsets; size is the total number of bins plus one.
-      integer, dimension(:), allocatable :: edge_indices !< Ordered local edge indices; size is the total number of memberships.
-      real(kind=dp), dimension(:), allocatable :: polygon_bin_scale !< Coordinate-to-bin scale per polygon; size `polygon_count`.
+      integer, dimension(:), allocatable :: polygon_bin_start !< First bin in flat storage per polygon; size `polygon_count`.
+      integer, dimension(:), allocatable :: polygon_num_bins !< Number of horizontal bins per polygon; size `polygon_count`.
+      integer, dimension(:), allocatable :: bin_offsets !< Start of each bin in `edge_indices`; size `total_bins + 1`.
+      integer, dimension(:), allocatable :: edge_indices !< Polygon-local edge numbers grouped by bin.
+      real(kind=dp), dimension(:), allocatable :: polygon_bin_scale !< Factor mapping y-coordinates to bins; size `polygon_count`.
    contains
       procedure :: point_is_inside => binned_edge_index_point_is_inside
       procedure, private :: populate_bin_storage => binned_edge_index_populate_bin_storage
@@ -265,10 +268,11 @@ contains
 
    end function polygon_set_polygon_contains_point
 
-   !> Build a latitude-binned edge index for the complete polygon set.
-   !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
-   !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
-   !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
+   !> Build a horizontal-bin edge index for every polygon in a polygon set.
+   !! For each polygon, choose a bin count from its number of edges and calculate the factor that maps
+   !! its y-range to those bins. Determine the number of edge entries required by assigning every
+   !! edge to all bins crossed by its vertical range. If that storage remains below the configured
+   !! limit, allocate the shared CSR arrays and populate each bin with polygon-local edge numbers.
    function construct_binned_edge_index(geometry) result(index)
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry to index.
       type(t_binned_edge_index) :: index
@@ -299,7 +303,7 @@ contains
          total_memberships = total_memberships + memberships
       end do
 
-      ! Keep the direct scan if long edges make the index too large.
+      ! Use direct polygon scans when storing all edge entries would exceed the memory limit.
       if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
          deallocate (index%polygon_bin_start, index%polygon_num_bins, index%polygon_bin_scale)
          return
@@ -309,7 +313,10 @@ contains
 
    end function construct_binned_edge_index
 
-   !> Allocate and populate the shared compressed-row storage for the complete polygon set.
+   !> Build the flat CSR arrays that store the edge numbers belonging to every bin.
+   !! First count the edge numbers in each bin and convert those counts into offsets in `edge_indices`.
+   !! Then visit the polygon edges in polygon order and append each edge number to every bin crossed
+   !! by its vertical range. Polygon order is preserved to maintain ray-casting boundary behavior.
    subroutine binned_edge_index_populate_bin_storage(this, geometry, total_bins, total_memberships)
       class(t_binned_edge_index), intent(inout) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
@@ -320,7 +327,7 @@ contains
       integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
       integer :: next_bin, next_edge_entry
 
-      ! edge_bin_offsets/edge_indices use compressed-row storage: each bin owns one contiguous slice.
+      ! Reserve one contiguous slice of edge_indices for every bin.
       allocate (this%bin_offsets(total_bins + 1), this%edge_indices(int(total_memberships)))
       next_bin = 1
       next_edge_entry = 1
@@ -336,8 +343,7 @@ contains
       end do
       this%bin_offsets(total_bins + 1) = next_edge_entry
 
-      ! Insert local edge numbers in polygon order. The indexed ray cast therefore sums crossings
-      ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
+      ! Insert local edge numbers into their reserved bin slices in polygon order.
       do i_poly = 1, geometry%polygon_count
          bins = this%polygon_num_bins(i_poly)
          do i_bin = 1, bins
@@ -357,7 +363,10 @@ contains
 
    end subroutine binned_edge_index_populate_bin_storage
 
-   !> Count memberships in O(edges), without visiting every bin that an edge spans.
+   !> Count the edge entries needed to store one polygon in the bin index.
+   !! For each edge, find the first and last bin crossed by its vertical extent. Count every bin from
+   !! the first through the last, including both, because the edge number is stored once in each of
+   !! those bins. Sum these counts over all polygon edges.
    function binned_edge_index_count_edge_memberships(this, geometry, i_poly, bins) result(memberships)
       class(t_binned_edge_index), intent(in) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
@@ -374,7 +383,10 @@ contains
       end do
    end function binned_edge_index_count_edge_memberships
 
-   !> Count candidate edges in each latitude bin for one polygon.
+   !> Count how many edge numbers each bin of one polygon will contain.
+   !! Initialize all bin counts to zero. For every edge, find its first and last bin and increment the
+   !! count of each bin from the first through the last. These counts determine the CSR slice reserved
+   !! for every bin.
    subroutine binned_edge_index_count_edges_per_bin(this, geometry, i_poly, bins, bin_counts)
       class(t_binned_edge_index), intent(in) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
@@ -393,10 +405,10 @@ contains
       end do
    end subroutine binned_edge_index_count_edges_per_bin
 
-   !> Get the inclusive bin range intersected by an edge.
-   !! Both edge endpoints and queries use get_edge_bin, so equal y-coordinates always map to the same
-   !! bin. Filling every bin from the lower endpoint through the upper endpoint preserves all edges
-   !! that the full ray cast could inspect at a query's y-coordinate.
+   !> Find the first and last bin that must contain an edge number.
+   !! Obtain the edge endpoints from its polygon-local edge number, expand their minimum and maximum
+   !! y-coordinates by a floating-point tolerance, and map both values to bin numbers. The tolerance
+   !! includes an adjacent bin when a query and endpoint are numerically equal across a bin boundary.
    pure subroutine binned_edge_index_edge_bin_range(this, geometry, i_poly, edge, bins, bin_first, bin_last)
       class(t_binned_edge_index), intent(in) :: this
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
@@ -422,7 +434,9 @@ contains
       bin_last = this%get_bin(upper_y + upper_tolerance, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
    end subroutine binned_edge_index_edge_bin_range
 
-   !> Map a y-coordinate to a clamped one-based latitude bin.
+   !> Map a y-coordinate to a one-based bin within one polygon.
+   !! Scale the coordinate relative to the polygon's minimum y-coordinate and clamp the result to the
+   !! valid range, so endpoint tolerance halos remain within the polygon's allocated bins.
    pure integer function binned_edge_index_get_bin(y, y_min, bin_scale, bins) result(i_bin)
       real(kind=dp), intent(in) :: y, y_min, bin_scale !< Coordinate, polygon minimum and bin scale.
       integer, intent(in) :: bins !< Number of bins.
@@ -431,7 +445,9 @@ contains
       i_bin = max(1, min(bins, i_bin))
    end function binned_edge_index_get_bin
 
-   !> Classify a point using only the ordered polygon edges in its latitude bin.
+   !> Classify a point using the polygon edges listed in its horizontal bin.
+   !! Convert the point's y-coordinate to a polygon-local bin, translate that bin to its position in
+   !! the shared CSR storage, and pass the corresponding ordered edge-number slice to `pinpok_raycast`.
    pure function binned_edge_index_point_is_inside(this, x, y, i_poly, geometry) result(is_inside)
       use geometry_module, only: pinpok_raycast
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -518,13 +518,13 @@ contains
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
    elemental function netcell_set_find_netcell(self, x, y) result(k)
-   use geometry_module, only: pinpok_raycast
+      use geometry_module, only: pinpok_raycast
 
       class(t_netcell_set), intent(in) :: self !< Net-cell set to query.
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
-   integer :: first_point, i_poly, last_point, num_points
+      integer :: first_point, i_poly, last_point, num_points
       logical :: is_inside
 
       k = 0

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -205,15 +205,14 @@ contains
    end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
-   elemental function polygon_set_is_masked(this, x, y) result(mask)
+   elemental function polygon_set_is_masked(this, x, y) result(is_masked)
       class(t_polygon_set), intent(in) :: this
-      integer :: mask
       real(kind=dp), intent(in) :: x, y !< Point coordinates
+      logical :: is_masked !< Whether the point should be masked.
 
       integer :: count_drypoint, i_poly
       logical :: found_inside_enclosure, is_inside
 
-      mask = 0
       associate (geometry => this%geometry)
          count_drypoint = 0
          found_inside_enclosure = .false.
@@ -240,19 +239,15 @@ contains
 
          ! Apply odd-even rule only if counting was needed
          if (jins == 1) then
-            if (mod(count_drypoint, 2) == 1) then
-               mask = 1
-            end if
+            is_masked = mod(count_drypoint, 2) == 1
          else
-            if (mod(count_drypoint, 2) == 0) then
-               mask = 1
-            end if
+            is_masked = mod(count_drypoint, 2) == 0
          end if
 
          ! if an enclosure is present, the point must lie is_inside at least one
          ! NOTE: this means we do not handle nested enclosure polygons.
          if (geometry%enclosures_present .and. .not. found_inside_enclosure) then
-            mask = 1
+            is_masked = .true.
          end if
       end associate
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -254,7 +254,7 @@ contains
       integer :: i_start, i_end, n_points
 
       ! Get bounds for this polygon from module arrays
-      associate (geometry => this%geometry)
+      associate (geometry => self%geometry)
          i_start = geometry%polygon_start(i_poly)
          i_end = geometry%polygon_end(i_poly)
          n_points = i_end - i_start + 1
@@ -562,8 +562,6 @@ contains
       use network_data, only: nump
       use m_missing, only: dmiss
 
-      implicit none
-
       class(t_netcell_set), intent(in) :: self !< Net-cell set to query.
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
@@ -600,8 +598,6 @@ contains
 
 !> Find all cells that a segment crosses and mark them in cellmask
    subroutine find_cells_for_segment(cache, xa, ya, xb, yb, cellmask)
-
-      implicit none
 
       class(t_polygon_set), intent(in) :: cache
       real(kind=dp), intent(in) :: xa, ya, xb, yb !< Segment endpoints

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -40,6 +40,29 @@ module m_cellmask_from_polygon_set
    public :: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
    public :: find_cells_crossed_by_polyline
 
+   !> Latitude-binned lookup table containing ordered candidate polygon edges for ray casting.
+   type, public :: t_binned_edge_index
+      private
+      integer, allocatable :: polygon_bin_start(:) !< First global bin for each polygon.
+      integer, allocatable :: polygon_num_bins(:) !< Number of latitude bins for each polygon.
+      integer, allocatable :: bin_offsets(:) !< CSR offsets into edge_indices for each global bin.
+      integer, allocatable :: edge_indices(:) !< Ordered local edge indices for all bins.
+      real(kind=dp), allocatable :: polygon_bin_scale(:) !< Scale from polygon y-coordinate to local bin.
+      integer, allocatable :: polygon_start(:), polygon_end(:) !< Point ranges of indexed polygons.
+      real(kind=dp), allocatable :: polygon_y_min(:), y_points(:) !< Geometry needed to assign edges and queries to bins.
+   contains
+      procedure :: initialize => binned_edge_index_initialize
+      procedure :: clear => binned_edge_index_clear
+      procedure :: is_initialized => binned_edge_index_is_initialized
+      procedure :: point_is_inside => binned_edge_index_point_is_inside
+      procedure, private :: get_candidate_bounds => binned_edge_index_get_candidate_bounds
+      procedure, private :: build => binned_edge_index_build
+      procedure, private :: count_edge_memberships => binned_edge_index_count_edge_memberships
+      procedure, private :: count_edges_per_bin => binned_edge_index_count_edges_per_bin
+      procedure, private :: edge_bin_range => binned_edge_index_edge_bin_range
+      procedure, nopass, private :: get_bin => binned_edge_index_get_bin
+   end type t_binned_edge_index
+
    real(kind=dp), allocatable, dimension(:) :: xpl_cache
    real(kind=dp), allocatable, dimension(:) :: ypl_cache
    real(kind=dp), allocatable, dimension(:) :: zpl_cache
@@ -50,9 +73,7 @@ module m_cellmask_from_polygon_set
    real(kind=dp), allocatable :: x_poly_max(:), y_poly_max(:) !< Polygon bounding box max coordinates, (dim = polygons)
    real(kind=dp), allocatable :: polygon_type(:) !< Polygon type, positive or dmiss = drypoint , negative = enclosure (dim = polygons)
    integer, allocatable :: i_poly_start(:), i_poly_end(:) !< Polygon start and end indices in coordinate arrays (dim = polygons)
-   integer, allocatable :: i_poly_bin_start(:), i_poly_num_bins(:) !< Start and number of bins for each polygon.
-   integer, allocatable :: edge_bin_offsets(:), edge_indices(:) !< CSR offsets and ordered local edge indices.
-   real(kind=dp), allocatable :: y_poly_bin_scale(:) !< Scale from polygon y-coordinate to bin index.
+   type(t_binned_edge_index) :: binned_edge_index
    logical :: cellmask_initialized = .false. !< Flag indicating if cellmask data structures have been initialized for safety
    logical :: enclosures_present = .false. !< Flag indicating if any enclosures are present in the polygon dataset
 
@@ -60,6 +81,61 @@ module m_cellmask_from_polygon_set
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
 
 contains
+
+   !> Release all storage owned by a binned edge index.
+   subroutine binned_edge_index_clear(this)
+      class(t_binned_edge_index), intent(inout) :: this
+
+      if (allocated(this%polygon_bin_start)) deallocate (this%polygon_bin_start)
+      if (allocated(this%polygon_num_bins)) deallocate (this%polygon_num_bins)
+      if (allocated(this%bin_offsets)) deallocate (this%bin_offsets)
+      if (allocated(this%edge_indices)) deallocate (this%edge_indices)
+      if (allocated(this%polygon_bin_scale)) deallocate (this%polygon_bin_scale)
+      if (allocated(this%polygon_start)) deallocate (this%polygon_start)
+      if (allocated(this%polygon_end)) deallocate (this%polygon_end)
+      if (allocated(this%polygon_y_min)) deallocate (this%polygon_y_min)
+      if (allocated(this%y_points)) deallocate (this%y_points)
+   end subroutine binned_edge_index_clear
+
+   !> Whether this index contains candidate edges and can be queried.
+   pure logical function binned_edge_index_is_initialized(this) result(is_initialized)
+      class(t_binned_edge_index), intent(in) :: this
+
+      is_initialized = allocated(this%edge_indices)
+   end function binned_edge_index_is_initialized
+
+   !> Return the contiguous edge_indices slice belonging to a polygon at a query y-coordinate.
+   pure subroutine binned_edge_index_get_candidate_bounds(this, i_poly, y, candidate_first, candidate_last)
+      class(t_binned_edge_index), intent(in) :: this
+      integer, intent(in) :: i_poly !< Polygon index.
+      real(kind=dp), intent(in) :: y !< Query y-coordinate.
+      integer, intent(out) :: candidate_first, candidate_last !< First and last candidate positions in edge_indices.
+
+      integer :: global_bin, local_bin
+
+      local_bin = this%get_bin(y, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
+      global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
+      candidate_first = this%bin_offsets(global_bin)
+      candidate_last = this%bin_offsets(global_bin + 1) - 1
+   end subroutine binned_edge_index_get_candidate_bounds
+
+   !> Classify a point using only the ordered polygon edges in its latitude bin.
+   pure function binned_edge_index_point_is_inside(this, x, y, i_poly, x_polygon, y_polygon, num_points) result(is_inside)
+      use geometry_module, only: pinpok_raycast
+
+      class(t_binned_edge_index), intent(in) :: this
+      real(kind=dp), intent(in) :: x, y !< Query coordinates.
+      integer, intent(in) :: i_poly !< Polygon index in this index.
+      integer, intent(in) :: num_points !< Number of polygon points.
+      real(kind=dp), intent(in) :: x_polygon(num_points), y_polygon(num_points) !< Polygon coordinates.
+      logical :: is_inside
+
+      integer :: candidate_first, candidate_last
+
+      call this%get_candidate_bounds(i_poly, y, candidate_first, candidate_last)
+      is_inside = pinpok_raycast(x, y, x_polygon, y_polygon, num_points, &
+                                 this%edge_indices(candidate_first:candidate_last))
+   end function binned_edge_index_point_is_inside
 
    !> Initialize module-level cellmask polygon data structures, such as the bounding boxes, cache and iistart/iiend
    ! this keeps the actual calculation routines elemental.
@@ -132,7 +208,7 @@ contains
       call realloc(polygon_type, polygons, keepExisting=.true.)
 
       if (enable_binning) then
-         call init_binned_polygon_edges()
+         call binned_edge_index%initialize(polygons, ypl_cache, i_poly_start, i_poly_end, y_poly_min, y_poly_max)
       end if
 
       ! check if there are any enclosure polygons
@@ -232,21 +308,7 @@ contains
       if (allocated(i_poly_end)) then
          deallocate (i_poly_end)
       end if
-      if (allocated(i_poly_bin_start)) then
-         deallocate (i_poly_bin_start)
-      end if
-      if (allocated(i_poly_num_bins)) then
-         deallocate (i_poly_num_bins)
-      end if
-      if (allocated(edge_bin_offsets)) then
-         deallocate (edge_bin_offsets)
-      end if
-      if (allocated(edge_indices)) then
-         deallocate (edge_indices)
-      end if
-      if (allocated(y_poly_bin_scale)) then
-         deallocate (y_poly_bin_scale)
-      end if
+      call binned_edge_index%clear()
 
       polygons = 0
       cellmask_initialized = .false.
@@ -262,18 +324,16 @@ contains
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
 
-      integer :: i_bin, i_start, i_end, n_points
+      integer :: i_start, i_end, n_points
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
-      if (allocated(edge_indices)) then
-         i_bin = get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly))
-         i_bin = i_poly_bin_start(i_poly) + i_bin - 1
-         is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
-                                   edge_indices(edge_bin_offsets(i_bin):edge_bin_offsets(i_bin + 1) - 1))
+      if (binned_edge_index%is_initialized()) then
+         is_inside = binned_edge_index%point_is_inside(x, y, i_poly, xpl_cache(i_start:i_end), &
+                                                       ypl_cache(i_start:i_end), n_points)
       else
          is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points)
       end if
@@ -285,154 +345,173 @@ contains
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
-   subroutine init_binned_polygon_edges()
+   subroutine binned_edge_index_initialize(this, polygon_count, y_points, polygon_start, polygon_end, polygon_y_min, polygon_y_max)
+      class(t_binned_edge_index), intent(inout) :: this
+      integer, intent(in) :: polygon_count
+      real(kind=dp), intent(in) :: y_points(:), polygon_y_min(:), polygon_y_max(:)
+      integer, intent(in) :: polygon_start(:), polygon_end(:)
+
       integer :: bins, i_poly, num_edges, total_bins, total_edges
       integer(kind=int64) :: memberships, total_memberships
 
-      allocate (i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
+      call this%clear()
+      allocate (this%polygon_bin_start(polygon_count), this%polygon_num_bins(polygon_count), &
+                this%polygon_bin_scale(polygon_count), this%polygon_start(polygon_count), &
+                this%polygon_end(polygon_count), this%polygon_y_min(polygon_count), this%y_points(size(y_points)))
+      this%polygon_start = polygon_start
+      this%polygon_end = polygon_end
+      this%polygon_y_min = polygon_y_min
+      this%y_points = y_points
       total_edges = 0
       total_bins = 0
       total_memberships = 0_int64
 
-      do i_poly = 1, polygons
-         num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-         if (y_poly_max(i_poly) > y_poly_min(i_poly)) then
+      do i_poly = 1, polygon_count
+         num_edges = polygon_end(i_poly) - polygon_start(i_poly) + 1
+         if (polygon_y_max(i_poly) > polygon_y_min(i_poly)) then
             bins = min(max_edge_bins, max(1, num_edges / 4))
-            y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
+            this%polygon_bin_scale(i_poly) = real(bins, dp) / (polygon_y_max(i_poly) - polygon_y_min(i_poly))
          else
             bins = 1
-            y_poly_bin_scale(i_poly) = 0.0_dp
+            this%polygon_bin_scale(i_poly) = 0.0_dp
          end if
-         i_poly_num_bins(i_poly) = bins
+         this%polygon_num_bins(i_poly) = bins
          total_edges = total_edges + num_edges
          total_bins = total_bins + bins
 
-         memberships = count_edge_memberships(i_poly, bins)
+         memberships = this%count_edge_memberships(i_poly, bins)
          total_memberships = total_memberships + memberships
       end do
 
       ! Keep the direct scan if long edges make the index too large.
       if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
-         deallocate (i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
+         call this%clear()
          return
       end if
 
-      call build_binned_edge_index(total_bins, total_memberships)
+      call this%build(total_bins, total_memberships, polygon_count)
+      deallocate (this%polygon_start, this%polygon_end, this%y_points)
 
-   end subroutine init_binned_polygon_edges
+   end subroutine binned_edge_index_initialize
 
    !> Allocate and populate the shared compressed-row storage for the complete polygon set.
-   subroutine build_binned_edge_index(total_bins, total_memberships)
+   subroutine binned_edge_index_build(this, total_bins, total_memberships, polygon_count)
+      class(t_binned_edge_index), intent(inout) :: this
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
       integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
+      integer, intent(in) :: polygon_count
 
       integer :: bin_edge_counts(max_edge_bins), bin_write_positions(max_edge_bins)
       integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
       integer :: next_bin, next_edge_entry
 
       ! edge_bin_offsets/edge_indices use compressed-row storage: each bin owns one contiguous slice.
-      allocate (edge_bin_offsets(total_bins + 1), edge_indices(int(total_memberships)))
+      allocate (this%bin_offsets(total_bins + 1), this%edge_indices(int(total_memberships)))
       next_bin = 1
       next_edge_entry = 1
-      do i_poly = 1, polygons
-         bins = i_poly_num_bins(i_poly)
-         call count_edges_per_bin(i_poly, bins, bin_edge_counts)
-         i_poly_bin_start(i_poly) = next_bin
+      do i_poly = 1, polygon_count
+         bins = this%polygon_num_bins(i_poly)
+         call this%count_edges_per_bin(i_poly, bins, bin_edge_counts)
+         this%polygon_bin_start(i_poly) = next_bin
          do i_bin = 1, bins
-            edge_bin_offsets(next_bin) = next_edge_entry
+            this%bin_offsets(next_bin) = next_edge_entry
             next_edge_entry = next_edge_entry + bin_edge_counts(i_bin)
             next_bin = next_bin + 1
          end do
       end do
-      edge_bin_offsets(total_bins + 1) = next_edge_entry
+      this%bin_offsets(total_bins + 1) = next_edge_entry
 
       ! Insert local edge numbers in polygon order. The indexed ray cast therefore sums crossings
       ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
-      do i_poly = 1, polygons
-         bins = i_poly_num_bins(i_poly)
+      do i_poly = 1, polygon_count
+         bins = this%polygon_num_bins(i_poly)
          do i_bin = 1, bins
-            bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
+            bin_write_positions(i_bin) = &
+               this%bin_offsets(this%polygon_bin_start(i_poly) + i_bin - 1)
          end do
 
-         num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+         num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
          do edge = 1, num_edges
-            call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+            call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
             do i_bin = bin_first, bin_last
-               edge_indices(bin_write_positions(i_bin)) = edge
+               this%edge_indices(bin_write_positions(i_bin)) = edge
                bin_write_positions(i_bin) = bin_write_positions(i_bin) + 1
             end do
          end do
       end do
 
-   end subroutine build_binned_edge_index
+   end subroutine binned_edge_index_build
 
    !> Count the storage needed by a polygon edge index without allocating or iterating over memberships.
-   function count_edge_memberships(i_poly, bins) result(memberships)
+   function binned_edge_index_count_edge_memberships(this, i_poly, bins) result(memberships)
+      class(t_binned_edge_index), intent(in) :: this
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer(kind=int64) :: memberships !< Total edge-to-bin memberships.
 
       integer :: bin_first, bin_last, edge, num_edges
 
       memberships = 0_int64
-      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
          memberships = memberships + int(bin_last - bin_first + 1, int64)
       end do
-   end function count_edge_memberships
+   end function binned_edge_index_count_edge_memberships
 
    !> Count candidate edges in each latitude bin for one polygon.
-   subroutine count_edges_per_bin(i_poly, bins, bin_counts)
+   subroutine binned_edge_index_count_edges_per_bin(this, i_poly, bins, bin_counts)
+      class(t_binned_edge_index), intent(in) :: this
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer, intent(out) :: bin_counts(:) !< Edge count per bin.
 
       integer :: bin_first, bin_last, edge, i_bin, num_edges
 
       bin_counts(1:bins) = 0
-      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      num_edges = this%polygon_end(i_poly) - this%polygon_start(i_poly) + 1
       do edge = 1, num_edges
-         call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+         call this%edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
          do i_bin = bin_first, bin_last
             bin_counts(i_bin) = bin_counts(i_bin) + 1
          end do
       end do
-   end subroutine count_edges_per_bin
+   end subroutine binned_edge_index_count_edges_per_bin
 
    !> Get the inclusive bin range intersected by an edge.
    !! Both edge endpoints and queries use get_edge_bin, so equal y-coordinates always map to the same
    !! bin. Filling every bin from the lower endpoint through the upper endpoint preserves all edges
    !! that the full ray cast could inspect at a query's y-coordinate.
-   pure subroutine edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
+   pure subroutine binned_edge_index_edge_bin_range(this, i_poly, edge, bins, bin_first, bin_last)
+      class(t_binned_edge_index), intent(in) :: this
       integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
 
       integer :: current_point, previous_point
       real(kind=dp) :: lower_tolerance, lower_y, upper_tolerance, upper_y
 
-      current_point = i_poly_start(i_poly) + edge - 1
+      current_point = this%polygon_start(i_poly) + edge - 1
       previous_point = current_point - 1
       if (edge == 1) then
-         previous_point = i_poly_end(i_poly)
+         previous_point = this%polygon_end(i_poly)
       end if
-      lower_y = min(ypl_cache(previous_point), ypl_cache(current_point))
-      upper_y = max(ypl_cache(previous_point), ypl_cache(current_point))
+      lower_y = min(this%y_points(previous_point), this%y_points(current_point))
+      upper_y = max(this%y_points(previous_point), this%y_points(current_point))
 
       ! pinpok_raycast treats y-coordinates within 2 epsilon as equal. Use a larger halo so an edge
       ! remains a candidate when a near-equal query falls in the neighboring bin.
       lower_tolerance = 4.0_dp * epsilon(lower_y) * max(abs(lower_y), 1.0_dp)
       upper_tolerance = 4.0_dp * epsilon(upper_y) * max(abs(upper_y), 1.0_dp)
-      bin_first = get_edge_bin(lower_y - lower_tolerance, y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
-      bin_last = get_edge_bin(upper_y + upper_tolerance, y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
-   end subroutine edge_bin_range
+      bin_first = this%get_bin(lower_y - lower_tolerance, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
+      bin_last = this%get_bin(upper_y + upper_tolerance, this%polygon_y_min(i_poly), this%polygon_bin_scale(i_poly), bins)
+   end subroutine binned_edge_index_edge_bin_range
 
    !> Map a y-coordinate to a clamped one-based latitude bin.
-   pure integer function get_edge_bin(y, y_min, bin_scale, bins) result(i_bin)
+   pure integer function binned_edge_index_get_bin(y, y_min, bin_scale, bins) result(i_bin)
       real(kind=dp), intent(in) :: y, y_min, bin_scale !< Coordinate, polygon minimum and bin scale.
       integer, intent(in) :: bins !< Number of bins.
 
       i_bin = int((y - y_min) * bin_scale) + 1
       i_bin = max(1, min(bins, i_bin))
-   end function get_edge_bin
+   end function binned_edge_index_get_bin
 
    !> Manually init geometry cache (used for dry points, test_pol_to_cellmask)
    subroutine init_geom_cache(npl_init, xpl_init, ypl_init, zpl_init)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -50,30 +50,27 @@ module m_cellmask_from_polygon_set
    real(kind=dp), allocatable :: x_poly_max(:), y_poly_max(:) !< Polygon bounding box max coordinates, (dim = polygons)
    real(kind=dp), allocatable :: polygon_type(:) !< Polygon type, positive or dmiss = drypoint , negative = enclosure (dim = polygons)
    integer, allocatable :: i_poly_start(:), i_poly_end(:) !< Polygon start and end indices in coordinate arrays (dim = polygons)
-   logical, allocatable :: polygon_uses_binned_edges(:) !< Whether each polygon uses the binned edge index.
    integer, allocatable :: i_poly_bin_start(:), i_poly_num_bins(:) !< Start and number of bins for each polygon.
    integer, allocatable :: edge_bin_offsets(:), edge_indices(:) !< CSR offsets and ordered local edge indices.
    real(kind=dp), allocatable :: y_poly_bin_scale(:) !< Scale from polygon y-coordinate to bin index.
    logical :: cellmask_initialized = .false. !< Flag indicating if cellmask data structures have been initialized for safety
    logical :: enclosures_present = .false. !< Flag indicating if any enclosures are present in the polygon dataset
 
-   integer, parameter :: min_edges_for_index = 256 !< Small polygons are cheaper to scan directly.
+   integer, parameter :: min_edges_for_binning = 256 !< Small polygon sets are cheaper to scan directly.
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
-   real(kind=dp), parameter :: min_predicted_speedup = 2.0_dp !< Required estimated improvement before indexing.
 
 contains
 
    !> Initialize module-level cellmask polygon data structures, such as the bounding boxes, cache and iistart/iiend
    ! this keeps the actual calculation routines elemental.
-   subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, num_query_points, x_query, y_query)
+   subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
       use m_alloc
       use geometry_module, only: get_startend
 
       integer, intent(in) :: polygon_points !< Number of polygon points
       real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinate arrays
-      integer, intent(in), optional :: num_query_points !< Number of points that will be classified.
-      real(kind=dp), intent(in), optional :: x_query(:), y_query(:) !< Points that will be classified, used to estimate index benefit.
+      logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index for large polygon sets.
 
       integer :: i_point, i_start, i_end, i_poly
 
@@ -135,8 +132,8 @@ contains
       call realloc(i_poly_end, polygons, keepExisting=.true.)
       call realloc(polygon_type, polygons, keepExisting=.true.)
 
-      if (present(num_query_points) .and. present(x_query) .and. present(y_query)) then
-         call init_binned_polygon_edges(num_query_points, x_query, y_query)
+      if (enable_binning) then
+         call init_binned_polygon_edges()
       end if
 
       ! check if there are any enclosure polygons
@@ -236,9 +233,6 @@ contains
       if (allocated(i_poly_end)) then
          deallocate (i_poly_end)
       end if
-      if (allocated(polygon_uses_binned_edges)) then
-         deallocate (polygon_uses_binned_edges)
-      end if
       if (allocated(i_poly_bin_start)) then
          deallocate (i_poly_bin_start)
       end if
@@ -270,19 +264,13 @@ contains
       logical :: is_inside !< Result
 
       integer :: i_bin, i_start, i_end, n_points
-      logical :: use_binned_edges
 
       ! Get bounds for this polygon from module arrays
       i_start = i_poly_start(i_poly)
       i_end = i_poly_end(i_poly)
       n_points = i_end - i_start + 1
 
-      use_binned_edges = .false.
-      if (allocated(polygon_uses_binned_edges)) then
-         use_binned_edges = polygon_uses_binned_edges(i_poly)
-      end if
-
-      if (use_binned_edges) then
+      if (allocated(edge_indices)) then
          i_bin = get_edge_bin(y, y_poly_min(i_poly), y_poly_bin_scale(i_poly), i_poly_num_bins(i_poly))
          i_bin = i_poly_bin_start(i_poly) + i_bin - 1
          is_inside = pinpok_raycast(x, y, xpl_cache(i_start:i_end), ypl_cache(i_start:i_end), n_points, &
@@ -293,102 +281,56 @@ contains
 
    end function pinpok_elemental
 
-   !> Select polygons that benefit from latitude bins and build their shared edge index.
+   !> Build a latitude-binned edge index if it benefits the complete polygon set.
    !!
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
-   subroutine init_binned_polygon_edges(num_query_points, x_query, y_query)
-      integer, intent(in) :: num_query_points !< Number of points that will be classified.
-      real(kind=dp), intent(in) :: x_query(:), y_query(:) !< Points that will be classified.
-
-      integer :: bins, i_poly, num_edges, total_bins
+   subroutine init_binned_polygon_edges()
+      integer :: bins, i_poly, num_edges, total_bins, total_edges
       integer(kind=int64) :: memberships, total_memberships
 
-      allocate (polygon_uses_binned_edges(polygons), i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
-      polygon_uses_binned_edges = .false.
-      i_poly_bin_start = 0
-      i_poly_num_bins = 0
-      y_poly_bin_scale = 0.0_dp
+      total_edges = 0
+      do i_poly = 1, polygons
+         total_edges = total_edges + i_poly_end(i_poly) - i_poly_start(i_poly) + 1
+      end do
+      if (total_edges < min_edges_for_binning) then
+         return
+      end if
 
+      allocate (i_poly_bin_start(polygons), i_poly_num_bins(polygons), y_poly_bin_scale(polygons))
       total_bins = 0
       total_memberships = 0_int64
 
       do i_poly = 1, polygons
          num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-         if (num_edges < min_edges_for_index .or. y_poly_max(i_poly) <= y_poly_min(i_poly)) then
-            cycle
+         if (y_poly_max(i_poly) > y_poly_min(i_poly)) then
+            bins = min(max_edge_bins, max(1, num_edges / 4))
+            y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
+         else
+            bins = 1
+            y_poly_bin_scale(i_poly) = 0.0_dp
          end if
-
-         bins = min(max_edge_bins, max(16, num_edges / 4))
-         if (.not. polygon_binning_is_worthwhile(i_poly, bins, num_query_points, x_query, y_query, memberships)) then
-            cycle
-         end if
-
-         polygon_uses_binned_edges(i_poly) = .true.
          i_poly_num_bins(i_poly) = bins
          total_bins = total_bins + bins
-         total_memberships = total_memberships + memberships
-      end do
 
-      if (total_bins == 0) then
-         deallocate (polygon_uses_binned_edges, i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
-         return
-      end if
+         memberships = count_edge_memberships(i_poly, bins)
+         total_memberships = total_memberships + memberships
+         ! Reject before allocation if edges span too many bins across the polygon set.
+         if (total_memberships > max_memberships_per_edge * int(total_edges, int64)) then
+            deallocate (i_poly_bin_start, i_poly_num_bins, y_poly_bin_scale)
+            return
+         end if
+      end do
 
       call build_binned_edge_index(total_bins, total_memberships)
 
    end subroutine init_binned_polygon_edges
 
-   !> Decide whether indexing one polygon will repay its construction cost for the supplied queries.
-   function polygon_binning_is_worthwhile(i_poly, bins, num_query_points, x_query, y_query, memberships) result(is_worthwhile)
-      integer, intent(in) :: i_poly, bins, num_query_points !< Polygon, proposed bin count and number of queries.
-      real(kind=dp), intent(in) :: x_query(:), y_query(:) !< Points that will be classified.
-      integer(kind=int64), intent(out) :: memberships !< Number of edge entries needed by the proposed index.
-      logical :: is_worthwhile
-
-      integer :: bin_edge_counts(max_edge_bins), bin_query_counts(max_edge_bins)
-      integer :: i_bin, num_edges, num_relevant_queries, point
-      real(kind=dp) :: candidate_work, direct_work, indexed_work
-
-      is_worthwhile = .false.
-      num_edges = i_poly_end(i_poly) - i_poly_start(i_poly) + 1
-      y_poly_bin_scale(i_poly) = real(bins, dp) / (y_poly_max(i_poly) - y_poly_min(i_poly))
-
-      ! Long, near-vertical edges can occur in many bins. Reject such an index before allocating it.
-      memberships = count_edge_memberships(i_poly, bins)
-      if (memberships > max_memberships_per_edge * int(num_edges, int64)) then
-         return
-      end if
-
-      call count_edges_per_bin(i_poly, bins, bin_edge_counts)
-      bin_query_counts(1:bins) = 0
-      do point = 1, min(num_query_points, size(x_query), size(y_query))
-         if (x_query(point) < x_poly_min(i_poly) .or. x_query(point) > x_poly_max(i_poly) .or. &
-             y_query(point) < y_poly_min(i_poly) .or. y_query(point) > y_poly_max(i_poly)) then
-            cycle
-         end if
-         i_bin = get_edge_bin(y_query(point), y_poly_min(i_poly), y_poly_bin_scale(i_poly), bins)
-         bin_query_counts(i_bin) = bin_query_counts(i_bin) + 1
-      end do
-
-      num_relevant_queries = sum(bin_query_counts(1:bins))
-      direct_work = real(num_relevant_queries, dp) * real(num_edges, dp)
-      candidate_work = 0.0_dp
-      do i_bin = 1, bins
-         candidate_work = candidate_work + real(bin_query_counts(i_bin), dp) * real(bin_edge_counts(i_bin), dp)
-      end do
-
-      ! Indexed work includes assessment, two membership passes, query lookup and the remaining ray-cast edges.
-      indexed_work = real(num_edges + num_relevant_queries, dp) + 2.0_dp * real(memberships, dp) + candidate_work
-      is_worthwhile = direct_work >= min_predicted_speedup * indexed_work
-
-   end function polygon_binning_is_worthwhile
-
-   !> Allocate and populate the shared compressed-row storage for all selected polygons.
+   !> Allocate and populate the shared compressed-row storage for the complete polygon set.
    subroutine build_binned_edge_index(total_bins, total_memberships)
-      integer, intent(in) :: total_bins !< Total number of bins over selected polygons.
-      integer(kind=int64), intent(in) :: total_memberships !< Total edge entries over selected polygons.
+      integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
+      integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
 
       integer :: bin_edge_counts(max_edge_bins), bin_write_positions(max_edge_bins)
       integer :: bin_first, bin_last, bins, edge, i_bin, i_poly, num_edges
@@ -399,9 +341,6 @@ contains
       next_bin = 1
       next_edge_entry = 1
       do i_poly = 1, polygons
-         if (.not. polygon_uses_binned_edges(i_poly)) then
-            cycle
-         end if
          bins = i_poly_num_bins(i_poly)
          call count_edges_per_bin(i_poly, bins, bin_edge_counts)
          i_poly_bin_start(i_poly) = next_bin
@@ -416,9 +355,6 @@ contains
       ! Insert local edge numbers in polygon order. The indexed ray cast therefore sums crossings
       ! in exactly the same order as the full scan, preserving floating-point and boundary behavior.
       do i_poly = 1, polygons
-         if (.not. polygon_uses_binned_edges(i_poly)) then
-            cycle
-         end if
          bins = i_poly_num_bins(i_poly)
          do i_bin = 1, bins
             bin_write_positions(i_bin) = edge_bin_offsets(i_poly_bin_start(i_poly) + i_bin - 1)
@@ -448,9 +384,6 @@ contains
       do edge = 1, num_edges
          call edge_bin_range(i_poly, edge, bins, bin_first, bin_last)
          memberships = memberships + int(bin_last - bin_first + 1, int64)
-         if (memberships > max_memberships_per_edge * int(num_edges, int64)) then
-            return
-         end if
       end do
    end function count_edge_memberships
 
@@ -566,7 +499,7 @@ contains
 
       ! initialize the cellmask module with these polygons
       ! this builds bounding boxes and polygon indices
-      call cellmask_from_polygon_set_init(npl_cache, xpl_init, ypl_init, zpl_init)
+      call cellmask_from_polygon_set_init(npl_cache, xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
    end subroutine init_cell_geom_as_polylines
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -500,12 +500,13 @@ contains
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
    elemental function netcell_set_find_netcell(this, x, y) result(k)
+   use geometry_module, only: pinpok_raycast
 
       class(t_netcell_set), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
-      integer :: i_poly
+   integer :: first_point, i_poly, last_point, num_points
       logical :: is_inside
 
       k = 0
@@ -521,7 +522,11 @@ contains
             end if
 
             ! Detailed point-in-polygon check
-            is_inside = this%polygons%polygon_contains_point(x, y, i_poly)
+            first_point = geometry%polygon_start(i_poly)
+            last_point = geometry%polygon_end(i_poly)
+            num_points = last_point - first_point + 1
+            ! explicit inlined call + first point + offset passing of an explicitly sized array to help compiler.
+            is_inside = pinpok_raycast(x, y, geometry%x(first_point), geometry%y(first_point), num_points)
 
             if (is_inside) then
                ! cell index equals polygon index

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -195,7 +195,7 @@ contains
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
    elemental function polygon_set_is_masked(self, x, y) result(is_masked)
-      class(t_polygon_set), intent(in) :: self
+      class(t_polygon_set), intent(in) :: self !< Polygon set to query.
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       logical :: is_masked !< Whether the point should be masked.
 
@@ -246,7 +246,7 @@ contains
    elemental function polygon_set_polygon_contains_point(self, x, y, i_poly) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
-      class(t_polygon_set), intent(in) :: self
+      class(t_polygon_set), intent(in) :: self !< Polygon set to query.
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
@@ -318,7 +318,7 @@ contains
    !! Then visit the polygon edges in polygon order and append each edge number to every bin crossed
    !! by its vertical range. Polygon order is preserved to maintain ray-casting boundary behavior.
    subroutine binned_edge_index_populate_bin_storage(self, geometry, total_bins, total_memberships)
-      class(t_binned_edge_index), intent(inout) :: self
+      class(t_binned_edge_index), intent(inout) :: self !< Binned edge index being constructed.
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: total_bins !< Total number of bins in the polygon set.
       integer(kind=int64), intent(in) :: total_memberships !< Total edge entries in the polygon set.
@@ -368,7 +368,7 @@ contains
    !! the first through the last, including both, because the edge number is stored once in each of
    !! those bins. Sum these counts over all polygon edges.
    function binned_edge_index_count_edge_memberships(self, geometry, i_poly, bins) result(memberships)
-      class(t_binned_edge_index), intent(in) :: self
+      class(t_binned_edge_index), intent(in) :: self !< Binned edge index being constructed.
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer(kind=int64) :: memberships !< Total edge-to-bin memberships.
@@ -388,7 +388,7 @@ contains
    !! count of each bin from the first through the last. These counts determine the CSR slice reserved
    !! for every bin.
    subroutine binned_edge_index_count_edges_per_bin(self, geometry, i_poly, bins, bin_counts)
-      class(t_binned_edge_index), intent(in) :: self
+      class(t_binned_edge_index), intent(in) :: self !< Binned edge index being constructed.
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, bins !< Polygon index and number of bins.
       integer, dimension(:), intent(out) :: bin_counts !< Edge count per bin.
@@ -410,7 +410,7 @@ contains
    !! y-coordinates by a floating-point tolerance, and map both values to bin numbers. The tolerance
    !! includes an adjacent bin when a query and endpoint are numerically equal across a bin boundary.
    pure subroutine binned_edge_index_edge_bin_range(self, geometry, i_poly, edge, bins, bin_first, bin_last)
-      class(t_binned_edge_index), intent(in) :: self
+      class(t_binned_edge_index), intent(in) :: self !< Binned edge index being constructed.
       type(t_polygon_geometry), intent(in) :: geometry !< Polygon geometry being indexed.
       integer, intent(in) :: i_poly, edge, bins !< Polygon index, local edge index and number of bins.
       integer, intent(out) :: bin_first, bin_last !< First and last intersected bins.
@@ -451,7 +451,7 @@ contains
    pure function binned_edge_index_point_is_inside(self, x, y, i_poly, geometry) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
-      class(t_binned_edge_index), intent(in) :: self
+      class(t_binned_edge_index), intent(in) :: self !< Binned edge index to query.
       real(kind=dp), intent(in) :: x, y !< Query coordinates.
       integer, intent(in) :: i_poly !< Polygon index in this index.
       type(t_polygon_geometry), intent(in) :: geometry !< Cached polygon coordinates and metadata.
@@ -520,7 +520,7 @@ contains
    elemental function netcell_set_find_netcell(self, x, y) result(k)
    use geometry_module, only: pinpok_raycast
 
-      class(t_netcell_set), intent(in) :: self
+      class(t_netcell_set), intent(in) :: self !< Net-cell set to query.
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
@@ -564,7 +564,7 @@ contains
 
       implicit none
 
-      class(t_netcell_set), intent(in) :: self
+      class(t_netcell_set), intent(in) :: self !< Net-cell set to query.
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
       integer, dimension(:), allocatable, intent(out) :: crossed_cells !> Indices of crossed cells in network_data::netcells

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -36,7 +36,7 @@ module m_cellmask_from_polygon_set
 
    private
 
-   public :: t_polygon_set_cache
+   public :: t_polygon_set
 
    !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
    type, private :: t_polygon_geometry
@@ -74,21 +74,21 @@ module m_cellmask_from_polygon_set
    end interface t_binned_edge_index
 
    !> Complete cached polygon set, including optional acceleration data and lifecycle state.
-   type :: t_polygon_set_cache
+   type :: t_polygon_set
       private
       type(t_polygon_geometry) :: geometry
       type(t_binned_edge_index) :: edge_index
    contains
-      procedure :: point_mask => polygon_set_cache_point_mask
-      procedure :: polygon_contains_point => polygon_set_cache_polygon_contains_point
-      procedure :: find_netcell => polygon_set_cache_find_netcell
-      procedure :: find_cells_crossed_by_polyline => polygon_set_cache_find_cells_crossed_by_polyline
-   end type t_polygon_set_cache
+      procedure :: point_mask => polygon_set_point_mask
+      procedure :: polygon_contains_point => polygon_set_polygon_contains_point
+      procedure :: find_netcell => polygon_set_find_netcell
+      procedure :: find_cells_crossed_by_polyline => polygon_set_find_cells_crossed_by_polyline
+   end type t_polygon_set
 
-   interface t_polygon_set_cache
-      module procedure construct_polygon_set_cache
+   interface t_polygon_set
+      module procedure construct_polygon_set
       module procedure construct_netcell_polygon_cache
-   end interface t_polygon_set_cache
+   end interface t_polygon_set
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
@@ -110,26 +110,29 @@ contains
       first_point = geometry%polygon_start(i_poly)
       last_point = geometry%polygon_end(i_poly)
       num_points = last_point - first_point + 1
+
       local_bin = this%get_bin(y, geometry%y_min(i_poly), this%polygon_bin_scale(i_poly), this%polygon_num_bins(i_poly))
       global_bin = this%polygon_bin_start(i_poly) + local_bin - 1
+
       candidate_first = this%bin_offsets(global_bin)
       candidate_last = this%bin_offsets(global_bin + 1) - 1
+
       is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
                                  this%edge_indices(candidate_first:candidate_last))
    end function binned_edge_index_point_is_inside
 
    !> Construct a consistent polygon cache from packed coordinates separated by missing values.
-   function construct_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning) result(cache)
+   function construct_polygon_set(x_poly, y_poly, z_poly, enable_binning) result(cache)
       real(kind=dp), intent(in) :: x_poly(:), y_poly(:), z_poly(:) !< Packed polygon coordinate arrays.
       logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index for large polygon sets.
-      type(t_polygon_set_cache) :: cache
+      type(t_polygon_set) :: cache
 
       cache%geometry = t_polygon_geometry(x_poly, y_poly, z_poly)
       if (enable_binning .and. cache%geometry%polygon_count > 0) then
          cache%edge_index = t_binned_edge_index(cache%geometry)
       end if
 
-   end function construct_polygon_set_cache
+   end function construct_polygon_set
 
    !> Construct polygon geometry and metadata from packed coordinates separated by missing values.
    function construct_polygon_geometry(x_poly, y_poly, z_poly) result(geometry)
@@ -202,8 +205,8 @@ contains
    end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
-   elemental function polygon_set_cache_point_mask(this, x, y) result(mask)
-      class(t_polygon_set_cache), intent(in) :: this
+   elemental function polygon_set_point_mask(this, x, y) result(mask)
+      class(t_polygon_set), intent(in) :: this
       integer :: mask
       real(kind=dp), intent(in) :: x, y !< Point coordinates
 
@@ -253,13 +256,13 @@ contains
          end if
       end associate
 
-   end function polygon_set_cache_point_mask
+   end function polygon_set_point_mask
 
    !> Test whether a point lies inside one cached polygon.
-   elemental function polygon_set_cache_polygon_contains_point(this, x, y, i_poly) result(is_inside)
+   elemental function polygon_set_polygon_contains_point(this, x, y, i_poly) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
-      class(t_polygon_set_cache), intent(in) :: this
+      class(t_polygon_set), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
@@ -279,10 +282,10 @@ contains
          end if
       end associate
 
-   end function polygon_set_cache_polygon_contains_point
+   end function polygon_set_polygon_contains_point
 
    !> Build a latitude-binned edge index for the complete polygon set.
-   !!
+
    !! A horizontal ray can intersect only edges whose vertical extent contains the query y-coordinate.
    !! The index stores those candidate edges per latitude bin. It changes only which edges reach the
    !! existing ray-casting calculation; it does not approximate or simplify polygon geometry.
@@ -453,7 +456,7 @@ contains
       use network_data
       use m_alloc
 
-      type(t_polygon_set_cache) :: cache
+      type(t_polygon_set) :: cache
       integer :: k, n, k1, total_points, ipoint
       real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init
 
@@ -487,14 +490,14 @@ contains
          zpl_init(ipoint) = dmiss
       end do
 
-      cache = t_polygon_set_cache(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
+      cache = t_polygon_set(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
    end function construct_netcell_polygon_cache
 
 !> Fast replacement for INCELLS using cached net-cell geometry.
-   elemental function polygon_set_cache_find_netcell(this, x, y) result(k)
+   elemental function polygon_set_find_netcell(this, x, y) result(k)
 
-      class(t_polygon_set_cache), intent(in) :: this
+      class(t_polygon_set), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
@@ -524,17 +527,17 @@ contains
          end do
       end associate
 
-   end function polygon_set_cache_find_netcell
+   end function polygon_set_find_netcell
 
 !> Find all cells crossed by polyline using brute force on cached geometry. The routine is inclusive of edge cases (touching edges or vertices).
-   subroutine polygon_set_cache_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
+   subroutine polygon_set_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
       use m_alloc, only: realloc
       use network_data, only: nump
       use m_missing, only: dmiss
 
       implicit none
 
-      class(t_polygon_set_cache), intent(in) :: this
+      class(t_polygon_set), intent(in) :: this
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
       integer, dimension(:), allocatable, intent(out) :: crossed_cells !> Indices of crossed cells in network_data::netcells
@@ -566,14 +569,14 @@ contains
          end if
       end if
 
-   end subroutine polygon_set_cache_find_cells_crossed_by_polyline
+   end subroutine polygon_set_find_cells_crossed_by_polyline
 
 !> Find all cells that a segment crosses and mark them in cellmask
    subroutine find_cells_for_segment(cache, xa, ya, xb, yb, cellmask)
 
       implicit none
 
-      class(t_polygon_set_cache), intent(in) :: cache
+      class(t_polygon_set), intent(in) :: cache
       real(kind=dp), intent(in) :: xa, ya, xb, yb !< Segment endpoints
       integer, intent(inout) :: cellmask(:) !< Cell mask array: 1=crossed, 0=not crossed
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/m_cellmask_from_polygon_set.f90
@@ -36,9 +36,7 @@ module m_cellmask_from_polygon_set
 
    private
 
-   public :: cellmask_from_polygon_set_init, cellmask_from_polygon_set_cleanup, cellmask_from_polygon_set, pinpok_elemental
-   public :: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
-   public :: find_cells_crossed_by_polyline
+   public :: t_polygon_set_cache
 
    !> Coordinates and per-polygon metadata shared by masking and net-cell lookup.
    type, private :: t_polygon_geometry
@@ -76,16 +74,21 @@ module m_cellmask_from_polygon_set
    end interface t_binned_edge_index
 
    !> Complete cached polygon set, including optional acceleration data and lifecycle state.
-   type, private :: t_polygon_set_cache
+   type :: t_polygon_set_cache
+      private
       type(t_polygon_geometry) :: geometry
       type(t_binned_edge_index) :: edge_index
+   contains
+      procedure :: point_mask => polygon_set_cache_point_mask
+      procedure :: polygon_contains_point => polygon_set_cache_polygon_contains_point
+      procedure :: find_netcell => polygon_set_cache_find_netcell
+      procedure :: find_cells_crossed_by_polyline => polygon_set_cache_find_cells_crossed_by_polyline
    end type t_polygon_set_cache
 
    interface t_polygon_set_cache
       module procedure construct_polygon_set_cache
+      module procedure construct_netcell_polygon_cache
    end interface t_polygon_set_cache
-
-   type(t_polygon_set_cache), allocatable :: polygon_cache
 
    integer, parameter :: max_edge_bins = 1024 !< Maximum number of latitude bins per polygon.
    integer(kind=int64), parameter :: max_memberships_per_edge = 8_int64 !< Memory/work cap for vertically long edges.
@@ -114,16 +117,6 @@ contains
       is_inside = pinpok_raycast(x, y, geometry%x(first_point:last_point), geometry%y(first_point:last_point), num_points, &
                                  this%edge_indices(candidate_first:candidate_last))
    end function binned_edge_index_point_is_inside
-
-   !> Populate the module-level polygon cache and optional acceleration data.
-   subroutine cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
-      integer, intent(in) :: polygon_points !< Number of polygon points.
-      real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinates.
-      logical, intent(in) :: enable_binning !< Whether to build a latitude-binned edge index.
-
-      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning)
-
-   end subroutine cellmask_from_polygon_set_init
 
    !> Construct a consistent polygon cache from packed coordinates separated by missing values.
    function construct_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning) result(cache)
@@ -209,7 +202,8 @@ contains
    end function construct_polygon_geometry
 
    !> Check if a point should be masked, either is_inside a dry-area polygon or outside an enclosure polygon.
-   elemental function cellmask_from_polygon_set(x, y) result(mask)
+   elemental function polygon_set_cache_point_mask(this, x, y) result(mask)
+      class(t_polygon_set_cache), intent(in) :: this
       integer :: mask
       real(kind=dp), intent(in) :: x, y !< Point coordinates
 
@@ -217,11 +211,7 @@ contains
       logical :: found_inside_enclosure, is_inside
 
       mask = 0
-      if (.not. allocated(polygon_cache)) then
-         return
-      end if
-
-      associate (geometry => polygon_cache%geometry)
+      associate (geometry => this%geometry)
          count_drypoint = 0
          found_inside_enclosure = .false.
 
@@ -234,7 +224,7 @@ contains
             end if
 
             ! Point-in-polygon test
-            is_inside = pinpok_elemental(x, y, i_poly)
+            is_inside = this%polygon_contains_point(x, y, i_poly)
 
             if (is_inside) then
                if (geometry%is_enclosure(i_poly)) then
@@ -263,21 +253,13 @@ contains
          end if
       end associate
 
-   end function cellmask_from_polygon_set
-
-   !> Clean up module-level cellmask polygon data structures.
-   subroutine cellmask_from_polygon_set_cleanup()
-
-      if (allocated(polygon_cache)) then
-         deallocate (polygon_cache)
-      end if
-
-   end subroutine cellmask_from_polygon_set_cleanup
+   end function polygon_set_cache_point_mask
 
    !> Test whether a point lies inside one cached polygon.
-   elemental function pinpok_elemental(x, y, i_poly) result(is_inside)
+   elemental function polygon_set_cache_polygon_contains_point(this, x, y, i_poly) result(is_inside)
       use geometry_module, only: pinpok_raycast
 
+      class(t_polygon_set_cache), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< Point coordinates
       integer, intent(in) :: i_poly !< Polygon index
       logical :: is_inside !< Result
@@ -285,19 +267,19 @@ contains
       integer :: i_start, i_end, n_points
 
       ! Get bounds for this polygon from module arrays
-      associate (geometry => polygon_cache%geometry)
+      associate (geometry => this%geometry)
          i_start = geometry%polygon_start(i_poly)
          i_end = geometry%polygon_end(i_poly)
          n_points = i_end - i_start + 1
 
-         if (allocated(polygon_cache%edge_index%edge_indices)) then
-            is_inside = polygon_cache%edge_index%point_is_inside(x, y, i_poly, geometry)
+         if (allocated(this%edge_index%edge_indices)) then
+            is_inside = this%edge_index%point_is_inside(x, y, i_poly, geometry)
          else
             is_inside = pinpok_raycast(x, y, geometry%x(i_start:i_end), geometry%y(i_start:i_end), n_points)
          end if
       end associate
 
-   end function pinpok_elemental
+   end function polygon_set_cache_polygon_contains_point
 
    !> Build a latitude-binned edge index for the complete polygon set.
    !!
@@ -466,11 +448,12 @@ contains
       i_bin = max(1, min(bins, i_bin))
    end function binned_edge_index_get_bin
 
-   !> Initialize xpl, ypl, zpl arrays with all netcell geometries (called once)
-   subroutine init_cell_geom_as_polylines()
+   !> Construct a polygon cache containing all net-cell geometries.
+   function construct_netcell_polygon_cache() result(cache)
       use network_data
       use m_alloc
 
+      type(t_polygon_set_cache) :: cache
       integer :: k, n, k1, total_points, ipoint
       real(kind=dp), allocatable, dimension(:) :: xpl_init, ypl_init, zpl_init
 
@@ -504,20 +487,14 @@ contains
          zpl_init(ipoint) = dmiss
       end do
 
-      ! initialize the cellmask module with these polygons
-      ! this builds bounding boxes and polygon indices
-      call cellmask_from_polygon_set_init(ipoint, xpl_init, ypl_init, zpl_init, enable_binning=.false.)
+      cache = t_polygon_set_cache(xpl_init, ypl_init, zpl_init, enable_binning=.false.)
 
-   end subroutine init_cell_geom_as_polylines
+   end function construct_netcell_polygon_cache
 
-   !> call general polygon cleanup and restore previous polygon data
-   subroutine cleanup_cell_geom_polylines()
-      call cellmask_from_polygon_set_cleanup()
-   end subroutine cleanup_cell_geom_polylines
+!> Fast replacement for INCELLS using cached net-cell geometry.
+   elemental function polygon_set_cache_find_netcell(this, x, y) result(k)
 
-!> Fast replacement for INCELLS using cached geometry in global polygon arrays
-   elemental function point_find_netcell(x, y) result(k)
-
+      class(t_polygon_set_cache), intent(in) :: this
       real(kind=dp), intent(in) :: x, y !< coordinates of point to locate enclosing netcell
       integer :: k !< cell number of enclosing netcell, or 0 if not found
 
@@ -526,7 +503,7 @@ contains
 
       k = 0
 
-      associate (geometry => polygon_cache%geometry)
+      associate (geometry => this%geometry)
          ! Loop over all netcell polygons with fast bounding box checks
          do i_poly = 1, geometry%polygon_count
 
@@ -537,7 +514,7 @@ contains
             end if
 
             ! Detailed point-in-polygon check
-            is_inside = pinpok_elemental(x, y, i_poly)
+            is_inside = this%polygon_contains_point(x, y, i_poly)
 
             if (is_inside) then
                ! cell index equals polygon index
@@ -547,16 +524,17 @@ contains
          end do
       end associate
 
-   end function point_find_netcell
+   end function polygon_set_cache_find_netcell
 
 !> Find all cells crossed by polyline using brute force on cached geometry. The routine is inclusive of edge cases (touching edges or vertices).
-   subroutine find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+   subroutine polygon_set_cache_find_cells_crossed_by_polyline(this, xpoly, ypoly, crossed_cells, error)
       use m_alloc, only: realloc
       use network_data, only: nump
       use m_missing, only: dmiss
 
       implicit none
 
+      class(t_polygon_set_cache), intent(in) :: this
       real(kind=dp), dimension(:), intent(in) :: xpoly !< Polyline x-coordinates
       real(kind=dp), dimension(:), intent(in) :: ypoly !< Polyline y-coordinates
       integer, dimension(:), allocatable, intent(out) :: crossed_cells !> Indices of crossed cells in network_data::netcells
@@ -577,24 +555,25 @@ contains
 
       ! Process each segment and put the result in cellmask
       do i = 1, npoly - 1
-         call find_cells_for_segment(xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
+         call find_cells_for_segment(this, xpoly(i), ypoly(i), xpoly(i + 1), ypoly(i + 1), cellmask)
       end do
 
       crossed_cells = pack([(i, i=1, nump)], mask=(cellmask == 1))
       if (size(crossed_cells) == 0) then !> check whether the whole polyline lies in a single cell if no boundaries were crossed
-         i = point_find_netcell(xpoly(1), ypoly(1))
+         i = this%find_netcell(xpoly(1), ypoly(1))
          if (i > 0) then
             crossed_cells = [i]
          end if
       end if
 
-   end subroutine find_cells_crossed_by_polyline
+   end subroutine polygon_set_cache_find_cells_crossed_by_polyline
 
 !> Find all cells that a segment crosses and mark them in cellmask
-   subroutine find_cells_for_segment(xa, ya, xb, yb, cellmask)
+   subroutine find_cells_for_segment(cache, xa, ya, xb, yb, cellmask)
 
       implicit none
 
+      class(t_polygon_set_cache), intent(in) :: cache
       real(kind=dp), intent(in) :: xa, ya, xb, yb !< Segment endpoints
       integer, intent(inout) :: cellmask(:) !< Cell mask array: 1=crossed, 0=not crossed
 
@@ -609,7 +588,7 @@ contains
       seg_ymin = min(ya, yb)
       seg_ymax = max(ya, yb)
 
-      associate (geometry => polygon_cache%geometry)
+      associate (geometry => cache%geometry)
          !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(i_start, i_end, n_points, i, i_point, ip1, intersects)
          do i_poly = 1, geometry%polygon_count
             ! Skip if already marked

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -58,7 +58,7 @@ contains
 
       call realloc(mask, num_netcells, keepexisting=.false., fill=0)
 
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly)
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, num_netcells, x_points, y_points)
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -65,7 +65,7 @@ contains
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do k = 1, num_netcells
-         mask(k) = polygon_cache%is_masked(x_points(k), y_points(k))
+         mask(k) = merge(1, 0, polygon_cache%is_masked(x_points(k), y_points(k)))
       end do
       !$OMP END PARALLEL DO
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -30,7 +30,7 @@
 !> Wrapper around cellmask_from_polygon_set that uses OpenMP to parallelize the loop over all points if not in MPI mode
 module m_pol_to_cellmask
    use precision, only: dp
-   use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+   use m_cellmask_from_polygon_set, only: t_polygon_set
 
    implicit none
 
@@ -52,7 +52,7 @@ contains
       integer, dimension(:), allocatable :: mask !< Output mask array (1 if inside polygon, 0 if outside)
 
       integer :: k
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       if (polygon_points == 0) then
          return
@@ -60,7 +60,7 @@ contains
 
       call realloc(mask, num_netcells, keepexisting=.false., fill=0)
 
-      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning)
+      polygon_cache = t_polygon_set(x_poly, y_poly, z_poly, enable_binning)
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -30,7 +30,7 @@
 !> Wrapper around cellmask_from_polygon_set that uses OpenMP to parallelize the loop over all points if not in MPI mode
 module m_pol_to_cellmask
    use precision, only: dp
-   use m_cellmask_from_polygon_set, only: cellmask_from_polygon_set_init, cellmask_from_polygon_set_cleanup, cellmask_from_polygon_set
+   use m_cellmask_from_polygon_set, only: t_polygon_set_cache
 
    implicit none
 
@@ -52,6 +52,7 @@ contains
       integer, dimension(:), allocatable :: mask !< Output mask array (1 if inside polygon, 0 if outside)
 
       integer :: k
+      type(t_polygon_set_cache) :: polygon_cache
 
       if (polygon_points == 0) then
          return
@@ -59,16 +60,14 @@ contains
 
       call realloc(mask, num_netcells, keepexisting=.false., fill=0)
 
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
+      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning)
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do k = 1, num_netcells
-         mask(k) = cellmask_from_polygon_set(x_points(k), y_points(k))
+         mask(k) = polygon_cache%point_mask(x_points(k), y_points(k))
       end do
       !$OMP END PARALLEL DO
-
-      call cellmask_from_polygon_set_cleanup()
 
    end function pol_to_cellmask
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -46,7 +46,7 @@ contains
 
       integer, intent(in) :: polygon_points !< Number of polygon points
       integer, intent(in) :: num_netcells !< Number of points to mask
-      real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinate arrays
+      real(kind=dp), dimension(polygon_points), intent(in) :: x_poly, y_poly, z_poly !< Polygon coordinate arrays
       real(kind=dp), intent(in), dimension(:) :: x_points, y_points !< Point coordinates to mask
       logical, intent(in) :: enable_binning !< Whether to use latitude bins for large polygon sets.
       integer, dimension(:), allocatable :: mask !< Output mask array (1 if inside polygon, 0 if outside)
@@ -122,7 +122,7 @@ contains
 
       if (ndx1d > 0) then
          mask(ndx2d + 1:ndxi) = pol_to_cellmask(npl, xpl, ypl, zpl, ndx1d, xz(ndx2d + 1:ndxi), &
-                                               yz(ndx2d + 1:ndxi), enable_binning=.false.)
+                                                yz(ndx2d + 1:ndxi), enable_binning=.false.)
       end if
 
       call delpol()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -65,7 +65,7 @@ contains
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
       do k = 1, num_netcells
-         mask(k) = polygon_cache%point_mask(x_points(k), y_points(k))
+         mask(k) = polygon_cache%is_masked(x_points(k), y_points(k))
       end do
       !$OMP END PARALLEL DO
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -41,13 +41,14 @@ module m_pol_to_cellmask
 contains
 
    !> Create a cellmask from a set of x,y coordinates and a set of polygon points. Any  point inside the polygon is masked as 1.
-   function pol_to_cellmask(polygon_points, x_poly, y_poly, z_poly, num_netcells, x_points, y_points) result(mask)
+   function pol_to_cellmask(polygon_points, x_poly, y_poly, z_poly, num_netcells, x_points, y_points, enable_binning) result(mask)
       use m_alloc, only: realloc
 
       integer, intent(in) :: polygon_points !< Number of polygon points
       integer, intent(in) :: num_netcells !< Number of points to mask
       real(kind=dp), intent(in) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points) !< Polygon coordinate arrays
       real(kind=dp), intent(in), dimension(:) :: x_points, y_points !< Point coordinates to mask
+      logical, intent(in) :: enable_binning !< Whether to use latitude bins for large polygon sets.
       integer, dimension(:), allocatable :: mask !< Output mask array (1 if inside polygon, 0 if outside)
 
       integer :: k
@@ -58,7 +59,7 @@ contains
 
       call realloc(mask, num_netcells, keepexisting=.false., fill=0)
 
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning)
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)
@@ -117,11 +118,12 @@ contains
       allocate (mask(ndxi), source=0)
 
       if (ndx2d > 0) then
-         mask(1:ndx2d) = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw(1:nump), yzw(1:nump))
+         mask(1:ndx2d) = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw(1:nump), yzw(1:nump), enable_binning=.false.)
       end if
 
       if (ndx1d > 0) then
-         mask(ndx2d + 1:ndxi) = pol_to_cellmask(npl, xpl, ypl, zpl, ndx1d, xz(ndx2d + 1:ndxi), yz(ndx2d + 1:ndxi))
+         mask(ndx2d + 1:ndxi) = pol_to_cellmask(npl, xpl, ypl, zpl, ndx1d, xz(ndx2d + 1:ndxi), &
+                                               yz(ndx2d + 1:ndxi), enable_binning=.false.)
       end if
 
       call delpol()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/pol_to_cellmask.F90
@@ -58,7 +58,7 @@ contains
 
       call realloc(mask, num_netcells, keepexisting=.false., fill=0)
 
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, num_netcells, x_points, y_points)
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
 
       !> Dynamic scheduling in case of unequal work, chunksize guided
       !$OMP PARALLEL DO SCHEDULE(GUIDED)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2752,7 +2752,7 @@ contains
       use m_filez, only: doclose
       use m_physcoef, only: dicoww
       use m_array_or_scalar, only: realloc
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
       use unstruc_inifields, only: finalize_1dfield_global_values
       use network_data, only: LINK_1D
 
@@ -2760,7 +2760,7 @@ contains
       logical :: hyst_dummy(2)
       real(kind=dp) :: area, width, hdx
       type(t_storage), pointer :: stors(:)
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       call finalize_waq_spatial_fields()
       call finalize_source_sinks()
@@ -3125,7 +3125,7 @@ contains
                end if
             end do
          end if
-         polygon_cache = t_polygon_set()
+         polygon_cache = t_netcell_set()
          !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(ja)
          do n = ndx2D + 1, ndxi
             if (kcs(n) == 1 .and. bare(n) > 0.0_dp) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2752,7 +2752,7 @@ contains
       use m_filez, only: doclose
       use m_physcoef, only: dicoww
       use m_array_or_scalar, only: realloc
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
       use unstruc_inifields, only: finalize_1dfield_global_values
       use network_data, only: LINK_1D
 
@@ -2760,7 +2760,7 @@ contains
       logical :: hyst_dummy(2)
       real(kind=dp) :: area, width, hdx
       type(t_storage), pointer :: stors(:)
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       call finalize_waq_spatial_fields()
       call finalize_source_sinks()
@@ -3125,7 +3125,7 @@ contains
                end if
             end do
          end if
-         polygon_cache = t_polygon_set_cache()
+         polygon_cache = t_polygon_set()
          !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(ja)
          do n = ndx2D + 1, ndxi
             if (kcs(n) == 1 .and. bare(n) > 0.0_dp) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -42,8 +42,8 @@ module fm_external_forcings
 
    private
 
-      public set_external_forcings_boundaries, adduniformtimerelation_objects, flow_initexternalforcings, findexternalboundarypoints, &
-         allocatewindarrays, init_spatial_fields, init_new, finalize_offline_wave_input_requirements
+   public set_external_forcings_boundaries, adduniformtimerelation_objects, flow_initexternalforcings, findexternalboundarypoints, &
+      allocatewindarrays, init_spatial_fields, init_new, finalize_offline_wave_input_requirements
 
    integer, parameter :: max_registered_item_id = 512
    integer :: max_ext_bnd_items = 64 ! Starting size, will grow dynamically when needed.
@@ -2759,7 +2759,7 @@ contains
       integer :: j, k, ierr, l, n, itp, kk, k1, k2, nstor, i, ja
       logical :: hyst_dummy(2)
       real(kind=dp) :: area, width, hdx
-      type(t_storage), pointer :: stors(:)
+      type(t_storage), dimension(:), pointer :: stors
       type(t_netcell_set) :: netcell_cache
 
       call finalize_waq_spatial_fields()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2760,7 +2760,7 @@ contains
       logical :: hyst_dummy(2)
       real(kind=dp) :: area, width, hdx
       type(t_storage), pointer :: stors(:)
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       call finalize_waq_spatial_fields()
       call finalize_source_sinks()
@@ -3125,11 +3125,11 @@ contains
                end if
             end do
          end if
-         polygon_cache = t_netcell_set()
+         netcell_cache = t_netcell_set()
          !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(ja)
          do n = ndx2D + 1, ndxi
             if (kcs(n) == 1 .and. bare(n) > 0.0_dp) then
-               ja = polygon_cache%find_netcell(Xz(n), Yz(n))
+               ja = netcell_cache%find_netcell(Xz(n), Yz(n))
                if (ja >= 1) then
                   bare(n) = 0.0_dp
                end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -2752,7 +2752,7 @@ contains
       use m_filez, only: doclose
       use m_physcoef, only: dicoww
       use m_array_or_scalar, only: realloc
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
       use unstruc_inifields, only: finalize_1dfield_global_values
       use network_data, only: LINK_1D
 
@@ -2760,6 +2760,7 @@ contains
       logical :: hyst_dummy(2)
       real(kind=dp) :: area, width, hdx
       type(t_storage), pointer :: stors(:)
+      type(t_polygon_set_cache) :: polygon_cache
 
       call finalize_waq_spatial_fields()
       call finalize_source_sinks()
@@ -3124,19 +3125,17 @@ contains
                end if
             end do
          end if
-         call init_cell_geom_as_polylines()
+         polygon_cache = t_polygon_set_cache()
          !$OMP PARALLEL DO SCHEDULE(GUIDED) PRIVATE(ja)
          do n = ndx2D + 1, ndxi
             if (kcs(n) == 1 .and. bare(n) > 0.0_dp) then
-               ja = point_find_netcell(Xz(n), Yz(n))
+               ja = polygon_cache%find_netcell(Xz(n), Yz(n))
                if (ja >= 1) then
                   bare(n) = 0.0_dp
                end if
             end if
          end do
          !$OMP END PARALLEL DO
-         call cleanup_cell_geom_polylines()
-
          a1ini = sum(bare(1:ndxi))
       end if
       deallocate (sah)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1601,7 +1601,7 @@ contains
       use string_module, only: strcmpi, str_tolower
       use network_data
       use m_flow
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
       use m_alloc, only: realloc
       use m_find_flownode, only: find_nearest_flownodes
       use m_GlobalParameters, only: INDTP_2D
@@ -1634,7 +1634,7 @@ contains
 
       type(tree_data), pointer :: block_ptr
       type(t_Bubblescreen) :: bubblescreen
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
       integer :: n_cells
       integer, dimension(:), allocatable :: bubblescreen_cells
 
@@ -1643,7 +1643,7 @@ contains
       num_bubblescreen_source_sinks = 0
       num_items_in_file = tree_num_nodes(bnd_ptr)
 
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Loop over all [blocks] in the external forcings file and count the [bubblescreen] blocks
       do i = 1, num_items_in_file

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1634,7 +1634,7 @@ contains
 
       type(tree_data), pointer :: block_ptr
       type(t_Bubblescreen) :: bubblescreen
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
       integer :: n_cells
       integer, dimension(:), allocatable :: bubblescreen_cells
 
@@ -1643,7 +1643,7 @@ contains
       num_bubblescreen_source_sinks = 0
       num_items_in_file = tree_num_nodes(bnd_ptr)
 
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Loop over all [blocks] in the external forcings file and count the [bubblescreen] blocks
       do i = 1, num_items_in_file
@@ -1681,7 +1681,7 @@ contains
                   end if
                end if
                ! Find cells crossed by the polyline and pre-init the bubblescreen data structure
-               call polygon_cache%find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, &
+               call netcell_cache%find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, &
                                                                  bubblescreen%flowcell_indices, error)
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
                n_cells = bubblescreen%num_flowcells

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1601,7 +1601,7 @@ contains
       use string_module, only: strcmpi, str_tolower
       use network_data
       use m_flow
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
       use m_alloc, only: realloc
       use m_find_flownode, only: find_nearest_flownodes
       use m_GlobalParameters, only: INDTP_2D
@@ -1634,7 +1634,7 @@ contains
 
       type(tree_data), pointer :: block_ptr
       type(t_Bubblescreen) :: bubblescreen
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
       integer :: n_cells
       integer, dimension(:), allocatable :: bubblescreen_cells
 
@@ -1643,7 +1643,7 @@ contains
       num_bubblescreen_source_sinks = 0
       num_items_in_file = tree_num_nodes(bnd_ptr)
 
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Loop over all [blocks] in the external forcings file and count the [bubblescreen] blocks
       do i = 1, num_items_in_file

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1601,7 +1601,7 @@ contains
       use string_module, only: strcmpi, str_tolower
       use network_data
       use m_flow
-      use m_cellmask_from_polygon_set, only: find_cells_crossed_by_polyline, init_cell_geom_as_polylines, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
       use m_alloc, only: realloc
       use m_find_flownode, only: find_nearest_flownodes
       use m_GlobalParameters, only: INDTP_2D
@@ -1634,6 +1634,7 @@ contains
 
       type(tree_data), pointer :: block_ptr
       type(t_Bubblescreen) :: bubblescreen
+      type(t_polygon_set_cache) :: polygon_cache
       integer :: n_cells
       integer, dimension(:), allocatable :: bubblescreen_cells
 
@@ -1642,8 +1643,7 @@ contains
       num_bubblescreen_source_sinks = 0
       num_items_in_file = tree_num_nodes(bnd_ptr)
 
-      ! Initialize cache
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       ! Loop over all [blocks] in the external forcings file and count the [bubblescreen] blocks
       do i = 1, num_items_in_file
@@ -1681,7 +1681,8 @@ contains
                   end if
                end if
                ! Find cells crossed by the polyline and pre-init the bubblescreen data structure
-               call find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, bubblescreen%flowcell_indices, error)
+               call polygon_cache%find_cells_crossed_by_polyline(polygon_x_coordinates, polygon_y_coordinates, &
+                                                                 bubblescreen%flowcell_indices, error)
                bubblescreen%num_flowcells = size(bubblescreen%flowcell_indices)
                n_cells = bubblescreen%num_flowcells
                ! we need the global number of bubblescreen cells, otherswise when doing addSourceSink the vectors will be re-allocated
@@ -1702,7 +1703,6 @@ contains
          end if
       end do
 
-      call cleanup_cell_geom_polylines()
       ! initialize global geometry
       call realloc(nodeCountBubbleScreen, size(bubblescreens), fill=0)
       nNodesBubbleScreen = 0
@@ -1746,7 +1746,6 @@ contains
       use messageHandling, only: err_flush, msgbuf, msg_flush
       use tree_data_types, only: tree_data
       use m_polygon, only: xpl, ypl, zpl, npl
-      use m_cellmask_from_polygon_set, only: find_cells_crossed_by_polyline
       use network_data
       use m_flow
       use fm_external_forcings_data

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
@@ -488,15 +488,15 @@ contains
    !! TODO, optionally: lump sources/sinks in the same cell
    !! TODO, optionally: dealloc self%sink/self%source arrays after use
    subroutine precice_adapter_add_to_fm_administration(self)
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
 
       class(precice_adapter_t), intent(inout) :: self
       integer :: i
       integer :: sink_cell
       integer :: source_cell
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
       source_sinks%num_total = source_sinks%num_total - source_sinks%num_nearfield
       source_sinks%num_nearfield = 0
       

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
@@ -494,15 +494,15 @@ contains
       integer :: i
       integer :: sink_cell
       integer :: source_cell
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
       source_sinks%num_total = source_sinks%num_total - source_sinks%num_nearfield
       source_sinks%num_nearfield = 0
       
       do i = 1, self%mesh_sources_sinks_size
-         sink_cell = polygon_cache%find_netcell(self%sinks_x(i), self%sinks_y(i))
-         source_cell = polygon_cache%find_netcell(self%sources_x(i), self%sources_y(i))
+         sink_cell = netcell_cache%find_netcell(self%sinks_x(i), self%sinks_y(i))
+         source_cell = netcell_cache%find_netcell(self%sources_x(i), self%sources_y(i))
          ! sink_cell=0 and source_cell=0: 
          !    Both source and sink location are outside this domain
          !    Still this source_sink needs to be added to avoid hampering the MPI communication in D-Flow FM (see subroutine reduce_srsn)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
@@ -488,15 +488,15 @@ contains
    !! TODO, optionally: lump sources/sinks in the same cell
    !! TODO, optionally: dealloc self%sink/self%source arrays after use
    subroutine precice_adapter_add_to_fm_administration(self)
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
 
       class(precice_adapter_t), intent(inout) :: self
       integer :: i
       integer :: sink_cell
       integer :: source_cell
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
       source_sinks%num_total = source_sinks%num_total - source_sinks%num_nearfield
       source_sinks%num_nearfield = 0
       

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
@@ -488,20 +488,21 @@ contains
    !! TODO, optionally: lump sources/sinks in the same cell
    !! TODO, optionally: dealloc self%sink/self%source arrays after use
    subroutine precice_adapter_add_to_fm_administration(self)
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
 
       class(precice_adapter_t), intent(inout) :: self
       integer :: i
       integer :: sink_cell
       integer :: source_cell
+      type(t_polygon_set_cache) :: polygon_cache
 
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
       source_sinks%num_total = source_sinks%num_total - source_sinks%num_nearfield
       source_sinks%num_nearfield = 0
       
       do i = 1, self%mesh_sources_sinks_size
-         sink_cell = point_find_netcell(self%sinks_x(i), self%sinks_y(i))
-         source_cell = point_find_netcell(self%sources_x(i), self%sources_y(i))
+         sink_cell = polygon_cache%find_netcell(self%sinks_x(i), self%sinks_y(i))
+         source_cell = polygon_cache%find_netcell(self%sources_x(i), self%sources_y(i))
          ! sink_cell=0 and source_cell=0: 
          !    Both source and sink location are outside this domain
          !    Still this source_sink needs to be added to avoid hampering the MPI communication in D-Flow FM (see subroutine reduce_srsn)
@@ -529,7 +530,6 @@ contains
          end if
       end do
 
-      call cleanup_cell_geom_polylines()
    end subroutine precice_adapter_add_to_fm_administration
 
 end module precice_adapter

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -3,7 +3,7 @@ module test_pol_to_cellmask
    use precision, only: dp
    use m_missing, only: dmiss
    use network_data, only: cellmask, npl, nump, xzw, yzw, xpl, ypl, zpl, nump1d2d
-   use m_cellmask_from_polygon_set, only: t_polygon_set
+   use m_cellmask_from_polygon_set, only: t_netcell_set, t_polygon_set
    use geometry_module, only: pinpok_legacy, pinpok_raycast
    use m_pol_to_cellmask, only: pol_to_cellmask, cell_mask_from_polygon_file
 
@@ -574,7 +574,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -583,7 +583,7 @@ contains
       call setup_simple_netcells()
 
       ! Initialize cache for new implementation
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Test 1: Point clearly inside first cell (0,0 to 10,10)
       xa = 5.0_dp
@@ -637,7 +637,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -645,7 +645,7 @@ contains
       nump = 3
       call setup_complex_netcells()
 
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Test 1: Inside triangle (cell 1)
       xa = 5.0_dp
@@ -689,7 +689,7 @@ contains
 
       integer :: kin_old, kin_new, i, mismatches
       real(kind=dp) :: xa, ya
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -697,7 +697,7 @@ contains
       nump = 100
       call setup_grid_netcells(10, 10, 10.0_dp)
 
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       mismatches = 0
 
@@ -730,7 +730,7 @@ contains
 
       integer :: kin1, kin2, kin_old
       real(kind=dp) :: xa, ya
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -743,7 +743,7 @@ contains
       ya = 5.0_dp
 
       ! Initialize cache and query
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
       kin1 = polygon_cache%find_netcell(xa, ya)
 
       ! Query again (should use cached data)
@@ -756,7 +756,7 @@ contains
       call f90_expect_eq(kin1, kin_old, "Cached result should match old implementation")
 
       ! Cleanup and re-initialize
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Query after re-initialization
       kin2 = polygon_cache%find_netcell(xa, ya)
@@ -776,14 +776,14 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
       ! Test 1: Empty grid (nump = 0)
       nump = 0
       call setup_empty_netcells()
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
@@ -797,7 +797,7 @@ contains
       ! Test 2: Single cell
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
@@ -816,7 +816,7 @@ contains
       ! Test 3: Very large coordinates
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       xa = 1.0e6_dp
       ya = 1.0e6_dp
@@ -982,7 +982,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1007,7 +1007,7 @@ contains
       ypoly(2) = 27.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
@@ -1051,7 +1051,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1075,7 +1075,7 @@ contains
       ypoly(3) = 0.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
 
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
@@ -1113,7 +1113,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1135,7 +1135,7 @@ contains
       ypoly(2) = 6.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -86,7 +86,7 @@ contains
       zpl(15) = dmiss
 
       ! Initialize polygon data structures
-      cellmask =  pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw) ! third column in pol-file may be used to specify inside (1), or outside (0) mode, only 0 or 1 allowed.
+      cellmask = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw, enable_binning=.false.) ! third column in pol-file may be used to specify inside (1), or outside (0) mode, only 0 or 1 allowed.
 
       ! Check results:
       ! Cell at (5,5) - inside enclosure, outside dry point -> mask=0
@@ -235,7 +235,7 @@ contains
       zpl(13) = dmiss
 
       ! Initialize polygon data structures
-      cellmask =  pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw) ! third column in pol-file may be used to specify inside (1), or outside (0) mode, only 0 or 1 allowed.
+      cellmask = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw, enable_binning=.false.) ! third column in pol-file may be used to specify inside (1), or outside (0) mode, only 0 or 1 allowed.
 
       ! Check results (odd-even rule):
       ! Cell at (5,5) - inside 1 polygon (outer) -> mask=1

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -509,6 +509,56 @@ contains
    end subroutine test_indexed_polygon_matches_full_scan
    !$f90tw)
 
+   !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_binned_polygon_edge_cases, test_binned_polygon_edge_cases,
+   subroutine test_binned_polygon_edge_cases() bind(C)
+      use m_missing, only: jins
+
+      integer, parameter :: polygon_segments = 6
+      integer, parameter :: points_per_segment = 48
+      integer, parameter :: polygon_points = polygon_segments * points_per_segment + 1
+      integer, parameter :: query_points = 14
+
+      integer :: actual_mask, original_jins, point, segment, step
+      real(kind=dp) :: fraction
+      real(kind=dp) :: vertex_x(polygon_segments + 1), vertex_y(polygon_segments + 1)
+      real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
+      real(kind=dp) :: x_query(query_points), y_query(query_points)
+
+      ! Dense L-shape: the internal horizontal edge at y=1 lies exactly on a latitude-bin boundary.
+      vertex_x = [-1.0_dp, 1.0_dp, 1.0_dp, 0.0_dp, 0.0_dp, -1.0_dp, -1.0_dp]
+      vertex_y = [0.0_dp, 0.0_dp, 1.0_dp, 1.0_dp, 2.0_dp, 2.0_dp, 0.0_dp]
+      do segment = 1, polygon_segments
+         do step = 0, points_per_segment - 1
+            point = (segment - 1) * points_per_segment + step + 1
+            fraction = real(step, dp) / real(points_per_segment, dp)
+            x_poly(point) = vertex_x(segment) + fraction * (vertex_x(segment + 1) - vertex_x(segment))
+            y_poly(point) = vertex_y(segment) + fraction * (vertex_y(segment + 1) - vertex_y(segment))
+         end do
+      end do
+      x_poly(polygon_points) = x_poly(1)
+      y_poly(polygon_points) = y_poly(1)
+      z_poly = 1.0_dp
+
+      x_query = [0.5_dp, -0.5_dp, 0.5_dp, 0.5_dp, 0.5_dp, 0.0_dp, 0.0_dp, 0.0_dp, &
+                 0.0_dp, nearest(0.0_dp, -1.0_dp), nearest(0.0_dp, 1.0_dp), -0.5_dp, 0.0_dp, 2.0_dp]
+      y_query = [0.5_dp, 1.5_dp, 1.5_dp, 1.0_dp, nearest(1.0_dp, -1.0_dp), 1.0_dp, &
+                 nearest(1.0_dp, -1.0_dp), nearest(1.0_dp, 1.0_dp), 1.5_dp, 1.5_dp, 1.5_dp, 2.0_dp, 0.0_dp, 1.0_dp]
+
+      original_jins = jins
+      jins = 1
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
+      do point = 1, query_points
+         actual_mask = cellmask_from_polygon_set(x_query(point), y_query(point))
+         call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
+                                                                   x_poly, y_poly, polygon_points)), &
+                            "Binned and full polygon scans should agree at edges and bin boundaries")
+      end do
+      call cellmask_from_polygon_set_cleanup()
+      jins = original_jins
+
+   end subroutine test_binned_polygon_edge_cases
+   !$f90tw)
+
 !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_incells_basic_functionality, test_incells_basic_functionality,
    subroutine test_incells_basic_functionality() bind(C)
       ! Test basic incells functionality: point inside/outside netcells

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -507,7 +507,7 @@ contains
                                                y_poly(large_polygon_points + 2:polygon_points), 5)
          polygons_containing_point = merge(1, 0, inside_large_polygon) + merge(1, 0, inside_small_polygon)
          expected_mask = modulo(polygons_containing_point, 2)
-         actual_mask = polygon_cache%is_masked(x_query(point), y_query(point))
+         actual_mask = merge(1, 0, polygon_cache%is_masked(x_query(point), y_query(point)))
          call f90_expect_eq(actual_mask, expected_mask, "Indexed and full polygon scans should agree")
       end do
       jins = original_jins
@@ -555,7 +555,7 @@ contains
       jins = 1
       polygon_cache = t_polygon_set(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
-         actual_mask = polygon_cache%is_masked(x_query(point), y_query(point))
+         actual_mask = merge(1, 0, polygon_cache%is_masked(x_query(point), y_query(point)))
          call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
                                                                    x_poly, y_poly, polygon_points)), &
                             "Binned and full polygon scans should agree at edges and bin boundaries")

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -3,7 +3,7 @@ module test_pol_to_cellmask
    use precision, only: dp
    use m_missing, only: dmiss
    use network_data, only: cellmask, npl, nump, xzw, yzw, xpl, ypl, zpl, nump1d2d
-   use m_cellmask_from_polygon_set, only: cellmask_from_polygon_set_init, cellmask_from_polygon_set, cellmask_from_polygon_set_cleanup
+   use m_cellmask_from_polygon_set, only: t_polygon_set_cache
    use geometry_module, only: pinpok_legacy, pinpok_raycast
    use m_pol_to_cellmask, only: pol_to_cellmask, cell_mask_from_polygon_file
 
@@ -467,6 +467,7 @@ contains
       real(kind=dp) :: angle
       real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
       real(kind=dp) :: x_query(query_points), y_query(query_points)
+      type(t_polygon_set_cache) :: polygon_cache
 
       do point = 1, large_polygon_points - 1
          angle = 2.0_dp * pi * real(point - 1, dp) / real(large_polygon_points - 1, dp)
@@ -498,7 +499,7 @@ contains
 
       original_jins = jins
       jins = 1
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
+      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
          inside_large_polygon = pinpok_raycast(x_query(point), y_query(point), x_poly, y_poly, large_polygon_points)
          inside_small_polygon = pinpok_raycast(x_query(point), y_query(point), &
@@ -506,10 +507,9 @@ contains
                                                y_poly(large_polygon_points + 2:polygon_points), 5)
          polygons_containing_point = merge(1, 0, inside_large_polygon) + merge(1, 0, inside_small_polygon)
          expected_mask = modulo(polygons_containing_point, 2)
-         actual_mask = cellmask_from_polygon_set(x_query(point), y_query(point))
+         actual_mask = polygon_cache%point_mask(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, expected_mask, "Indexed and full polygon scans should agree")
       end do
-      call cellmask_from_polygon_set_cleanup()
       jins = original_jins
 
    end subroutine test_indexed_polygon_matches_full_scan
@@ -529,6 +529,7 @@ contains
       real(kind=dp) :: vertex_x(polygon_segments + 1), vertex_y(polygon_segments + 1)
       real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
       real(kind=dp) :: x_query(query_points), y_query(query_points)
+      type(t_polygon_set_cache) :: polygon_cache
 
       ! Dense L-shape: the internal horizontal edge at y=1 lies exactly on a latitude-bin boundary.
       vertex_x = [-1.0_dp, 1.0_dp, 1.0_dp, 0.0_dp, 0.0_dp, -1.0_dp, -1.0_dp]
@@ -552,14 +553,13 @@ contains
 
       original_jins = jins
       jins = 1
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
+      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
-         actual_mask = cellmask_from_polygon_set(x_query(point), y_query(point))
+         actual_mask = polygon_cache%point_mask(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
                                                                    x_poly, y_poly, polygon_points)), &
                             "Binned and full polygon scans should agree at edges and bin boundaries")
       end do
-      call cellmask_from_polygon_set_cleanup()
       jins = original_jins
 
    end subroutine test_binned_polygon_edge_cases
@@ -569,12 +569,12 @@ contains
    subroutine test_incells_basic_functionality() bind(C)
       ! Test basic incells functionality: point inside/outside netcells
       use gridoperations, only: incells
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
       use network_data, only: netcell, nump, xk, yk
       use m_alloc, only: realloc
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -583,13 +583,13 @@ contains
       call setup_simple_netcells()
 
       ! Initialize cache for new implementation
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       ! Test 1: Point clearly inside first cell (0,0 to 10,10)
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside first cell")
       call f90_expect_eq(kin_new, 1, "Should be in cell 1")
 
@@ -597,7 +597,7 @@ contains
       xa = 15.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside second cell")
       call f90_expect_eq(kin_new, 2, "Should be in cell 2")
 
@@ -605,7 +605,7 @@ contains
       xa = 25.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point outside all cells")
       call f90_expect_eq(kin_new, 0, "Should be in no cell")
 
@@ -613,18 +613,17 @@ contains
       xa = 10.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on cell boundary")
 
       ! Test 5: Point on cell corner
       xa = 0.0_dp
       ya = 0.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on cell corner")
 
       ! Cleanup
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_incells_basic_functionality
@@ -634,11 +633,11 @@ contains
    subroutine test_incells_complex_geometry() bind(C)
       ! Test incells with more complex netcell geometries (triangles, pentagons, hexagons)
       use gridoperations, only: incells
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
       use network_data, only: netcell, nump, xk, yk
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -646,38 +645,37 @@ contains
       nump = 3
       call setup_complex_netcells()
 
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       ! Test 1: Inside triangle (cell 1)
       xa = 5.0_dp
       ya = 3.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside triangle")
 
       ! Test 2: Inside pentagon (cell 2)
       xa = 15.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside pentagon")
 
       ! Test 3: Inside hexagon (cell 3)
       xa = 25.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside hexagon")
 
       ! Test 4: On edge of complex polygon
       xa = 10.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on complex polygon edge")
 
       ! Cleanup
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_incells_complex_geometry
@@ -687,11 +685,11 @@ contains
    subroutine test_incells_large_grid() bind(C)
       ! Test incells with a larger grid (performance sanity check)
       use gridoperations, only: incells
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
       use network_data, only: netcell, nump
 
       integer :: kin_old, kin_new, i, mismatches
       real(kind=dp) :: xa, ya
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -699,7 +697,7 @@ contains
       nump = 100
       call setup_grid_netcells(10, 10, 10.0_dp)
 
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       mismatches = 0
 
@@ -709,7 +707,7 @@ contains
          ya = 25.0_dp
 
          call incells(xa, ya, kin_old)
-         kin_new = point_find_netcell(xa, ya)
+         kin_new = polygon_cache%find_netcell(xa, ya)
 
          if (kin_old /= kin_new) then
             mismatches = mismatches + 1
@@ -719,7 +717,6 @@ contains
       call f90_expect_eq(mismatches, 0, "No mismatches in large grid test")
 
       ! Cleanup
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_incells_large_grid
@@ -729,11 +726,11 @@ contains
    subroutine test_incells_cache_consistency() bind(C)
       ! Test that cache initialization produces consistent results
       use gridoperations, only: incells
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
       use network_data, only: nump
 
       integer :: kin1, kin2, kin_old
       real(kind=dp) :: xa, ya
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -746,11 +743,11 @@ contains
       ya = 5.0_dp
 
       ! Initialize cache and query
-      call init_cell_geom_as_polylines()
-      kin1 = point_find_netcell(xa, ya)
+      polygon_cache = t_polygon_set_cache()
+      kin1 = polygon_cache%find_netcell(xa, ya)
 
       ! Query again (should use cached data)
-      kin2 = point_find_netcell(xa, ya)
+      kin2 = polygon_cache%find_netcell(xa, ya)
 
       call f90_expect_eq(kin1, kin2, "Cached queries should match")
 
@@ -759,15 +756,13 @@ contains
       call f90_expect_eq(kin1, kin_old, "Cached result should match old implementation")
 
       ! Cleanup and re-initialize
-      call cleanup_cell_geom_polylines()
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       ! Query after re-initialization
-      kin2 = point_find_netcell(xa, ya)
+      kin2 = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin1, kin2, "Re-initialized cache should give same result")
 
       ! Cleanup
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_incells_cache_consistency
@@ -777,62 +772,59 @@ contains
    subroutine test_incells_edge_cases() bind(C)
       ! Test edge cases: empty grid, single cell, point at infinity
       use gridoperations, only: incells
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
       use network_data, only: netcell, nump
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
       ! Test 1: Empty grid (nump = 0)
       nump = 0
       call setup_empty_netcells()
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Empty grid")
       call f90_expect_eq(kin_new, 0, "Should return 0 for empty grid")
 
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
       ! Test 2: Single cell
       nump = 1
       call setup_single_netcell()
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Single cell - inside")
 
       xa = 15.0_dp
       ya = 15.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Single cell - outside")
 
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
       ! Test 3: Very large coordinates
       nump = 1
       call setup_single_netcell()
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       xa = 1.0e6_dp
       ya = 1.0e6_dp
       call incells(xa, ya, kin_old)
-      kin_new = point_find_netcell(xa, ya)
+      kin_new = polygon_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Very large coordinates")
       call f90_expect_eq(kin_new, 0, "Should be outside")
 
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_incells_edge_cases
@@ -982,7 +974,6 @@ contains
 !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_find_cells_crossed_by_polyline_simple, test_find_cells_crossed_by_polyline_simple,
    subroutine test_find_cells_crossed_by_polyline_simple() bind(C)
       ! Test find_cells_crossed_by_polyline: polyline crosses some cells, misses others
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, find_cells_crossed_by_polyline, cleanup_cell_geom_polylines
       use network_data, only: nump
       use m_alloc, only: realloc
 
@@ -991,6 +982,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1015,10 +1007,10 @@ contains
       ypoly(2) = 27.0_dp
 
       ! Initialize cache
-      call init_cell_geom_as_polylines()      
+      polygon_cache = t_polygon_set_cache()
 
       ! Call the function
-      call find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")
@@ -1043,7 +1035,6 @@ contains
       ! Cleanup
       deallocate (xpoly, ypoly)
       if (allocated(crossed_cells)) deallocate (crossed_cells)
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_find_cells_crossed_by_polyline_simple
@@ -1052,7 +1043,6 @@ contains
 !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_find_cells_crossed_by_polyline_edge_cases, test_find_cells_crossed_by_polyline_edge_cases,
    subroutine test_find_cells_crossed_by_polyline_edge_cases() bind(C)
       ! Test find_cells_crossed_by_polyline: polyline crosses some cells, misses others
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, find_cells_crossed_by_polyline, cleanup_cell_geom_polylines
       use network_data, only: nump
       use m_alloc, only: realloc
 
@@ -1061,6 +1051,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1084,10 +1075,10 @@ contains
       ypoly(3) = 0.0_dp
 
       ! Initialize cache
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
 
       ! Call the function
-      call find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")
@@ -1106,7 +1097,6 @@ contains
       ! Cleanup
       deallocate (xpoly, ypoly)
       if (allocated(crossed_cells)) deallocate (crossed_cells)
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_find_cells_crossed_by_polyline_edge_cases
@@ -1115,7 +1105,6 @@ contains
 !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_find_cells_crossed_by_polyline_edge_case2, test_find_cells_crossed_by_polyline_edge_case2,
    subroutine test_find_cells_crossed_by_polyline_edge_case2() bind(C)
       ! Test find_cells_crossed_by_polyline: polyline crosses some cells, misses others
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, find_cells_crossed_by_polyline, cleanup_cell_geom_polylines
       use network_data, only: nump
       use m_alloc, only: realloc
 
@@ -1124,6 +1113,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
+      type(t_polygon_set_cache) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1145,9 +1135,9 @@ contains
       ypoly(2) = 6.0_dp
 
       ! Initialize cache
-      call init_cell_geom_as_polylines()
+      polygon_cache = t_polygon_set_cache()
       ! Call the function
-      call find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")
@@ -1158,7 +1148,6 @@ contains
       ! Cleanup
       deallocate (xpoly, ypoly)
       if (allocated(crossed_cells)) deallocate (crossed_cells)
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
 
    end subroutine test_find_cells_crossed_by_polyline_edge_case2

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -3,7 +3,7 @@ module test_pol_to_cellmask
    use precision, only: dp
    use m_missing, only: dmiss
    use network_data, only: cellmask, npl, nump, xzw, yzw, xpl, ypl, zpl, nump1d2d
-   use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+   use m_cellmask_from_polygon_set, only: t_polygon_set
    use geometry_module, only: pinpok_legacy, pinpok_raycast
    use m_pol_to_cellmask, only: pol_to_cellmask, cell_mask_from_polygon_file
 
@@ -467,7 +467,7 @@ contains
       real(kind=dp) :: angle
       real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
       real(kind=dp) :: x_query(query_points), y_query(query_points)
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       do point = 1, large_polygon_points - 1
          angle = 2.0_dp * pi * real(point - 1, dp) / real(large_polygon_points - 1, dp)
@@ -499,7 +499,7 @@ contains
 
       original_jins = jins
       jins = 1
-      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning=.true.)
+      polygon_cache = t_polygon_set(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
          inside_large_polygon = pinpok_raycast(x_query(point), y_query(point), x_poly, y_poly, large_polygon_points)
          inside_small_polygon = pinpok_raycast(x_query(point), y_query(point), &
@@ -529,7 +529,7 @@ contains
       real(kind=dp) :: vertex_x(polygon_segments + 1), vertex_y(polygon_segments + 1)
       real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
       real(kind=dp) :: x_query(query_points), y_query(query_points)
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       ! Dense L-shape: the internal horizontal edge at y=1 lies exactly on a latitude-bin boundary.
       vertex_x = [-1.0_dp, 1.0_dp, 1.0_dp, 0.0_dp, 0.0_dp, -1.0_dp, -1.0_dp]
@@ -553,7 +553,7 @@ contains
 
       original_jins = jins
       jins = 1
-      polygon_cache = t_polygon_set_cache(x_poly, y_poly, z_poly, enable_binning=.true.)
+      polygon_cache = t_polygon_set(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
          actual_mask = polygon_cache%point_mask(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
@@ -574,7 +574,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -583,7 +583,7 @@ contains
       call setup_simple_netcells()
 
       ! Initialize cache for new implementation
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Test 1: Point clearly inside first cell (0,0 to 10,10)
       xa = 5.0_dp
@@ -637,7 +637,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -645,7 +645,7 @@ contains
       nump = 3
       call setup_complex_netcells()
 
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Test 1: Inside triangle (cell 1)
       xa = 5.0_dp
@@ -689,7 +689,7 @@ contains
 
       integer :: kin_old, kin_new, i, mismatches
       real(kind=dp) :: xa, ya
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -697,7 +697,7 @@ contains
       nump = 100
       call setup_grid_netcells(10, 10, 10.0_dp)
 
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       mismatches = 0
 
@@ -730,7 +730,7 @@ contains
 
       integer :: kin1, kin2, kin_old
       real(kind=dp) :: xa, ya
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -743,7 +743,7 @@ contains
       ya = 5.0_dp
 
       ! Initialize cache and query
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
       kin1 = polygon_cache%find_netcell(xa, ya)
 
       ! Query again (should use cached data)
@@ -756,7 +756,7 @@ contains
       call f90_expect_eq(kin1, kin_old, "Cached result should match old implementation")
 
       ! Cleanup and re-initialize
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Query after re-initialization
       kin2 = polygon_cache%find_netcell(xa, ya)
@@ -776,14 +776,14 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 !> in case previous tests set npl
 
       ! Test 1: Empty grid (nump = 0)
       nump = 0
       call setup_empty_netcells()
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
@@ -797,7 +797,7 @@ contains
       ! Test 2: Single cell
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
@@ -816,7 +816,7 @@ contains
       ! Test 3: Very large coordinates
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       xa = 1.0e6_dp
       ya = 1.0e6_dp
@@ -982,7 +982,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1007,7 +1007,7 @@ contains
       ypoly(2) = 27.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
@@ -1051,7 +1051,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1075,7 +1075,7 @@ contains
       ypoly(3) = 0.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
 
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
@@ -1113,7 +1113,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1135,7 +1135,7 @@ contains
       ypoly(2) = 6.0_dp
 
       ! Initialize cache
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
       ! Call the function
       call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -101,6 +101,12 @@ contains
       ! Cell at (25,25) - inside enclosure, outside dry point -> mask=0
       call f90_expect_eq(cellmask(13), 0, "Cell (25,25) should not be masked")
 
+      ! Legacy polygon files also use z=0 for outside/enclosure polygons.
+      zpl(1:5) = 0.0_dp
+      cellmask = pol_to_cellmask(npl, xpl, ypl, zpl, nump, xzw, yzw, enable_binning=.false.)
+      call f90_expect_eq(cellmask(1), 0, "Cell inside z=0 enclosure should not be masked")
+      call f90_expect_eq(cellmask(4), 1, "Cell outside z=0 enclosure should be masked")
+
       ! Cleanup
       deallocate (xzw, yzw, xpl, ypl, zpl, cellmask)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -123,7 +123,7 @@ contains
       character(len=*), parameter :: polygon_file_a = 'test_map_mask_a.pol'
       character(len=*), parameter :: polygon_file_b = 'test_map_mask_b.pol'
       integer :: ierror, original_jsferic, original_jins
-      integer, allocatable :: mask(:)
+      integer, dimension(:), allocatable :: mask
 
       ! File A contains two polygons; file B contributes a third one.
       call write_polygon_file(polygon_file_a, [0.0_dp, 20.0_dp], ierror)
@@ -465,8 +465,8 @@ contains
       integer :: actual_mask, expected_mask, polygons_containing_point
       logical :: inside_large_polygon, inside_small_polygon
       real(kind=dp) :: angle
-      real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
-      real(kind=dp) :: x_query(query_points), y_query(query_points)
+      real(kind=dp), dimension(polygon_points) :: x_poly, y_poly, z_poly
+      real(kind=dp), dimension(query_points) :: x_query, y_query
       type(t_polygon_set) :: polygon_cache
 
       do point = 1, large_polygon_points - 1
@@ -526,9 +526,9 @@ contains
 
       integer :: actual_mask, original_jins, point, segment, step
       real(kind=dp) :: fraction
-      real(kind=dp) :: vertex_x(polygon_segments + 1), vertex_y(polygon_segments + 1)
-      real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
-      real(kind=dp) :: x_query(query_points), y_query(query_points)
+      real(kind=dp), dimension(polygon_segments + 1) :: vertex_x, vertex_y
+      real(kind=dp), dimension(polygon_points) :: x_poly, y_poly, z_poly
+      real(kind=dp), dimension(query_points) :: x_query, y_query
       type(t_polygon_set) :: polygon_cache
 
       ! Dense L-shape: the internal horizontal edge at y=1 lies exactly on a latitude-bin boundary.
@@ -557,7 +557,7 @@ contains
       do point = 1, query_points
          actual_mask = merge(1, 0, polygon_cache%is_masked(x_query(point), y_query(point)))
          call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
-                                                                   x_poly, y_poly, polygon_points)), &
+                                                                    x_poly, y_poly, polygon_points)), &
                             "Binned and full polygon scans should agree at edges and bin boundaries")
       end do
       jins = original_jins
@@ -977,8 +977,8 @@ contains
       use network_data, only: nump
       use m_alloc, only: realloc
 
-      real(kind=dp), allocatable :: xpoly(:), ypoly(:)
-      integer, allocatable :: crossed_cells(:)
+      real(kind=dp), dimension(:), allocatable :: xpoly, ypoly
+      integer, dimension(:), allocatable :: crossed_cells
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
@@ -995,7 +995,6 @@ contains
       ! 1 | 2 | 3
       nump = 9
       call setup_grid_netcells(3, 3, 10.0_dp)
-
 
       ! Create polyline from (1, 3) to (29, 27)
       ! This goes slightly off-diagonal, crossing cells: 1, 4, 5, 6, 9
@@ -1046,8 +1045,8 @@ contains
       use network_data, only: nump
       use m_alloc, only: realloc
 
-      real(kind=dp), allocatable :: xpoly(:), ypoly(:)
-      integer, allocatable :: crossed_cells(:)
+      real(kind=dp), dimension(:), allocatable :: xpoly, ypoly
+      integer, dimension(:), allocatable :: crossed_cells
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
@@ -1108,8 +1107,8 @@ contains
       use network_data, only: nump
       use m_alloc, only: realloc
 
-      real(kind=dp), allocatable :: xpoly(:), ypoly(:)
-      integer, allocatable :: crossed_cells(:)
+      real(kind=dp), dimension(:), allocatable :: xpoly, ypoly
+      integer, dimension(:), allocatable :: crossed_cells
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
@@ -1159,7 +1158,7 @@ contains
 
    subroutine write_polygon_file(filename, x_origins, ierror)
       character(len=*), intent(in) :: filename
-      real(kind=dp), intent(in) :: x_origins(:)
+      real(kind=dp), dimension(:), intent(in) :: x_origins
       integer, intent(out) :: ierror
 
       integer :: ipolygon, unit

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -507,7 +507,7 @@ contains
                                                y_poly(large_polygon_points + 2:polygon_points), 5)
          polygons_containing_point = merge(1, 0, inside_large_polygon) + merge(1, 0, inside_small_polygon)
          expected_mask = modulo(polygons_containing_point, 2)
-         actual_mask = polygon_cache%point_mask(x_query(point), y_query(point))
+         actual_mask = polygon_cache%is_masked(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, expected_mask, "Indexed and full polygon scans should agree")
       end do
       jins = original_jins
@@ -555,7 +555,7 @@ contains
       jins = 1
       polygon_cache = t_polygon_set(x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
-         actual_mask = polygon_cache%point_mask(x_query(point), y_query(point))
+         actual_mask = polygon_cache%is_masked(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, merge(1, 0, pinpok_raycast(x_query(point), y_query(point), &
                                                                    x_poly, y_poly, polygon_points)), &
                             "Binned and full polygon scans should agree at edges and bin boundaries")

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -445,6 +445,58 @@ contains
    end subroutine test_pinpok_raycast_complex
    !$f90tw)
 
+   !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_indexed_polygon_matches_full_scan, test_indexed_polygon_matches_full_scan,
+   subroutine test_indexed_polygon_matches_full_scan() bind(C)
+      use m_missing, only: jins
+
+      integer, parameter :: polygon_points = 513
+      integer, parameter :: grid_size = 41
+      integer, parameter :: query_points = grid_size * grid_size + 8
+      real(kind=dp), parameter :: pi = acos(-1.0_dp)
+
+      integer :: column, original_jins, point, row
+      integer :: actual_mask, expected_mask
+      real(kind=dp) :: angle
+      real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
+      real(kind=dp) :: x_query(query_points), y_query(query_points)
+
+      do point = 1, polygon_points - 1
+         angle = 2.0_dp * pi * real(point - 1, dp) / real(polygon_points - 1, dp)
+         x_poly(point) = cos(angle)
+         y_poly(point) = sin(angle)
+      end do
+      x_poly(polygon_points) = x_poly(1)
+      y_poly(polygon_points) = y_poly(1)
+      z_poly = 1.0_dp
+
+      point = 0
+      do row = 1, grid_size
+         do column = 1, grid_size
+            point = point + 1
+            x_query(point) = -1.2_dp + 2.4_dp * real(column - 1, dp) / real(grid_size - 1, dp)
+            y_query(point) = -1.2_dp + 2.4_dp * real(row - 1, dp) / real(grid_size - 1, dp)
+         end do
+      end do
+      do column = 1, 8
+         point = point + 1
+         x_query(point) = x_poly(1 + (column - 1) * 64)
+         y_query(point) = y_poly(1 + (column - 1) * 64)
+      end do
+
+      original_jins = jins
+      jins = 1
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, query_points, x_query, y_query)
+      do point = 1, query_points
+         expected_mask = merge(1, 0, pinpok_raycast(x_query(point), y_query(point), x_poly, y_poly, polygon_points))
+         actual_mask = cellmask_from_polygon_set(x_query(point), y_query(point))
+         call f90_expect_eq(actual_mask, expected_mask, "Indexed and full polygon scans should agree")
+      end do
+      call cellmask_from_polygon_set_cleanup()
+      jins = original_jins
+
+   end subroutine test_indexed_polygon_matches_full_scan
+   !$f90tw)
+
 !$f90tw TESTCODE(TEST, test_pol_to_cellmask, test_incells_basic_functionality, test_incells_basic_functionality,
    subroutine test_incells_basic_functionality() bind(C)
       ! Test basic incells functionality: point inside/outside netcells

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -449,25 +449,32 @@ contains
    subroutine test_indexed_polygon_matches_full_scan() bind(C)
       use m_missing, only: jins
 
-      integer, parameter :: polygon_points = 513
+      integer, parameter :: large_polygon_points = 513
+      integer, parameter :: polygon_points = large_polygon_points + 6
       integer, parameter :: grid_size = 41
       integer, parameter :: query_points = grid_size * grid_size + 8
       real(kind=dp), parameter :: pi = acos(-1.0_dp)
 
       integer :: column, original_jins, point, row
-      integer :: actual_mask, expected_mask
+      integer :: actual_mask, expected_mask, polygons_containing_point
+      logical :: inside_large_polygon, inside_small_polygon
       real(kind=dp) :: angle
       real(kind=dp) :: x_poly(polygon_points), y_poly(polygon_points), z_poly(polygon_points)
       real(kind=dp) :: x_query(query_points), y_query(query_points)
 
-      do point = 1, polygon_points - 1
-         angle = 2.0_dp * pi * real(point - 1, dp) / real(polygon_points - 1, dp)
+      do point = 1, large_polygon_points - 1
+         angle = 2.0_dp * pi * real(point - 1, dp) / real(large_polygon_points - 1, dp)
          x_poly(point) = cos(angle)
          y_poly(point) = sin(angle)
       end do
-      x_poly(polygon_points) = x_poly(1)
-      y_poly(polygon_points) = y_poly(1)
+      x_poly(large_polygon_points) = x_poly(1)
+      y_poly(large_polygon_points) = y_poly(1)
       z_poly = 1.0_dp
+      x_poly(large_polygon_points + 1) = dmiss
+      y_poly(large_polygon_points + 1) = dmiss
+      z_poly(large_polygon_points + 1) = dmiss
+      x_poly(large_polygon_points + 2:polygon_points) = [0.2_dp, 0.4_dp, 0.4_dp, 0.2_dp, 0.2_dp]
+      y_poly(large_polygon_points + 2:polygon_points) = [0.2_dp, 0.2_dp, 0.4_dp, 0.4_dp, 0.2_dp]
 
       point = 0
       do row = 1, grid_size
@@ -485,9 +492,14 @@ contains
 
       original_jins = jins
       jins = 1
-      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, query_points, x_query, y_query)
+      call cellmask_from_polygon_set_init(polygon_points, x_poly, y_poly, z_poly, enable_binning=.true.)
       do point = 1, query_points
-         expected_mask = merge(1, 0, pinpok_raycast(x_query(point), y_query(point), x_poly, y_poly, polygon_points))
+         inside_large_polygon = pinpok_raycast(x_query(point), y_query(point), x_poly, y_poly, large_polygon_points)
+         inside_small_polygon = pinpok_raycast(x_query(point), y_query(point), &
+                                               x_poly(large_polygon_points + 2:polygon_points), &
+                                               y_poly(large_polygon_points + 2:polygon_points), 5)
+         polygons_containing_point = merge(1, 0, inside_large_polygon) + merge(1, 0, inside_small_polygon)
+         expected_mask = modulo(polygons_containing_point, 2)
          actual_mask = cellmask_from_polygon_set(x_query(point), y_query(point))
          call f90_expect_eq(actual_mask, expected_mask, "Indexed and full polygon scans should agree")
       end do

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_pol_to_cellmask.f90
@@ -574,7 +574,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -583,13 +583,13 @@ contains
       call setup_simple_netcells()
 
       ! Initialize cache for new implementation
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Test 1: Point clearly inside first cell (0,0 to 10,10)
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside first cell")
       call f90_expect_eq(kin_new, 1, "Should be in cell 1")
 
@@ -597,7 +597,7 @@ contains
       xa = 15.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside second cell")
       call f90_expect_eq(kin_new, 2, "Should be in cell 2")
 
@@ -605,7 +605,7 @@ contains
       xa = 25.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point outside all cells")
       call f90_expect_eq(kin_new, 0, "Should be in no cell")
 
@@ -613,14 +613,14 @@ contains
       xa = 10.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on cell boundary")
 
       ! Test 5: Point on cell corner
       xa = 0.0_dp
       ya = 0.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on cell corner")
 
       ! Cleanup
@@ -637,7 +637,7 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -645,34 +645,34 @@ contains
       nump = 3
       call setup_complex_netcells()
 
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Test 1: Inside triangle (cell 1)
       xa = 5.0_dp
       ya = 3.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside triangle")
 
       ! Test 2: Inside pentagon (cell 2)
       xa = 15.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside pentagon")
 
       ! Test 3: Inside hexagon (cell 3)
       xa = 25.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point inside hexagon")
 
       ! Test 4: On edge of complex polygon
       xa = 10.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Point on complex polygon edge")
 
       ! Cleanup
@@ -689,7 +689,7 @@ contains
 
       integer :: kin_old, kin_new, i, mismatches
       real(kind=dp) :: xa, ya
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -697,7 +697,7 @@ contains
       nump = 100
       call setup_grid_netcells(10, 10, 10.0_dp)
 
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       mismatches = 0
 
@@ -707,7 +707,7 @@ contains
          ya = 25.0_dp
 
          call incells(xa, ya, kin_old)
-         kin_new = polygon_cache%find_netcell(xa, ya)
+         kin_new = netcell_cache%find_netcell(xa, ya)
 
          if (kin_old /= kin_new) then
             mismatches = mismatches + 1
@@ -730,7 +730,7 @@ contains
 
       integer :: kin1, kin2, kin_old
       real(kind=dp) :: xa, ya
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 !> in case previous tests set npl
 
@@ -743,11 +743,11 @@ contains
       ya = 5.0_dp
 
       ! Initialize cache and query
-      polygon_cache = t_netcell_set()
-      kin1 = polygon_cache%find_netcell(xa, ya)
+      netcell_cache = t_netcell_set()
+      kin1 = netcell_cache%find_netcell(xa, ya)
 
       ! Query again (should use cached data)
-      kin2 = polygon_cache%find_netcell(xa, ya)
+      kin2 = netcell_cache%find_netcell(xa, ya)
 
       call f90_expect_eq(kin1, kin2, "Cached queries should match")
 
@@ -756,10 +756,10 @@ contains
       call f90_expect_eq(kin1, kin_old, "Cached result should match old implementation")
 
       ! Cleanup and re-initialize
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Query after re-initialization
-      kin2 = polygon_cache%find_netcell(xa, ya)
+      kin2 = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin1, kin2, "Re-initialized cache should give same result")
 
       ! Cleanup
@@ -776,19 +776,19 @@ contains
 
       integer :: kin_old, kin_new
       real(kind=dp) :: xa, ya
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 !> in case previous tests set npl
 
       ! Test 1: Empty grid (nump = 0)
       nump = 0
       call setup_empty_netcells()
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Empty grid")
       call f90_expect_eq(kin_new, 0, "Should return 0 for empty grid")
 
@@ -797,18 +797,18 @@ contains
       ! Test 2: Single cell
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       xa = 5.0_dp
       ya = 5.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Single cell - inside")
 
       xa = 15.0_dp
       ya = 15.0_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Single cell - outside")
 
       call cleanup_netcells()
@@ -816,12 +816,12 @@ contains
       ! Test 3: Very large coordinates
       nump = 1
       call setup_single_netcell()
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       xa = 1.0e6_dp
       ya = 1.0e6_dp
       call incells(xa, ya, kin_old)
-      kin_new = polygon_cache%find_netcell(xa, ya)
+      kin_new = netcell_cache%find_netcell(xa, ya)
       call f90_expect_eq(kin_old, kin_new, "Very large coordinates")
       call f90_expect_eq(kin_new, 0, "Should be outside")
 
@@ -982,7 +982,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1007,10 +1007,10 @@ contains
       ypoly(2) = 27.0_dp
 
       ! Initialize cache
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Call the function
-      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call netcell_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")
@@ -1051,7 +1051,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1075,10 +1075,10 @@ contains
       ypoly(3) = 0.0_dp
 
       ! Initialize cache
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
 
       ! Call the function
-      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call netcell_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")
@@ -1113,7 +1113,7 @@ contains
       character, dimension(:), allocatable :: error
       integer :: i
       logical :: found_cell
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
 
       npl = 0 ! Reset from previous tests
 
@@ -1135,9 +1135,9 @@ contains
       ypoly(2) = 6.0_dp
 
       ! Initialize cache
-      polygon_cache = t_netcell_set()
+      netcell_cache = t_netcell_set()
       ! Call the function
-      call polygon_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
+      call netcell_cache%find_cells_crossed_by_polyline(xpoly, ypoly, crossed_cells, error)
 
       ! Check for errors
       call f90_expect_true(.not. allocated(error), "No error should occur")

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
@@ -48,7 +48,7 @@ contains
    !$f90tw TESTCODE(TEST, test_precice_adapter, test_adapter_add_to_fm_administration, test_adapter_add_to_fm_administration,
    subroutine test_adapter_add_to_fm_administration() bind(C)
       use m_flow_geominit, only: flow_geominit
-      use m_cellmask_from_polygon_set, only: t_polygon_set
+      use m_cellmask_from_polygon_set, only: t_netcell_set
       use precice_adapter
       use m_source_sink, only: source_sinks, source_sink_all_discharges
       use m_alloc, only: realloc
@@ -56,7 +56,7 @@ contains
 
       type(t_grid_helper) :: grid_helper
       type(precice_adapter_t) :: adapter
-      type(t_polygon_set) :: polygon_cache
+      type(t_netcell_set) :: polygon_cache
       integer :: expected_sink_cell
       integer :: expected_source_cell
 
@@ -71,7 +71,7 @@ contains
          )
       call flow_geominit(0)
 
-      polygon_cache = t_polygon_set()
+      polygon_cache = t_netcell_set()
       expected_sink_cell = polygon_cache%find_netcell(5.0_dp, 5.0_dp)
       expected_source_cell = polygon_cache%find_netcell(15.0_dp, 7.0_dp)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
@@ -48,7 +48,7 @@ contains
    !$f90tw TESTCODE(TEST, test_precice_adapter, test_adapter_add_to_fm_administration, test_adapter_add_to_fm_administration,
    subroutine test_adapter_add_to_fm_administration() bind(C)
       use m_flow_geominit, only: flow_geominit
-      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
+      use m_cellmask_from_polygon_set, only: t_polygon_set
       use precice_adapter
       use m_source_sink, only: source_sinks, source_sink_all_discharges
       use m_alloc, only: realloc
@@ -56,7 +56,7 @@ contains
 
       type(t_grid_helper) :: grid_helper
       type(precice_adapter_t) :: adapter
-      type(t_polygon_set_cache) :: polygon_cache
+      type(t_polygon_set) :: polygon_cache
       integer :: expected_sink_cell
       integer :: expected_source_cell
 
@@ -71,7 +71,7 @@ contains
          )
       call flow_geominit(0)
 
-      polygon_cache = t_polygon_set_cache()
+      polygon_cache = t_polygon_set()
       expected_sink_cell = polygon_cache%find_netcell(5.0_dp, 5.0_dp)
       expected_source_cell = polygon_cache%find_netcell(15.0_dp, 7.0_dp)
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
@@ -56,7 +56,7 @@ contains
 
       type(t_grid_helper) :: grid_helper
       type(precice_adapter_t) :: adapter
-      type(t_netcell_set) :: polygon_cache
+      type(t_netcell_set) :: netcell_cache
       integer :: expected_sink_cell
       integer :: expected_source_cell
 
@@ -71,9 +71,9 @@ contains
          )
       call flow_geominit(0)
 
-      polygon_cache = t_netcell_set()
-      expected_sink_cell = polygon_cache%find_netcell(5.0_dp, 5.0_dp)
-      expected_source_cell = polygon_cache%find_netcell(15.0_dp, 7.0_dp)
+      netcell_cache = t_netcell_set()
+      expected_sink_cell = netcell_cache%find_netcell(5.0_dp, 5.0_dp)
+      expected_source_cell = netcell_cache%find_netcell(15.0_dp, 7.0_dp)
 
       ! Setup adapter
       call precice_adapter_allocate_read_arrays(adapter, 1)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_precice_adapter.f90
@@ -48,7 +48,7 @@ contains
    !$f90tw TESTCODE(TEST, test_precice_adapter, test_adapter_add_to_fm_administration, test_adapter_add_to_fm_administration,
    subroutine test_adapter_add_to_fm_administration() bind(C)
       use m_flow_geominit, only: flow_geominit
-      use m_cellmask_from_polygon_set, only: init_cell_geom_as_polylines, point_find_netcell, cleanup_cell_geom_polylines
+      use m_cellmask_from_polygon_set, only: t_polygon_set_cache
       use precice_adapter
       use m_source_sink, only: source_sinks, source_sink_all_discharges
       use m_alloc, only: realloc
@@ -56,6 +56,7 @@ contains
 
       type(t_grid_helper) :: grid_helper
       type(precice_adapter_t) :: adapter
+      type(t_polygon_set_cache) :: polygon_cache
       integer :: expected_sink_cell
       integer :: expected_source_cell
 
@@ -70,10 +71,9 @@ contains
          )
       call flow_geominit(0)
 
-      call init_cell_geom_as_polylines()
-      expected_sink_cell = point_find_netcell(5.0_dp, 5.0_dp)
-      expected_source_cell = point_find_netcell(15.0_dp, 7.0_dp)
-      call cleanup_cell_geom_polylines()
+      polygon_cache = t_polygon_set_cache()
+      expected_sink_cell = polygon_cache%find_netcell(5.0_dp, 5.0_dp)
+      expected_source_cell = polygon_cache%find_netcell(15.0_dp, 7.0_dp)
 
       ! Setup adapter
       call precice_adapter_allocate_read_arrays(adapter, 1)
@@ -104,7 +104,6 @@ contains
       call f90_assert_near(source_sink_all_discharges(1, 1), 9.10_dp, 1e-5_dp, "Unexpected source_sink_all_discharges(1, 1) in source sinks"//c_null_char)
 
       ! Cleanup
-      call cleanup_cell_geom_polylines()
       call cleanup_netcells()
       call precice_adapter_deallocate_read_arrays(adapter)
       call resetfullflowmodel()

--- a/src/utils_lgpl/deltares_common/packages/deltares_common/src/geometry_module.f90
+++ b/src/utils_lgpl/deltares_common/packages/deltares_common/src/geometry_module.f90
@@ -275,16 +275,17 @@ contains
 
 !> optimized ray-casting point-in-polygon test.
 !! pure function that works with array slices or full arrays.
-   pure function pinpok_raycast(xl, yl, x, y, n) result(is_inside)
+   pure function pinpok_raycast(xl, yl, x, y, n, edge_indices) result(is_inside)
       use precision_basics, only: equal
 
       real(kind=dp), intent(in) :: xl, yl !< point coordinates to test
       integer, intent(in) :: n !< number of polygon points
       real(kind=dp), dimension(n), intent(in) :: x, y !< polygon coordinates (at least n elements)
+      integer, dimension(:), intent(in), optional :: edge_indices !< Ordered indices of edges to test; each index identifies the edge ending at that point
       logical :: is_inside !< result: true if inside (respecting jins mode)
 
       ! locals
-      integer :: i, j, crossings
+      integer :: i, i_edge, j, crossings, num_edges
       real(kind=dp) :: x_intersect
       real(kind=dp), parameter :: TOLERANCE_FACTOR = 100.0_dp
 
@@ -301,9 +302,21 @@ contains
 
       ! ray-casting algorithm: count crossings of horizontal ray from point to +infinity
       crossings = 0
-      j = n ! In order to check the entire polygon, start the first link which lies between the last point (n) and the first point
+      num_edges = n
+      if (present(edge_indices)) then
+         num_edges = size(edge_indices)
+      end if
 
-      do i = 1, n
+      do i_edge = 1, num_edges
+         i = i_edge
+         if (present(edge_indices)) then
+            i = edge_indices(i_edge)
+         end if
+         j = i - 1
+         if (i == 1) then
+            j = n
+         end if
+
          ! check for missing value (polygon separator)
          if (x(i) == dmiss) then
             exit
@@ -347,7 +360,6 @@ contains
                return
             end if
          end if
-         j = i ! current point becomes previous for next iteration
       end do
 
       ! odd number of crossings = inside, even = outside


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

-added a binning algorithm to reduce workload for large (for dcsm: 90k) enclosure polygons. Since every cell scans every polygon, the current brute-force raycasting implementation is very efficient for many small polygons and extremely inefficient for a single super large one

EDIT:

-refactored towards an OOP implementation. Instead of a global polyline cache, we now have a polyline geometry object with a nice default constructor and type-bound procedures.
-Also a separate netcell geometry, and the binning implementation also has its own type, constructor and procedures.
 

## Enclosure Polygon Binning

### Problem

Point-in-polygon normally checks every polygon edge for every model cell:

$$
\text{work} \approx \text{cells} \times \text{polygon edges}
$$

For the DCSM enclosure, this meant checking approximately 93,000 edges for almost every cell because the enclosure bounding box covers the complete model.

### Approach

Enclosure polygons are divided into horizontal latitude bins. Each bin stores only the edges whose vertical extent intersects that bin. This significantly reduces the edges that need to be checked for intersection by the raycast algorithm. In this example, the binning excludes e2 and e4 from consideration because the ray will never cross them anyway:

<img width="545" height="472" alt="image" src="https://github.com/user-attachments/assets/98512914-0cea-46fd-a2d5-b2fadd7b2f60" />

For a query point, its latitude identifies one bin. The existing ray-casting algorithm then examines only the edges stored in that bin.

```mermaid
flowchart LR
    A[Cell center] --> B[Find latitude bin]
    B --> C[Retrieve candidate edges]
    C --> D[Existing ray-casting calculation]
    D --> E[Inside or outside]
```

The polygon geometry is not simplified or approximated.

### Construction

```mermaid
flowchart TD
    A[Read enclosure polygons] --> B[Choose latitude bins]
    B --> C[Determine bins crossed by each edge]
    C --> D{Index storage bounded?}
    D -- No --> E[Use original full scan]
    D -- Yes --> F[Store edge numbers per bin]
    F --> G[Use binned ray casting]
```

Edges are inserted in their original polygon order. Therefore, the indexed ray cast processes its candidate edges in the same order as the original implementation.

### Safety Fallback

An edge crossing several bins is stored once in every crossed bin. Normally, short coastline edges occur in only one or two bins.

For pathological polygons containing many long vertical edges, storage could grow excessively. If the average exceeds eight memberships per edge, index creation is abandoned and the original full scan is used.

This fallback affects performance and memory use only, not results.

### Scope

Binning is enabled only for `GridEnclosureFile` processing. Dry-area polygons continue using the original implementation because their smaller bounding boxes already reject most cells efficiently.

### Validation

The implementation was checked by running the original and binned algorithms independently on the complete DCSM model and comparing their resulting masks.

- Masks: identical
- Original enclosure processing: approximately 196 seconds
- Binned enclosure processing: approximately 1.2 seconds

# Evidence of the work done 
before:
<img width="1046" height="288" alt="image" src="https://github.com/user-attachments/assets/3d5216fc-bc0f-4e15-9742-b0b6aa61ba34" />

after:

<img width="1053" height="472" alt="image" src="https://github.com/user-attachments/assets/dde6daa6-e4e8-47b9-bb88-8b825e827dfb" />

added a full comparison test that reported 0 mismatches for DCSM-FM_100m.mdu
<img width="1081" height="379" alt="image" src="https://github.com/user-attachments/assets/4ab52c76-fb2e-4f74-bb79-1f3bd3665672" />

<img width="1222" height="237" alt="image" src="https://github.com/user-attachments/assets/88a2ed63-d03b-4f5c-bc45-ae55d0dd8a6c" />



- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
