### PR TITLE
UNST-10206 Pass the CMAKE_GENERATOR_INSTANCE to cmake for visual stud…

### DIFF
--- a/build.py
+++ b/build.py
@@ -131,6 +131,9 @@ def run_cmake_configure(
         cmd += ["-T", "fortran=ifx", "-A", "x64"]
         if vs_year and vs_year in VS_GENERATORS:
             cmd += ["-G", VS_GENERATORS[vs_year]]
+            generator_instance = os.environ.get("CMAKE_GENERATOR_INSTANCE")
+            if generator_instance:
+                cmd.append(f"-DCMAKE_GENERATOR_INSTANCE:STRING={generator_instance}")
     else:
         # On Linux, single-config generator; pass build type directly
         cmd += [f"-DCMAKE_BUILD_TYPE={build_type}"]

--- a/ci/dockerfiles/windows/Dockerfile-dhydro-vs2026-i26
+++ b/ci/dockerfiles/windows/Dockerfile-dhydro-vs2026-i26
@@ -26,6 +26,11 @@ RUN $installer = 'C:\vs_Community.exe'; \
         if ($registeredPath -ne $installPath) { \
             throw ('Visual Studio registered at {0}, expected {1}' -f $registeredPath, $installPath) \
         } \
+        $installationVersion = & $vswhere -latest -products * -property installationVersion; \
+        if ($installationVersion -notmatch '^\d+\.\d+\.\d+\.\d+$') { \
+            throw ('Visual Studio reported an invalid installation version: {0}' -f $installationVersion) \
+        } \
+        setx /M CMAKE_GENERATOR_INSTANCE ($installPath + ',version=' + $installationVersion); \
     } finally { \
         Remove-Item -Force $installer -ErrorAction SilentlyContinue \
     }


### PR DESCRIPTION
…io to attempt to resolve the random cmake failures in the vs2026 container

I ran CMake four times in the locally built container, it did not fail.

CMake is supposed to pick up the CMAKE_GENERATOR_INSTANCE from the environment variable, but it appears to fail if the generator is explicitly passed on the command line, so I am also forwarding it to the command line in build.py.


# Issue link UNST-10206
