### PR TITLE
UNST-10262: revert the unc_read_net split and detect_proj_string call

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -11256,43 +11256,6 @@ contains
 !! Processing is done elsewhere.
    subroutine unc_read_net(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
       use precision, only: dp
-      use dfm_error, only: dfm_noerr
-
-      character(len=*), intent(in) :: filename !< Name of NetCDF file.
-      integer, intent(inout) :: numk_keep !< Number of netnodes to keep in existing net.
-      integer, intent(inout) :: numl_keep !< Number of netlinks to keep in existing net.
-      integer, intent(out) :: numk_read !< Number of new netnodes read from file.
-      integer, intent(out) :: numl_read !< Number of new netlinks read from file.
-      integer, intent(out) :: ierr !< Return status (NetCDF operations)
-
-      call readyy('Reading net data', 0.0_dp)
-
-      call prepare_error('Could not read NetCDF file '''//trim(filename)//'''. Details follow:')
-
-      !
-      ! Try and read as new UGRID NetCDF format
-      !
-      call unc_read_net_ugrid(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
-      if (ierr /= dfm_noerr) then
-         ! No UGRID, but just try to use the 'old' format now.
-         call unc_read_net_old(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
-      end if
-
-      if (ierr == dfm_noerr .and. crs%proj_string == ' ') then
-         ierr = detect_proj_string(crs)
-         if (ierr /= dfm_noerr) then
-            ierr = dfm_noerr
-            call mess(LEVEL_WARN, 'Unable to determine projection string for UGRID net file '''//trim(filename)//'''.')
-            if (iand(unc_writeopts, UG_WRITE_LATLON) /= 0) then
-               call mess(LEVEL_WARN, 'NcWriteLatLon cannot be used if projection string is unknown. Switched off.')
-               unc_writeopts = iand(unc_writeopts, not(UG_WRITE_LATLON))
-            end if
-         end if
-      end if
-   end subroutine unc_read_net
-
-   subroutine unc_read_net_old(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
-      use precision, only: dp
       use network_data
       use m_sferic
       use m_missing
@@ -11321,8 +11284,24 @@ contains
       integer :: L
       real(kind=dp) :: zk_fillvalue
 
+      call readyy('Reading net data', 0.0_dp)
+
+      call prepare_error('Could not read NetCDF file '''//trim(filename)//'''. Details follow:')
+
       nerr_ = 0
       allocate (character(len=0) :: coordsyscheck)
+
+      !
+      ! Try and read as new UGRID NetCDF format
+      !
+      call unc_read_net_ugrid(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
+      if (ierr == dfm_noerr) then
+         ! UGRID successfully read, we're done.
+         return
+      else
+         ! No UGRID, but just try to use the 'old' format now.
+         continue
+      end if
 
       ierr = unc_open(filename, nf90_nowrite, inetfile)
       call check_error(ierr, 'file '''//trim(filename)//'''')
@@ -11459,7 +11438,7 @@ contains
       ierr = unc_close(inetfile)
       call readyy('Reading net data', -1.0_dp)
 
-   end subroutine unc_read_net_old
+   end subroutine unc_read_net
 
 !> print MD5 checksum for net file, based on netlinks only.
 !! Only in case of loglevel is debug or all.


### PR DESCRIPTION
This is an attempt to fix the test: `e02_f014_c120` which has been flaky. Here's the [test history](
https://dpcbuild.deltares.nl/test/7298440300687791830?currentProjectId=Delft3D_WindowsTest_virtual)
The frequency of failures started increasing after merging this PR from three weeks ago: [ncWriteLatLon should write latitude and longitude for model in known projected coordinate system](https://github.com/Deltares/Delft3D/pull/1064)
I have tried my best to find the root cause of the bug (or perhaps several bugs) but haven't found it yet. My attempts to fix it have been on TeamCity (I can't reproduce it on my laptop), and I've had to resort to print-debugging. But it seems the crash occurs in `detect_proj_string` added in the PR above. Although I have seen crashes at earlier points (somewhere in flow_geominit). It seems this particular test has something wrong in the `_net.nc` file. But I haven't been able to pin it down yet.

I have posted about it in the [flaky test channel]( https://teams.microsoft.com/l/message/19:66c48107e28c44a68ac4198fefb3a0fc@thread.tacv2/1786951815241?tenantId=15f3fe0e-d712-4981-bc7c-fe949af215bb&groupId=13e11e46-4789-469c-ab6c-82a96e94a3fd&parentMessageId=1786951815241&teamName=HMWESS&channelName=Flaky%20tests&createdTime=1786951815241)
There is a [JIRA issue](https://issuetracker.deltares.nl/browse/UNST-10262)

I will not close UNST-10262 after this merge, but I either keep it open or create a follow-up issue to find the problem with the `detect_proj_string`. For now, reverting a commit from PR number 1064 seems to improve the flakyness significantly.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
