### PR TITLE
feat: add jira epic link to VA email

### DIFF
--- a/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
+++ b/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
@@ -49,7 +49,7 @@ class HtmlFormatter:
                 </ul>
                 <h3>Detailed difference analysis</h3>
                 <p>
-                    Detailed analyses are available in the JIRA Epic: 
+                    Detailed analyses are available in the JIRA Epic:
                     <a href="https://issuetracker.deltares.nl/browse/UNST-9541">UNST-9541</a>. An issue is created only
                     for DIMRset versions with detected differences.
                 </p>

--- a/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
+++ b/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
@@ -47,6 +47,12 @@ class HtmlFormatter:
                     <li>Current output: {current_prefix}</li>
                     <li>Reference output: {reference_prefix}</li>
                 </ul>
+                <h3>Detailed Difference analysis</h3>
+                <p>
+                    detailed analyses are available in the JIRA Epic: 
+                    <a href="https://issuetracker.deltares.nl/browse/UNST-9541">UNST-9541</a>. An issue is created only
+                    for DIMRset versions with detected differences.
+                </p>
                 <h3>Verschillentool output</h3>
                 <p>
                     The verschillentool compared the current output files to the

--- a/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
+++ b/ci/python/ci_tools/verschilanalyse/util/html_formatter.py
@@ -47,9 +47,9 @@ class HtmlFormatter:
                     <li>Current output: {current_prefix}</li>
                     <li>Reference output: {reference_prefix}</li>
                 </ul>
-                <h3>Detailed Difference analysis</h3>
+                <h3>Detailed difference analysis</h3>
                 <p>
-                    detailed analyses are available in the JIRA Epic: 
+                    Detailed analyses are available in the JIRA Epic: 
                     <a href="https://issuetracker.deltares.nl/browse/UNST-9541">UNST-9541</a>. An issue is created only
                     for DIMRset versions with detected differences.
                 </p>


### PR DESCRIPTION
# What was done 

Adds a link to the jira epic to the weekly VA email as requested. Should be merged after #1217 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
DEVOPSCICD-14