### PR TITLE
UNST-10068; map atmosphericpressure ext-alias to airPressure for bc support

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
@@ -578,7 +578,7 @@ contains
          end if
          ! Each qhbnd polytim file replaces exactly one element in the target data array.
          ! Converter will put qh value in target_array(n_qhbnd)
-      case ('windx', 'windy', 'windxy', 'stressxy', 'airpressure', 'atmosphericpressure', 'airpressure_windx_windy', 'airdensity', &
+      case ('windx', 'windy', 'windxy', 'stressxy', 'airpressure', 'airpressure_windx_windy', 'airdensity', &
             'airpressure_windx_windy_charnock', 'charnock', 'airpressure_stressx_stressy', 'humidity', 'dewpoint', 'airtemperature', &
             'cloudiness', 'solarradiation', 'longwaveradiation', 'sensibleheatflux', 'latentheatflux')
          if (present(srcmaskfile)) then
@@ -893,7 +893,7 @@ contains
             goto 1234
          end if
          source_connection_created = .true.
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          if (ec_filetype == provFile_spiderweb) then ! other filetypes are handled generically
             sourceItemName = 'p_drop'
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -223,7 +223,7 @@ contains
             ! Retrieve stress's y-component for ext-file quantity 'stressy'.
          else if (ec_item_id == item_stressy) then
             call get_timespace_value_by_item(item_stressy)
-            ! Retrieve wind's p-component for ext-file quantity 'atmosphericpressure'.
+            ! Retrieve wind's p-component for ext-file quantity 'airpressure'.
          else if (ec_item_id == item_atmosphericpressure) then
             call get_timespace_value_by_item(item_atmosphericpressure)
             ! Retrieve value for ext-file quantity 'pseudo_air_pressure'.

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -224,8 +224,8 @@ contains
          else if (ec_item_id == item_stressy) then
             call get_timespace_value_by_item(item_stressy)
             ! Retrieve wind's p-component for ext-file quantity 'airpressure'.
-         else if (ec_item_id == item_atmosphericpressure) then
-            call get_timespace_value_by_item(item_atmosphericpressure)
+         else if (ec_item_id == item_airpressure) then
+            call get_timespace_value_by_item(item_airpressure)
             ! Retrieve value for ext-file quantity 'pseudo_air_pressure'.
          else if (ec_item_id == item_pseudo_air_pressure) then
             call get_timespace_value_by_item(item_pseudo_air_pressure)
@@ -283,7 +283,7 @@ contains
          end do
       end if
 
-      if (item_atmosphericpressure /= ec_undef_int) then
+      if (item_airpressure /= ec_undef_int) then
          do k = 1, ndx
             if (comparereal(air_pressure(k), dmiss, EPS10) == 0) then
                air_pressure(k) = BACKGROUND_AIR_PRESSURE
@@ -2867,7 +2867,7 @@ contains
       end if
 
       if (ja_computed_airdensity == 1) then
-         if ((item_apwxwy_p == ec_undef_int) .and. (item_atmosphericpressure == ec_undef_int)) then
+         if ((item_apwxwy_p == ec_undef_int) .and. (item_airpressure == ec_undef_int)) then
             call mess(LEVEL_ERROR, 'When "computedAirdensity = 1", quantity airpressure must be provided in the .ext file.')
          end if
          if ((item_hac_air_temperature == ec_undef_int) .and. (item_hacs_air_temperature == ec_undef_int) .and. &

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -822,7 +822,7 @@ contains
       case ('airdensity')
          call realloc(air_density, ndx, fill=0.0_dp, keepexisting=.true.)
 
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          call realloc(air_pressure, ndx, keepExisting=.true., fill=0.0_dp)
 
       case ('pseudoairpressure')
@@ -1250,7 +1250,7 @@ contains
       case ('airdensity')
          ja_airdensity = 1
 
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          air_pressure_available = .true.
 
       case ('pseudoAirPressure')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -123,6 +123,7 @@ contains
          maxSearchRadius = -1
          call readprovider(mext, qid, filename, filetype, method, operand, transformcoef, ja, varname, sourcemask, maxSearchRadius)
          if (ja == 1) then
+            qid = quantity_name_config_file_to_internal_name(qid)
             call resolvePath(filename, md_extfile_dir)
 
             call mess(LEVEL_INFO, 'External Forcing or Initialising '''//trim(qid)//''' from file '''//trim(filename)//'''.')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -32,7 +32,7 @@ submodule(fm_external_forcings) fm_external_forcings_update
    use m_flowtimes, only: handle_ext, irefdate, tunit, time1
    use m_flowgeom, only: ndx, lnx
    use m_meteo, only: ec_gettimespacevalue, ecgetvalues, twav, success, air_pressure, pavbnd, ja_airdensity, item_air_density, &
-                      air_density, ja_computed_airdensity, item_atmosphericpressure, item_air_temperature, air_temperature, &
+                      air_density, ja_computed_airdensity, item_airpressure, item_air_temperature, air_temperature, &
                       item_dew_point_temperature, dew_point_temperature, update_wind_stress_each_time_step, temperature_model, &
                       TEMPERATURE_MODEL_EXCESS, TEMPERATURE_MODEL_COMPOSITE, ja_friction_coefficient_time_dependent, item_frcu, frcu, tzone, &
                       ecsupporttimeunitconversionfactor, ncdamsg, item_damlevel, zcdam, ncgensg, item_generalstructure, zcgen, npumpsg, &
@@ -945,14 +945,14 @@ contains
 
 !> prepare_air_pressure_temperature_dew_point_temperature
    module subroutine prepare_air_pressure_temperature_dew_point_temperature(time_in_seconds)
-      use m_meteo, only: item_apwxwy_p, item_atmosphericpressure, item_hac_air_temperature, item_hacs_air_temperature, item_dac_air_temperature, &
+      use m_meteo, only: item_apwxwy_p, item_airpressure, item_hac_air_temperature, item_hacs_air_temperature, item_dac_air_temperature, &
                          item_dacs_air_temperature, item_air_temperature, item_dac_dew_point_temperature, item_dacs_dew_point_temperature, item_dew_point_temperature
 
       real(kind=dp), intent(in) :: time_in_seconds !< Time in seconds
 
       ! air pressure items
       call get_timespace_value_by_item_and_consider_success_value(item_apwxwy_p, time_in_seconds)
-      call get_timespace_value_by_item_and_consider_success_value(item_atmosphericpressure, time_in_seconds)
+      call get_timespace_value_by_item_and_consider_success_value(item_airpressure, time_in_seconds)
 
       ! air temperature items
       call get_timespace_value_by_item_and_consider_success_value(item_hac_air_temperature, time_in_seconds)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -4341,7 +4341,7 @@ contains
       case ('normalvelocitybnd')
          itemPtr1 => item_normalvelocitybnd
          dataPtr1 => zbndn
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          itemPtr1 => item_atmosphericpressure
          dataPtr1 => air_pressure
       case ('pseudoairpressure')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -3749,7 +3749,7 @@ module m_meteo
    integer, target :: item_apwxwy_c !< Unique Item id of the ext-file's 'airpressure_windx_windy_charnock' quantity 'c' (space var Charnock).
    integer, target :: item_charnock !< Unique Item id of the ext-file's 'space var Charnock' quantity 'C'.
    integer, target :: item_waterlevelbnd !< Unique Item id of the ext-file's 'waterlevelbnd' quantity's ...-component.
-   integer, target :: item_atmosphericpressure !< Unique Item id of the ext-file's 'atmosphericpressure' quantity
+   integer, target :: item_airpressure !< Unique Item id of the ext-file's 'atmosphericpressure' quantity
    integer, target :: item_pseudo_air_pressure !< Unique Item id of the ext-file's 'pseudo_air_pressure' quantity
    integer, target :: item_water_level_correction !< Unique Item id of the ext-file's 'water_level_correction' quantity
    integer, target :: item_sea_ice_area_fraction !< Unique Item id of the ext-file's 'sea_ice_area_fraction' quantity
@@ -3933,7 +3933,7 @@ contains
       item_apwxwy_c = ec_undef_int
       item_charnock = ec_undef_int
       item_waterlevelbnd = ec_undef_int
-      item_atmosphericpressure = ec_undef_int
+      item_airpressure = ec_undef_int
       item_pseudo_air_pressure = ec_undef_int
       item_water_level_correction = ec_undef_int
       item_sea_ice_area_fraction = ec_undef_int
@@ -4342,7 +4342,7 @@ contains
          itemPtr1 => item_normalvelocitybnd
          dataPtr1 => zbndn
       case ('airpressure')
-         itemPtr1 => item_atmosphericpressure
+         itemPtr1 => item_airpressure
          dataPtr1 => air_pressure
       case ('pseudoairpressure')
          itemPtr1 => item_pseudo_air_pressure

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -4194,6 +4194,8 @@ contains
          quantity_internal_name = 'sea_ice_thickness'
       case ('bedrocksurfaceelevation')
          quantity_internal_name = 'bedrock_surface_elevation'
+      case ('atmosphericpressure')
+         quantity_internal_name = 'airpressure'
       case default
          ! keep other names unchanged
       end select

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -522,7 +522,7 @@ contains
    !! connection when its provider-specific source mapping does not support BC.
    subroutine test_airpressure_bcascii_uses_generic_source_fallback() bind(C)
       use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
-      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_atmosphericpressure
+      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_airpressure
 
       type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
@@ -564,11 +564,11 @@ contains
       call tree_destroy(bnd_ptr)
 
       call f90_expect_true(success, "init_spatial_fields should use the generic fallback for bcascii airpressure")
-      call f90_expect_true(item_atmosphericpressure /= -999, "airpressure should have an EC target item")
+      call f90_expect_true(item_airpressure /= -999, "airpressure should have an EC target item")
 
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 0.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 0.0_dp)
       value_at_t0 = air_pressure(1)
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 50.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 50.0_dp)
       value_at_t50 = air_pressure(1)
 
       call f90_expect_near(value_at_t0, 101325.0_dp, 1.0e-6_dp, "airpressure at t=0 should be read from the BC file")
@@ -582,7 +582,7 @@ contains
    !> Verifies that the 'atmosphericpressure' ext alias correctly works with 'airpressure' .bc data.
    subroutine test_atmosphericpressure_alias_works_as_airpressure() bind(C)
       use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
-      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_atmosphericpressure
+      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_airpressure
 
       type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
@@ -624,11 +624,11 @@ contains
       call tree_destroy(bnd_ptr)
 
       call f90_expect_true(success, "init_spatial_fields should map atmosphericpressure alias to airpressure")
-      call f90_expect_true(item_atmosphericpressure /= -999, "atmosphericpressure should have an EC target item")
+      call f90_expect_true(item_airpressure /= -999, "atmosphericpressure should have an EC target item")
 
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 0.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 0.0_dp)
       value_at_t0 = air_pressure(1)
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 50.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 50.0_dp)
       value_at_t50 = air_pressure(1)
 
       call f90_expect_near(value_at_t0, 101325.0_dp, 1.0e-6_dp, "atmosphericpressure at t=0 should be read from the BC file")
@@ -2057,7 +2057,7 @@ contains
    end subroutine run_scalar_meteo_case
 
    subroutine scalar_meteo_target(quantity, item_id, target_data)
-      use m_meteo, only: item_air_density, item_atmosphericpressure, item_air_temperature, item_cloudiness, &
+      use m_meteo, only: item_air_density, item_airpressure, item_air_temperature, item_cloudiness, &
                          item_dew_point_temperature, item_relative_humidity, item_latent_heat_flux, item_long_wave_radiation, &
                          item_solar_radiation, item_sensible_heat_flux, item_stressx, item_stressy, item_windx, item_windy
       use m_wind, only: air_density, air_pressure, air_temperature, cloudiness, dew_point_temperature, relative_humidity, &
@@ -2076,7 +2076,7 @@ contains
          item_id = item_air_density
          target_data => air_density
       case ('airpressure')
-         item_id = item_atmosphericpressure
+         item_id = item_airpressure
          target_data => air_pressure
       case ('airtemperature')
          item_id = item_air_temperature

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -578,6 +578,66 @@ contains
    end subroutine test_airpressure_bcascii_uses_generic_source_fallback
    !$f90tw)
 
+   !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_atmosphericpressure_alias_works_as_airpressure, test_atmosphericpressure_alias_works_as_airpressure,
+   !> Verifies that the 'atmosphericpressure' ext alias correctly works with 'airpressure' .bc data.
+   subroutine test_atmosphericpressure_alias_works_as_airpressure() bind(C)
+      use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
+      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_atmosphericpressure
+
+      type(tree_data), pointer :: bnd_ptr, block_ptr
+      logical :: success
+      real(dp) :: value_at_t0, value_at_t50
+      character(len=*), parameter :: AIRPRESSURE_BC = "test_airpressure.bc"
+      character(len=*), parameter :: AIRPRESSURE_EXT = "test_atmosphericpressure.ext"
+
+      call create_file(AIRPRESSURE_BC, [ &
+                       "[General]", &
+                       "    fileVersion           = 1.01", &
+                       "    fileType              = boundConds", &
+                       "", &
+                       "[forcing]", &
+                       "    name                  = global", &
+                       "    function              = timeseries", &
+                       "    timeInterpolation     = linear", &
+                       "    quantity              = time", &
+                       "    unit                  = seconds since 2000-01-01 00:00:00", &
+                       "    quantity              = airpressure", &
+                       "    unit                  = Pa", &
+                       "    0    101325.0", &
+                       "    100  101300.0"])
+
+      call create_file(AIRPRESSURE_EXT, [ &
+                       "[Spatial]", &
+                       "    quantity        = atmosphericpressure", &
+                       "    dataFile     = "//AIRPRESSURE_BC, &
+                       "    dataFileType = bcascii"])
+
+      irefdate = 20000101
+      tzone = 0.0_dp
+      tstart_user = 0.0_dp
+      threshold_abort = LEVEL_FATAL
+      call setup_minimal_grid()
+      call initialize_ec_module()
+
+      call parse_spatial_block(AIRPRESSURE_EXT, bnd_ptr, block_ptr)
+      success = init_spatial_fields(block_ptr, BASE_DIR, AIRPRESSURE_EXT, 'Spatial')
+      call tree_destroy(bnd_ptr)
+
+      call f90_expect_true(success, "init_spatial_fields should map atmosphericpressure alias to airpressure")
+      call f90_expect_true(item_atmosphericpressure /= -999, "atmosphericpressure should have an EC target item")
+
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 0.0_dp)
+      value_at_t0 = air_pressure(1)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 50.0_dp)
+      value_at_t50 = air_pressure(1)
+
+      call f90_expect_near(value_at_t0, 101325.0_dp, 1.0e-6_dp, "atmosphericpressure at t=0 should be read from the BC file")
+      call f90_expect_near(value_at_t50, 101312.5_dp, 1.0e-6_dp, "atmosphericpressure at t=50 should be linearly interpolated")
+
+      call teardown_minimal_grid()
+   end subroutine test_atmosphericpressure_alias_works_as_airpressure
+   !$f90tw)
+
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_unknown_quantity_returns_error, test_unknown_quantity_returns_error,
    !> Verifies that a [Spatial] block with an unrecognized quantity causes
    !! init_spatial_fields to return .false.. The 'default' branch in

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -2811,7 +2811,7 @@ contains
          twx = 1
          twy = 2
          twp = 3
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          twp = 1
       case ('windx')
          twx = 1

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
@@ -365,7 +365,7 @@ contains
          ncstdnames(1) = 'surface_downward_eastward_stress'
          ncvarnames(2) = 'tauv' ! northward wind stress
          ncstdnames(2) = 'surface_downward_northward_stress'
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          allocate (ncvarnames(1))
          allocate (ncstdnames(1))
          ncvarnames(1) = 'msl' ! mean sea-level pressure


### PR DESCRIPTION
...because even with recent cleanup in ec_addtimespacerelation, the call to `ecCreateInitializeBCFileReader()` uses the given (ext) quantity name as only name that will be searched in the .bc header. atmosphericpressure was the only remaining alias quantity, all others are unique, so quickest solution was to remap atmosphericpressure to airpressure in the existing function `quantity_name_config_file_to_internal_name()`.

# What was done 

<a short description with bullets> 

- e.g. Restarts are made more robust 
- e.g. Fixes a bug related to the writing of water depth on the map file 
- e.g. Introduces a new functionality on energy losses at bridge piers
- e.g. … 
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
