### PR TITLE
UNST-10291 Improved checking of coordinate transformation

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -11273,19 +11273,24 @@ contains
 
       call prepare_error('Could not read NetCDF file '''//trim(filename)//'''. Details follow:')
 
-      !
       ! Try and read as new UGRID NetCDF format
-      !
       call unc_read_net_ugrid(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
       if (ierr /= dfm_noerr) then
          ! No UGRID, but just try to use the 'old' format now.
          call unc_read_net_old(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
       end if
-
-      if (ierr == dfm_noerr .and. crs%proj_string == ' ') then
-         ierr = detect_proj_string(crs)
+      if (ierr /= dfm_noerr) then
+         ! An error occurred while reading the net-file; no reason to continue.
+         return
       end if
       
+      ! File reading went fine, now check the coordinate system.
+      if (crs%proj_string == ' ') then
+         ierr = detect_proj_string(crs)
+         ierr = dfm_noerr ! don't stumble over proj string detection errors
+      end if
+
+      ! Check the coordinate transformation to lat/lon if requested.
       if (iand(unc_writeopts, UG_WRITE_LATLON) /= 0) then
          call transform_coordinates(crs%proj_string, WGS84_PROJ_STRING, xk(1:1), yk(1:1), lonn, latn, success)
          if (.not. success) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -11257,6 +11257,7 @@ contains
    subroutine unc_read_net(filename, numk_keep, numl_keep, numk_read, numl_read, ierr)
       use precision, only: dp
       use dfm_error, only: dfm_noerr
+      use network_data, only: xk,yk
 
       character(len=*), intent(in) :: filename !< Name of NetCDF file.
       integer, intent(inout) :: numk_keep !< Number of netnodes to keep in existing net.
@@ -11264,6 +11265,9 @@ contains
       integer, intent(out) :: numk_read !< Number of new netnodes read from file.
       integer, intent(out) :: numl_read !< Number of new netlinks read from file.
       integer, intent(out) :: ierr !< Return status (NetCDF operations)
+
+      logical :: success ! Flag to check if coordinate transformation is successful.
+      real(hp), dimension(1) :: lonn, latn ! Temporary arrays to receive test conversion.
 
       call readyy('Reading net data', 0.0_dp)
 
@@ -11280,13 +11284,15 @@ contains
 
       if (ierr == dfm_noerr .and. crs%proj_string == ' ') then
          ierr = detect_proj_string(crs)
-         if (ierr /= dfm_noerr) then
-            ierr = dfm_noerr
-            call mess(LEVEL_WARN, 'Unable to determine projection string for UGRID net file '''//trim(filename)//'''.')
-            if (iand(unc_writeopts, UG_WRITE_LATLON) /= 0) then
-               call mess(LEVEL_WARN, 'NcWriteLatLon cannot be used if projection string is unknown. Switched off.')
-               unc_writeopts = iand(unc_writeopts, not(UG_WRITE_LATLON))
-            end if
+      end if
+      
+      if (iand(unc_writeopts, UG_WRITE_LATLON) /= 0) then
+         call transform_coordinates(crs%proj_string, WGS84_PROJ_STRING, xk(1:1), yk(1:1), lonn, latn, success)
+         if (.not. success) then
+            call mess(LEVEL_WARN, 'Unable to transform coordinates to WGS84; most likely the projection is not specified.')
+            call mess(LEVEL_WARN, 'NcWriteLatLon cannot be used if transformation fails. Switched off.')
+            unc_writeopts = iand(unc_writeopts, not(UG_WRITE_LATLON))
+            crs%proj_string = ' ' ! set_model_boundingbox checks for empty proj string
          end if
       end if
    end subroutine unc_read_net

--- a/src/utils_lgpl/io_netcdf/packages/io_netcdf/src/coordinate_reference_system.F90
+++ b/src/utils_lgpl/io_netcdf/packages/io_netcdf/src/coordinate_reference_system.F90
@@ -238,7 +238,7 @@ end function get_proj_string_from_epsg
 
    !> Transforms the given coordinates from the given source coordinate system to the given destination coordinate system.
    ! This subroutine uses the proj library for coordinate transformations.
-   subroutine transform_coordinates(src_proj_string, dst_proj_string, src_x, src_y, dst_x, dst_y)
+   subroutine transform_coordinates(src_proj_string, dst_proj_string, src_x, src_y, dst_x, dst_y, success)
       use proj
       use iso_c_binding, only: c_char, c_null_char
 
@@ -250,6 +250,7 @@ end function get_proj_string_from_epsg
       real(kind=kind(1.0d00)), dimension(:), intent(in)  :: src_y           !< y coordinates to transform in degrees/meters.
       real(kind=kind(1.0d00)), dimension(:), intent(out) :: dst_x           !< transformed x coordinates in degrees/meters.
       real(kind=kind(1.0d00)), dimension(:), intent(out) :: dst_y           !< transformed y coordinates in degrees/meters.
+      logical, optional, intent(out) :: success !< Whether the transformation was successful.
 
       type(pj_object) :: coord_trans !< Proj coordinate transformation.
       character(kind=c_char, len=:), allocatable :: src_proj_c, dst_proj_c
@@ -263,12 +264,19 @@ end function get_proj_string_from_epsg
 
       if (proj_associated_pj(coord_trans)) then
          call transform(coord_trans, src_x, src_y, dst_x, dst_y)
+         if (present(success)) then
+            success = .true.
+         end if
       else
          dst_x = src_x
          dst_y = src_y
-         write (message, *) 'transform_coordinates: proj_create_crs_to_crs failed. len(src)=', &
-            len_trim(src_proj_string), ', len(dst)=', len_trim(dst_proj_string)
-         call mess(LEVEL_WARN, trim(message))
+         if (present(success)) then
+            success = .false.
+         else
+            write (message, *) 'transform_coordinates: proj_create_crs_to_crs failed. len(src)=', &
+               len_trim(src_proj_string), ', len(dst)=', len_trim(dst_proj_string)
+            call mess(LEVEL_WARN, trim(message))
+         end if
       end if
 
       coord_trans = proj_destroy(coord_trans)


### PR DESCRIPTION
# What was done 

Check once if coordinate transformation works. If not, give a warning and switch of NcWriteLatLon and set projection string to empty such that no further attempts are made to convert coordinates.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [x]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link

UNST-10291