### PR TITLE
Increase maxRunTime's of timing out test cases

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -841,7 +841,7 @@
   </testCase>
   <testCase name="e02_f090_c011_san_francisco_bay_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f090_validation_realworld/c011_san_francisco_bay_3d</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/historical_WY2011_map.nc" type="netCDF">
         <parameters>
@@ -1015,7 +1015,7 @@
   </testCase>
   <testCase name="e02_f208_c011_gate_sub_3Dz" ref="platform_specific">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c011_gate_sub_3Dz</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatesub_3Dz_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
@@ -337,7 +337,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c05" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c05-ti_com_dtuser_in_mdu</path>
-
+    <maxRunTime>600</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_oldext_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_oldext_cases.xml
@@ -6050,7 +6050,7 @@
   </testCase>
   <testCase name="e02_f422_c55_oldext_curvebend_spiral_mor_Bedup_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c55_oldext_curvebend_spiral_mor_Bedup_Unstr</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/c31smallbendUnstr_20010101_014000_rst.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
@@ -1596,7 +1596,7 @@
   </testCase>
   <testCase name="e02_f030_c401_Course_tracers" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c401_Course_tracers</path>
-      <maxRunTime>480</maxRunTime>
+      <maxRunTime>900</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>
@@ -1644,7 +1644,7 @@
   </testCase>
   <testCase name="e02_f030_c403_Course_eutrophication" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c403_Course_eutrophication</path>
-    <maxRunTime>480</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
@@ -2,7 +2,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f09_c01_SWANDCSM" ref="dimr_trunk">
     <path version="DVC">e04_wave/f09-SWANDCSM/c01</path>
-    <maxRunTime>3600</maxRunTime>
+    <maxRunTime>4200</maxRunTime>
     <checks>
       <file name="wavm-Waves.nc" type="NETCDF">
         <parameters>


### PR DESCRIPTION
# What was done 

A handful of test cases still fail due to TimeoutErrors, and this is blocking the dimrset.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
