### PR TITLE
feat: require approval for VA run jobs

### DIFF
--- a/ci/teamcity/Delft3D/verschilanalyse/ReportVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/ReportVerschilanalyse.kt
@@ -18,6 +18,12 @@ object ReportVerschilanalyse: BuildType({
         summaries
     """.trimIndent()
 
+    features {
+        approval {
+            approvalRules = "group:VERSCHILANALYSE:1"
+        }
+    }
+
     params {
         param("current_prefix", "output/weekly/development")
         param("reference_prefix", "output/release/2025.01")

--- a/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
@@ -18,6 +18,12 @@ object StartVerschilanalyse : BuildType({
         cleanCheckout = true
     }
 
+    features {
+        approval {
+            approvalRules = "group:VERSCHILANALYSE:1"
+        }
+    }
+
     params {
         param("harbor_webhook.image.tag", "development")
         param("va_harbor_protocol", "docker")


### PR DESCRIPTION
# What was done 

Since a VA requires quite some computation and has side effects, not everyone should be able to run one. This PR introduces the need to get at least one approval from a VA runner before being able to submit it. 

Should be merged after #1217 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link

DEVOPSDSC-982 