### PR TITLE
DEVOPSCICD-29: Fix H7 container smoketest after the DVC migration.

### DIFF
--- a/ci/teamcity/Delft3D/linux/container_smoketest/ReceiveH7ContainerSmokeTest.kt
+++ b/ci/teamcity/Delft3D/linux/container_smoketest/ReceiveH7ContainerSmokeTest.kt
@@ -39,6 +39,10 @@ object LinuxReceiveH7ContainerSmokeTest : BuildType({
         password("h7_account_password", DslContext.getParameter("ad_h7_smoke_test_password"))
         
         param("testbench_container_image", "containers.deltares.nl/delft3d-dev/test/delft3d-test-container:alma8-%dep.${LinuxBuild.id}.product%-%dep.${LinuxBuild.id}.commit_id%")
+
+        // TestBench still takes --username/--password; map them to DVC remote credentials.
+        param("s3_dsctestbench_accesskey", DslContext.getParameter("dvc_testbench_accesskey"))
+        password("s3_dsctestbench_secret", DslContext.getParameter("dvc_testbench_secret"))
     }
 
     vcs {
@@ -92,8 +96,7 @@ object LinuxReceiveH7ContainerSmokeTest : BuildType({
                 --rm
                 --pull always
                 --shm-size 8G
-                -v %teamcity.build.workingDir%:/data/data/cases
-                -v %teamcity.build.workingDir%/test/deltares_testbench:/testbench
+                --mount type=bind,source=/dvc-cache/delft3d,target=%teamcity.build.checkoutDir%/.dvc/cache
             """.trimIndent()
         }
     }

--- a/ci/teamcity/Delft3D/linux/container_smoketest/SubmitH7ContainerSmokeTest.kt
+++ b/ci/teamcity/Delft3D/linux/container_smoketest/SubmitH7ContainerSmokeTest.kt
@@ -34,6 +34,10 @@ object LinuxSubmitH7ContainerSmokeTest : BuildType({
 
         // TeamCity configuration name for result upload
         param("teamcity_receive_config", "${LinuxReceiveH7ContainerSmokeTest.id}")
+
+        // TestBench still takes --username/--password; map them to DVC remote credentials.
+        param("s3_dsctestbench_accesskey", DslContext.getParameter("dvc_testbench_accesskey"))
+        password("s3_dsctestbench_secret", DslContext.getParameter("dvc_testbench_secret"))
     }
 
     vcs {
@@ -54,6 +58,7 @@ object LinuxSubmitH7ContainerSmokeTest : BuildType({
                     --reference
                     --skip-run 
                     --skip-post-processing 
+                    --skip-download references
                     --config configs/smoke_tests/apptainer_lnx64.xml
                     --log-level INFO
                     --parallel
@@ -67,8 +72,7 @@ object LinuxSubmitH7ContainerSmokeTest : BuildType({
                 --rm
                 --pull always
                 --shm-size 8G
-                -v %teamcity.build.workingDir%:/data/data/cases
-                -v %teamcity.build.workingDir%/test/deltares_testbench:/testbench
+                --mount type=bind,source=/dvc-cache/delft3d,target=%teamcity.build.checkoutDir%/.dvc/cache
             """.trimIndent()
         }
         script {

--- a/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/common_utilities.sh
+++ b/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/common_utilities.sh
@@ -4,7 +4,28 @@
 # This file contains shared functions used by prepare_all_models.sh and run_all_models.sh
 
 find_dimr_directories() {
+    # DVC checkouts live at <engine>/<feature>/<case>/input and a TestBench work
+    # copy at <case>/input_work. Prefer the work copies so we do not submit both.
+    local dvc_work
+    dvc_work=$(find . -type d -name 'input_work' | sort)
+    if [ -n "$dvc_work" ]; then
+        printf '%s\n' "$dvc_work"
+        return
+    fi
+
     find . -type f \( -name "dimr.xml" -o -name "dimr_config.xml" \) -exec dirname {} \; | sort -u
+}
+
+# JSON model keys are DVC case folder names (parent of input_work), e.g. c010_weir_timeseries.
+smoke_test_model_name() {
+    local dir="$1"
+    local base
+    base=$(basename "$dir")
+    if [ "$base" = "input_work" ]; then
+        basename "$(dirname "$dir")"
+    else
+        echo "$base"
+    fi
 }
 
 is_supported_platform() {

--- a/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/dimr_smoke_test_lnx64_slurm_setup.json
+++ b/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/dimr_smoke_test_lnx64_slurm_setup.json
@@ -1,22 +1,22 @@
 {
     "models": {
-        "e02_f014_c001_trench_EH_par_crs": {
+        "c001_trench_EH_par_crs": {
             "nodes": 2,
             "tasks_per_node": 2
         },
-        "e109_f01_c010_weir_timeseries": {
+        "c010_weir_timeseries": {
             "nodes": 1,
             "tasks_per_node": 1
         },
-        "e112_f01_c11_waardenburg": {
+        "c11_waardenburg": {
             "nodes": 1,
             "tasks_per_node": 1
         },
-        "e02_f030_c001_frisianinlet_dynamo": {
+        "c001_frisianinlet_dynamo": {
             "nodes": 1,
             "tasks_per_node": 1
         },
-        "e100_f00_c00": {
+        "c00-FriesianInlet_schematic_nonstat": {
             "nodes": 1,
             "tasks_per_node": 1
         }

--- a/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/prepare_all_models.sh
+++ b/ci/teamcity/Delft3D/linux/scripts/hpc-smoke/prepare_all_models.sh
@@ -109,12 +109,20 @@ parse_json_config() {
 
 get_model_config_from_json() {
     local model_name="$1"
-    
+
     if [ -n "${MODEL_CONFIG[$model_name]:-}" ]; then
         echo "${MODEL_CONFIG[$model_name]}"
         return 0
     fi
-    
+
+    local key
+    for key in "${!MODEL_CONFIG[@]}"; do
+        if [[ "$model_name" == *"$key"* ]]; then
+            echo "${MODEL_CONFIG[$key]}"
+            return 0
+        fi
+    done
+
     return 1
 }
 
@@ -267,7 +275,8 @@ prepare_directory() {
     fi
     
     # Get user input for nodes and tasks
-    local model_name=$(basename "$dir")
+    local model_name
+    model_name=$(smoke_test_model_name "$dir")
     echo "    Model: $model_name"
     local nodes_tasks_output
     nodes_tasks_output=$(get_nodes_and_tasks "$model_name")
@@ -286,7 +295,7 @@ prepare_directory() {
     # Extract file information
     local mdu_file_folder=$(extract_working_dir "$dir" "$dimr_file")
     local mdu_file=$(extract_mdu_file "$dir" "$dimr_file")
-    local job_name=$(basename "$dir")
+    local job_name="$model_name"
     
     # Get platform configuration
     get_platform_config "$platform"

--- a/test/deltares_testbench/configs/smoke_tests/apptainer_lnx64.xml
+++ b/test/deltares_testbench/configs/smoke_tests/apptainer_lnx64.xml
@@ -7,16 +7,16 @@
 		<localPaths>
 			<testCasesDir>./data/cases</testCasesDir>
 			<enginesDir>./data/engines</enginesDir>
-			<referenceDir>./data/reference_results</referenceDir>
+			<referenceDir>./data/cases</referenceDir>
 		</localPaths>
 		<locations>
 			<location name="cases">
 				<credential ref="commandline"/>
-				<root>{server_base_url}/cases</root>
+				<root>./data/cases</root>
 			</location>
 			<location name="reference_results">
 				<credential ref="commandline"/>
-				<root>{server_base_url}/references</root>
+				<root>./data/cases</root>
 			</location>
 			<location name="reference_engines">
 				<credential ref="commandline"/>

--- a/test/deltares_testbench/src/suite/test_set_runner.py
+++ b/test/deltares_testbench/src/suite/test_set_runner.py
@@ -474,6 +474,10 @@ class TestSetRunner(ABC):
 
     def __create_dvc_work_copies(self, dvc_configs: list[TestCaseConfig]) -> None:
         """Create _work copies of all DVC input directories serially."""
+        if PathType.INPUT in self.skip_download:
+            self.__logger.info("Skipping DVC work copies (skip download argument for cases)")
+            return
+
         for config in dvc_configs:
             if not config.absolute_test_case_path:
                 continue

--- a/test/deltares_testbench/test/suite/test_ComparisonRunner.py
+++ b/test/deltares_testbench/test/suite/test_ComparisonRunner.py
@@ -496,6 +496,51 @@ class TestComparisonRunner:
             assert f.read() == "new"
         assert not fs.exists(f"{expected_work_path}/old.txt")
 
+    def test_create_dvc_work_copies_skipped_when_input_download_skipped(self, fs: FakeFilesystem) -> None:
+        # Arrange: H7 receive already has results in input_work, plus a pristine input checkout.
+        settings = TestBenchSettings()
+        settings.command_line_settings.skip_download = [PathType.INPUT]
+        logger = MagicMock(spec=ConsoleLogger)
+        runner = ComparisonRunner(settings, logger)
+
+        input_path = "/cases/c010_weir_timeseries/input"
+        work_path = "/cases/c010_weir_timeseries/input_work"
+        fs.makedirs(input_path, exist_ok=True)
+        fs.create_file(f"{input_path}/fresh.txt", contents="from-dvc")
+        fs.makedirs(work_path, exist_ok=True)
+        fs.create_file(f"{work_path}/h7_result.txt", contents="from-h7")
+
+        config = TestComparisonRunner.create_test_case_config("c010_weir_timeseries")
+        config.absolute_test_case_path = work_path
+
+        # Act
+        runner._TestSetRunner__create_dvc_work_copies([config])
+
+        # Assert: existing work copy (H7 output) is left intact.
+        assert fs.exists(f"{work_path}/h7_result.txt")
+        assert not fs.exists(f"{work_path}/fresh.txt")
+
+    def test_create_dvc_work_copies_from_input_when_not_skipped(self, fs: FakeFilesystem) -> None:
+        settings = TestBenchSettings()
+        settings.command_line_settings.skip_download = []
+        logger = MagicMock(spec=ConsoleLogger)
+        runner = ComparisonRunner(settings, logger)
+
+        input_path = "/cases/c010_weir_timeseries/input"
+        work_path = "/cases/c010_weir_timeseries/input_work"
+        fs.makedirs(input_path, exist_ok=True)
+        fs.create_file(f"{input_path}/fresh.txt", contents="from-dvc")
+        fs.makedirs(work_path, exist_ok=True)
+        fs.create_file(f"{work_path}/stale.txt", contents="old")
+
+        config = TestComparisonRunner.create_test_case_config("c010_weir_timeseries")
+        config.absolute_test_case_path = work_path
+
+        runner._TestSetRunner__create_dvc_work_copies([config])
+
+        assert fs.exists(f"{work_path}/fresh.txt")
+        assert not fs.exists(f"{work_path}/stale.txt")
+
     def test_run_prepares_dvc_cases_before_dispatch(self, mocker: MockerFixture) -> None:
         # Arrange
         settings = TestBenchSettings()


### PR DESCRIPTION
Proof-of-work: https://dpcbuild.deltares.nl/buildConfiguration/Delft3D_LinuxReceiveH7ContainerSmokeTest/7786289?buildTab=dependencies&type=snapshot&mode=chain&groupAllProjects=false&groupAllComposite=false