### PR TITLE
UNST-10126: Set default MinTimestepBreak to 0.001

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
@@ -199,7 +199,7 @@ contains
       umag_max_err = 0.0_dp ! max. velocity: off
       ssc_max_err = 0.0_dp
       s01maxavg_min_err = 0.0_dp !< min. avg. water level change: off
-      dtavg_min_err = 0.0_dp !< smallest allowed timestep, otherwise break: off
+      dtavg_min_err = 0.001_dp !< smallest allowed timestep, otherwise break: off
       s1_max_warn = 0.0_dp
       u1abs_max_warn = 0.0_dp
       umag_max_warn = 0.0_dp

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
@@ -51,7 +51,7 @@ contains
       use m_flow_validatestate_data
       use m_flow_externaloutput_direct, only: flow_externaloutput_direct
       use precision, only: dp
-      use messagehandling, only: LEVEL_WARN, msgbuf, mess, warn_flush
+      use messagehandling, only: LEVEL_WARN, LEVEL_ERROR, msgbuf, mess, warn_flush
       use m_flow
       use m_flowgeom
       use m_flowparameters
@@ -144,8 +144,8 @@ contains
          ! at least done dnt > VALIDATESTATEWINDOWSIZE time steps, to prevent the initial
          ! spin-up period to cause unwanted simulation breaks.
          if (dnt >= VALIDATESTATEWINDOWSIZE_double .and. dtavg < dtavg_min_err) then
-            write (msgbuf, '(a,e11.4,a,e11.4,a)') 'Comp. time step average below threshold: ', dtavg, ' < ', dtavg_min_err, '.'
-            call mess(LEVEL_WARN, msgbuf)
+            write (msgbuf, '(a,e11.4,a,e11.4,a)') 'Average computational time step below threshold: ', dtavg, ' < ', dtavg_min_err, '.'
+            call mess(LEVEL_ERROR, msgbuf)
             iresult = DFM_INVALIDSTATE
          end if
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/flow_validatestate.f90
@@ -198,8 +198,8 @@ contains
       u01_max_err = 0.0_dp ! max. velocity change: off
       umag_max_err = 0.0_dp ! max. velocity: off
       ssc_max_err = 0.0_dp
-      s01maxavg_min_err = 0.0_dp !< min. avg. water level change: off
-      dtavg_min_err = 0.001_dp !< smallest allowed timestep, otherwise break: off
+      s01maxavg_min_err = 0.0_dp ! min. avg. water level change: off
+      dtavg_min_err = 0.001_dp ! smallest allowed timestep, otherwise break: off
       s1_max_warn = 0.0_dp
       u1abs_max_warn = 0.0_dp
       umag_max_warn = 0.0_dp


### PR DESCRIPTION
# What was done 

- Set default `MinTimestepBreak` to 0.001
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
