### PR TITLE
Fm/bugfix/unst 9594 dcsm initialisation fixes

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/flowgeom_mask.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_utils/flowgeom_mask.f90
@@ -225,8 +225,8 @@ contains
       integer, intent(out) :: ierr !< Result status (DFM_NOERR if succesful, or different if mask could not be constructed for this quantity's location).
 
       ! Local variables
-      integer :: i !< Loop variable for mask array.
       integer, dimension(:), allocatable :: selected_points !< Array of selected points based on the target mask file.
+      integer, dimension(:), allocatable :: polygon_mask !< Direct mask of points selected by the polygon.
       integer :: number_of_selected_points !< The number of selected points based on the target mask file.
       integer :: point !< Loop variable for points.
       logical :: spatial_mask_applied !< Flag to indicate whether a spatial mask has already been applied to the mask array.
@@ -266,13 +266,12 @@ contains
          end select
 
          if (spatial_mask_applied) then
-            do i = 1, size(mask)
-               if (mask(i) == 1 .and. any(i == selected_points)) then
-                  mask(i) = 1
-               else
-                  mask(i) = 0
-               end if
+            allocate (polygon_mask(size(mask)))
+            polygon_mask = 0
+            do point = 1, number_of_selected_points
+               polygon_mask(selected_points(point)) = 1
             end do
+            mask = mask * polygon_mask
          else
             do point = 1, number_of_selected_points
                mask(selected_points(point)) = 1

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -4334,29 +4334,32 @@ contains
       integer, dimension(:), intent(in), optional :: target_mask !< optional mask selecting target values to check
 
       integer :: i
-
-      istat = .false.
-
-      if (any(operand == [EC_OPERAND_ADD, EC_OPERAND_MULTIPLY, EC_OPERAND_MINIMUM, EC_OPERAND_MAXIMUM])) then
-         if (present(target_mask)) then
-            do i = 1, size(target_values)
-               if (target_mask(i) == 0) then
-                  cycle
-               end if
-               if (target_values(i) == ec_undef_hp) then
-                  call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
-                  return
-               end if
-            end do
-         else
-            if (any(target_values == ec_undef_hp)) then
-               call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
-               return
-            end if
-         end if
-      end if
+      logical :: has_undefined_value
 
       istat = .true.
+      if (.not. any(operand == [EC_OPERAND_ADD, EC_OPERAND_MULTIPLY, EC_OPERAND_MINIMUM, EC_OPERAND_MAXIMUM])) then
+         return
+      end if
+
+      has_undefined_value = .false.
+      if (present(target_mask)) then
+         do i = 1, size(target_values)
+            if (target_mask(i) == 0) then
+               cycle
+            end if
+            if (target_values(i) == ec_undef_hp) then
+               has_undefined_value = .true.
+               exit
+            end if
+         end do
+      else
+         has_undefined_value = any(target_values == ec_undef_hp)
+      end if
+
+      if (has_undefined_value) then
+         call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
+         istat = .false.
+      end if
 
    end subroutine check_undefined_values_for_operand
 

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -4238,7 +4238,6 @@ contains
       real(dp) :: data_value !< the scalar source value
       integer :: i, j
       integer :: jmin, jmax
-      integer, allocatable :: idx(:) !< indices of the target points to update
       type(tEcField), pointer :: targetField
       integer, dimension(:), pointer :: targetMask
       logical :: status
@@ -4260,13 +4259,15 @@ contains
          end if
 
          if (associated(targetMask)) then
-            ! Gather masked in indices in `idx` array.
-            idx = pack([(j, j = jmin, jmax)], targetMask(jmin:jmax) /= 0)
-            call check_undefined_values_for_operand(connection%converterPtr%operandType, targetField%arr1dPtr(idx), status)
+            call check_undefined_values_for_operand(connection%converterPtr%operandType, targetField%arr1dPtr(jmin:jmax), status, targetMask(jmin:jmax))
             if (.not. status) then
                return
             end if
-            call apply_operand(connection%converterPtr%operandType, targetField%arr1dPtr(idx), data_value)
+            do j = jmin, jmax
+               if (targetMask(j) /= 0) then
+                  call apply_operand(connection%converterPtr%operandType, targetField%arr1dPtr(j), data_value)
+               end if
+            end do
          else
             ! Directly use `jmin:jmax` slice of `arr1dPtr`.
             call check_undefined_values_for_operand(connection%converterPtr%operandType, targetField%arr1dPtr(jmin:jmax), status)
@@ -4325,18 +4326,33 @@ contains
    end subroutine apply_operand
 
    !> Checks for undefined values in the target values array when using add, multiply, minimum, or maximum operands.
-   subroutine check_undefined_values_for_operand(operand, target_values, istat)
+   subroutine check_undefined_values_for_operand(operand, target_values, istat, target_mask)
       ! Arguments
       integer, intent(in) :: operand !< operand type (EC_OPERAND_ADD, EC_OPERAND_MULTIPLY, EC_OPERAND_MINIMUM, EC_OPERAND_MAXIMUM)
       real(dp), dimension(:), intent(in) :: target_values !< array of target values to check for undefined values
       logical, intent(out) :: istat !< status code (.true. for success, .false. for error)
+      integer, dimension(:), intent(in), optional :: target_mask !< optional mask selecting target values to check
+
+      integer :: i
 
       istat = .false.
 
       if (any(operand == [EC_OPERAND_ADD, EC_OPERAND_MULTIPLY, EC_OPERAND_MINIMUM, EC_OPERAND_MAXIMUM])) then
-         if (any(target_values == ec_undef_hp)) then
-            call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
-            return
+         if (present(target_mask)) then
+            do i = 1, size(target_values)
+               if (target_mask(i) == 0) then
+                  cycle
+               end if
+               if (target_values(i) == ec_undef_hp) then
+                  call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
+                  return
+               end if
+            end do
+         else
+            if (any(target_values == ec_undef_hp)) then
+               call set_ec_message("ERROR: ec_converter::check_undefined_values_for_operand: Target Field contains undefined values, cannot perform '"// ec_operand_enum_to_string(operand) //"' operation.")
+               return
+            end if
          end if
       end if
 


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- fix very slow polygon masking due to accidental O(N^2) algorithm
- fix stackoverflow from unsafe pack in ec-converter
- very slow enclosure file initialisation will be fixed in a separate PR: https://github.com/Deltares/Delft3D/pull/1211
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
