### PR TITLE
Increase drtc 3d cases max run times, because we're experiencing timeouts

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_3D.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_3D.xml
@@ -2,7 +2,7 @@
   <!-- ======================================================================== -->
   <testCase name="e105_f06_c071_generalstructure_door_closing_at_sill_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c071_generalstructure_door_closing_at_sill_3Dsigma</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
 
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
@@ -22,7 +22,7 @@
   </testCase>
   <testCase name="e105_f06_c074_generalstructure_door_closing_at_sill_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c074_generalstructure_door_closing_at_sill_3Dz</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
 
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
@@ -42,7 +42,7 @@
   </testCase>
   <testCase name="e105_f06_c077_generalstructure_door_closing_at_sill_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c077_generalstructure_door_closing_at_sill_3Dz_sigma</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
 
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
@@ -62,7 +62,7 @@
   </testCase>
   <testCase name="e105_f06_c072__generalstructure_lowering_open_door_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c072_generalstructure_lowering_open_door_3Dsigma</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -81,7 +81,7 @@
   </testCase>
   <testCase name="e105_f06_c075__generalstructure_lowering_open_door_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c075_generalstructure_lowering_open_door_3Dz</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -100,7 +100,7 @@
   </testCase>
   <testCase name="e105_f06_c078__generalstructure_lowering_open_door_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c078_generalstructure_lowering_open_door_3Dz_sigma</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -119,7 +119,7 @@
   </testCase>
   <testCase name="e105_f06_c073_generalstructure_lowering_closed_door_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c073_generalstructure_lowering_closed_door_3Dsigma</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>
@@ -138,7 +138,7 @@
   </testCase>
   <testCase name="e105_f06_c076_generalstructure_lowering_closed_door_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c076_generalstructure_lowering_closed_door_3Dz</path>
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>
@@ -158,7 +158,7 @@
   <testCase name="e105_f06_c079_generalstructure_lowering_closed_door_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c079_generalstructure_lowering_closed_door_3Dz_sigma</path>
 
-      <maxRunTime>900</maxRunTime>
+      <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_restart.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_restart.xml
@@ -102,6 +102,7 @@
   </testCase>
   <testCase name="e105_f05_c08_f01_c071_closing_at_sill" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f05_restart/c08_f01_c071_closing_at_sill</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="NETCDF">
         <parameters>
@@ -114,6 +115,7 @@
   </testCase>
   <testCase name="e105_f05_c09_f01_c071_closing_at_sill_refdate_2006_12_31" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f05_restart/c09_f01_c071_closing_at_sill_refdate_2006_12_31</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="NETCDF">
         <parameters>
@@ -126,6 +128,7 @@
   </testCase>
   <testCase name="e105_f05_c10_f01_c071_closing_at_sill_restart_2007_01_03" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f05_restart/c10_f01_c071_closing_at_sill_restart_2007_01_03</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="NETCDF">
         <parameters>
@@ -138,6 +141,7 @@
   </testCase>
   <testCase name="e105_f05_c11_f01_c071_closing_at_sill_restart_2007_01_03_refdate_2006_12_31" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f05_restart/c11_f01_c071_closing_at_sill_restart_2007_01_03_refdate_2006_12_31</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="NETCDF">
         <parameters>


### PR DESCRIPTION
These ones also slipped under the radar.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
