### PR TITLE
feat: remove VA webhook

### DIFF
--- a/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
@@ -4,6 +4,7 @@ import java.io.File
 import jetbrains.buildServer.configs.kotlin.*
 import jetbrains.buildServer.configs.kotlin.buildSteps.*
 import jetbrains.buildServer.configs.kotlin.buildFeatures.*
+import jetbrains.buildServer.configs.kotlin.triggers.finishBuildTrigger
 
 import Delft3D.verschilanalyse.ReportVerschilanalyse
 
@@ -18,12 +19,16 @@ object StartVerschilanalyse : BuildType({
         cleanCheckout = true
     }
 
-    if (DslContext.getParameter("start_verschilanalyze").lowercase() == "true") {
+    if (DslContext.getParameter("enable_verschilanalyse_trigger").lowercase() == "true") {
         triggers {
             finishBuildTrigger {
                 buildType = "Delft3D_Publish"
                 successfulOnly = true
-                branchFilter = branchFilters
+		branchFilter = """
+		    +:<default>
+		    +:main
+		    +:all/release/*
+		""".trimIndent()
             }
         }
     }   

--- a/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
+++ b/ci/teamcity/Delft3D/verschilanalyse/StartVerschilanalyse.kt
@@ -18,6 +18,16 @@ object StartVerschilanalyse : BuildType({
         cleanCheckout = true
     }
 
+    if (DslContext.getParameter("start_verschilanalyze").lowercase() == "true") {
+        triggers {
+            finishBuildTrigger {
+                buildType = "Delft3D_Publish"
+                successfulOnly = true
+                branchFilter = branchFilters
+            }
+        }
+    }   
+
     params {
         param("harbor_webhook.image.tag", "development")
         param("va_harbor_protocol", "docker")
@@ -61,34 +71,6 @@ object StartVerschilanalyse : BuildType({
             checked = "true", 
             unchecked = "false",
         )
-    }
-
-    triggers {
-        if (DslContext.getParameter("enable_verschilanalyse_trigger").lowercase() == "true") {
-            // TeamCity webhook plugin docs: https://github.com/tcplugins/tcWebHookTrigger
-            // I couldn't find a webhook event payload example in the Harbor documentation,
-            // but this GitHub issue comment has an example:
-            // https://github.com/keel-hq/keel/issues/510#issuecomment-647014097
-            trigger {
-                type = "webhookBuildTrigger"
-                param("webhook.build.trigger.path.mappings", """
-                    name=harbor_webhook.type::path=${'$'}.type::required=true
-                    name=harbor_webhook.image.digest::path=${'$'}.event_data.resources[0].digest::required=true
-                    name=harbor_webhook.image.tag::path=${'$'}.event_data.resources[0].tag::required=true
-                    name=harbor_webhook.image.url::path=${'$'}.event_data.resources[0].resource_url::required=true
-                    name=harbor_webhook.repository::path=${'$'}.event_data.repository.name::required=true
-                    name=harbor_webhook.project::path=${'$'}.event_data.repository.namespace::required=true
-                """.trimIndent())
-                param("webhook.build.trigger.path.filters", """
-                    name=harbor_webhook.type::template=${'$'}{harbor_webhook.type}::regex=PUSH_ARTIFACT
-                    name=harbor_webhook.project::template=${'$'}{harbor_webhook.project}::regex=${DslContext.getParameter("va_harbor_project")}
-                    name=harbor_webhook.repository::template=${'$'}{harbor_webhook.repository}::regex=${DslContext.getParameter("va_harbor_repository")}
-                    name=harbor_webhook.image.tag::template=${'$'}{harbor_webhook.image.tag}::regex=${DslContext.getParameter("va_harbor_webhook_image_tag_regex")}
-                    name=current_prefix::template=output/weekly/${'$'}{harbor_webhook.image.tag}::regex=output/weekly/${DslContext.getParameter("va_harbor_webhook_image_tag_regex")}
-                """.trimIndent())
-                param("webhook.build.trigger.include.payload", "true")
-            }
-        }
     }
 
     steps {


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

removes the webhook trigger in favour of a finished build trigger in publish.  This enables us to push images/tags without triggering the VA and the VA job becomes better visible in the chain.

Not to be merged before the  2027.01 release is finalised. 

# Issue link
DEVOPSDSC-704