### PR TITLE
UNST-10134: adding forgotten doc images

### DIFF
--- a/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f006_external_forcing/c401_katwijk_fixed/doc.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 89fbf4187c9887a77ac16dec4b96a338.dir
-  size: 60447
-  nfiles: 3
+- md5: 0a1405f2adc3a9c709289f219c1db85b.dir
+  size: 790426
+  nfiles: 11
   hash: md5
   path: doc


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
