### PR TITLE
UNST-10214 create_test cmake function wrongly interprets PATH semicol…

### DIFF
--- a/src/cmake/functions.cmake
+++ b/src/cmake/functions.cmake
@@ -339,10 +339,10 @@ function(create_test test_name)
     )
     # Set environment paths to find *.so/*.dll files Make sure DLL is found by adding its directory to PATH
     if (UNIX)
-        set(lib_path "LD_LIBRARY_PATH=${CMAKE_INSTALL_PREFIX}/lib:$ENV{LD_LIBRARY_PATH}")
+        set(lib_path_modification "LD_LIBRARY_PATH=path_list_prepend:${CMAKE_INSTALL_PREFIX}/lib")
     endif (UNIX)
     if (WIN32)
-        set(lib_path "PATH=${CMAKE_INSTALL_PREFIX}/bin\;$ENV{PATH}")
+        set(lib_path_modification "PATH=path_list_prepend:${CMAKE_INSTALL_PREFIX}/bin")
     endif (WIN32)
 
 
@@ -399,7 +399,8 @@ function(create_test test_name)
         set(data_path "DATA_PATH=${TEST_DATA_PATH}")
 
         set_tests_properties(${test_i} PROPERTIES
-            ENVIRONMENT "${lib_path};${data_path}"
+            ENVIRONMENT "${data_path}"
+            ENVIRONMENT_MODIFICATION "${lib_path_modification}"
             LABELS "${labels}"
         )
     endforeach()


### PR DESCRIPTION
…ons as cmake list

On Windows, PATH contains semicolons. Within CMake, semicolons in variables mean that the variable is a list of items with semicolons as the separators. Currently, the create_test function adds PATH, but since it becomes a list, only the first element is added to the path and the rest of the path is thrown away. Currently it works when running cmake --install first, because then the install folder contains all necessary dlls. However, when just running cmake --build suddenly the intel runtime is missing because the system path is not kept.

# Issue link UNST-10214
