### PR TITLE
Datavalue is now time dependent if any other block of the same quanti…

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
@@ -1505,6 +1505,10 @@ contains
          end if
       end if
 
+      if (present(tgt_item1) .and. associated(targetItemPtr1)) then
+         tgt_item1 = targetItemPtr1
+      end if
+
       ec_addtimespacerelation = .true.
       return
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -51,6 +51,7 @@ contains
       use m_meteo, only: item_waqfun, item_waqsfun
       use m_ec_parameters, only: ec_undef_int
       use m_source_sink, only: source_sinks
+      use m_spatial_field, only: deallocate_time_dependent_spatial_quantities
       use m_unstruc_model_data, only: extfile_new_list
       use messageHandling, only: warn_flush, err_flush, msgbuf, LEVEL_FATAL
       use processes_input, only: num_time_functions, num_spatial_time_fuctions, nosfunext
@@ -124,6 +125,8 @@ contains
          call split_filename(file_names(i_ext), base_dirs(i_ext), fnam)
 
       end do
+
+      call scan_time_dependent_spatial_inputs(bnd_ptrs)
 
       ! Register all global WAQ functions before creating any EC target fields.
       ! Growing funinp after a field points into it would invalidate that pointer.
@@ -227,7 +230,7 @@ contains
             istat, &
             prefix='While reading '''//trim(file_names(i_ext))//'''', &
             print_context_keywords=['quantity', 'dataFile'] &
-         )
+            )
 
          if (allocated(itpenzr)) then
             deallocate (itpenzr)
@@ -248,6 +251,8 @@ contains
          call tree_destroy(bnd_ptrs(i_ext)%node_ptr)
       end do
 
+      call deallocate_time_dependent_spatial_quantities()
+
       if (res) then
          iresult = DFM_NOERR
       else
@@ -255,6 +260,69 @@ contains
       end if
 
    end subroutine init_new
+
+   !> Collect quantities with an input that is updated during the time loop.
+   subroutine scan_time_dependent_spatial_inputs(bnd_ptrs)
+      use m_meteo, only: quantity_name_config_file_to_internal_name
+      use m_spatial_field, only: t_spatial_field_input, read_spatial_field_block, is_static_file_type, &
+                                 allocate_time_dependent_spatial_quantities, register_time_dependent_spatial_quantity
+      use precision_basics, only: comparereal
+      use string_module, only: str_tolower
+      use timespace, only: convert_method_string_to_integer, get_default_method_for_file_type, &
+                           update_method_with_weightfactor_fallback, update_method_in_case_extrapolation
+      use tree_data_types, only: tree_data, tree_data_ptr
+      use tree_structures, only: tree_get_name, tree_num_nodes
+
+      type(tree_data_ptr), dimension(:), intent(in) :: bnd_ptrs
+
+      type(tree_data), pointer :: bnd_ptr
+      type(tree_data), pointer :: block_ptr
+      type(t_spatial_field_input) :: input
+      integer :: i, i_ext, max_num_quantities, num_items
+      character(len=:), allocatable :: group_name
+
+      max_num_quantities = 0
+      do i_ext = 1, size(bnd_ptrs)
+         max_num_quantities = max_num_quantities + tree_num_nodes(bnd_ptrs(i_ext)%node_ptr)
+      end do
+      call allocate_time_dependent_spatial_quantities(max_num_quantities)
+
+      do i_ext = 1, size(bnd_ptrs)
+         bnd_ptr => bnd_ptrs(i_ext)%node_ptr
+         num_items = tree_num_nodes(bnd_ptr)
+         do i = 1, num_items
+            block_ptr => bnd_ptr%child_nodes(i)%node_ptr
+            group_name = str_tolower(trim(tree_get_name(block_ptr)))
+            select case (group_name)
+            case ('spatial', 'meteo', 'parameter', 'initial')
+               input = read_spatial_field_block(block_ptr)
+            case default
+               cycle
+            end select
+
+            if (comparereal(input%data_value, dmiss) /= 0) then
+               cycle
+            end if
+            input%quantity = quantity_name_config_file_to_internal_name(input%quantity)
+            if (len_trim(input%quantity) == 0 .or. len_trim(input%forcing_file_type) == 0) then
+               cycle
+            end if
+            if (len_trim(input%interpolation_method) > 0) then
+               input%method = convert_method_string_to_integer(input%interpolation_method)
+               call update_method_with_weightfactor_fallback(input%forcing_file_type, input%method)
+            else
+               input%method = get_default_method_for_file_type(input%forcing_file_type)
+            end if
+            if (input%method == -1) cycle
+            call update_method_in_case_extrapolation(input%method, input%is_extrapolation_allowed)
+
+            if (.not. is_static_file_type(input%forcing_file_type, input%method)) then
+               call register_time_dependent_spatial_quantity(input%quantity)
+            end if
+         end do
+      end do
+
+   end subroutine scan_time_dependent_spatial_inputs
 
    !> Checks the version number of the external forcing file and opens it, returning a pointer to the tree of external forcings file boundary blocks.
    subroutine check_version_number_and_open_external_forcing_file(external_force_file_name, bnd_ptr, major, iresult)
@@ -967,9 +1035,9 @@ contains
       use tree_data_types, only: tree_data
       use fm_location_types, only: parse_spatial_location_type, UNC_LOC_S, UNC_LOC_U, UNC_LOC_3DV, UNC_LOC_S3D, SPATIAL_LOCATION_1D, SPATIAL_LOCATION_2D, SPATIAL_LOCATION_ALL
       use m_meteo, only: ec_addtimespacerelation, ec_gettimespacevalue_by_itemID, ecInstancePtr
-      use m_flowtimes, only: tzone, tunit
+      use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
       use m_ec_parameters, only: ec_undef_int
-      use timespace_parameters, only: WEIGHTFACTORS, FIELD1D
+      use timespace_parameters, only: WEIGHTFACTORS, FIELD1D, DATAVALUE
       use properties, only: prop_get
       use m_alloc, only: realloc, reallocP
       use m_spatial_field, only: t_spatial_field_input, read_spatial_field_block, validate_spatial_field_input, &
@@ -1103,7 +1171,14 @@ contains
                      oper = OPERAND_OVERRIDE ! first call must always override, actual operand to be applied in initialfield2Dto3D_dbl_indx
                   end if
 
-                  if (associated(target_data)) then
+                  if (filetype == DATAVALUE .and. associated(target_data)) then
+                     res = ec_addtimespacerelation(quantity, target_x, target_y, mask, kx, forcing_file, filetype, &
+                                                   method, oper, data_value=input%data_value, tgt_item1=ec_item, tgt_data1=target_data)
+                     if (res) then
+                        res = ec_gettimespacevalue_by_itemID(ecInstancePtr, ec_item, irefdate, tzone, tunit, tstart_user, target_data)
+                     end if
+                     ec_item = ec_undef_int
+                  else if (associated(target_data)) then
                      res = timespaceinitialfield(target_x, target_y, target_data, target_num_points, &
                                                  forcing_file, filetype, method, oper, transformcoef, target_location_type, mask)
                   else if (associated(target_data_integer)) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -264,12 +264,11 @@ contains
    !> Collect quantities with an input that is updated during the time loop.
    subroutine scan_time_dependent_spatial_inputs(bnd_ptrs)
       use m_meteo, only: quantity_name_config_file_to_internal_name
-      use m_spatial_field, only: t_spatial_field_input, read_spatial_field_block, is_static_file_type, &
-                                 allocate_time_dependent_spatial_quantities, register_time_dependent_spatial_quantity
+      use m_spatial_field, only: t_spatial_field_input, read_spatial_field_block, select_spatial_field_method, &
+                                 is_static_file_type, allocate_time_dependent_spatial_quantities, &
+                                 register_time_dependent_spatial_quantity
       use precision_basics, only: comparereal
       use string_module, only: str_tolower
-      use timespace, only: convert_method_string_to_integer, get_default_method_for_file_type, &
-                           update_method_with_weightfactor_fallback, update_method_in_case_extrapolation
       use tree_data_types, only: tree_data, tree_data_ptr
       use tree_structures, only: tree_get_name, tree_num_nodes
 
@@ -307,14 +306,8 @@ contains
             if (len_trim(input%quantity) == 0 .or. len_trim(input%forcing_file_type) == 0) then
                cycle
             end if
-            if (len_trim(input%interpolation_method) > 0) then
-               input%method = convert_method_string_to_integer(input%interpolation_method)
-               call update_method_with_weightfactor_fallback(input%forcing_file_type, input%method)
-            else
-               input%method = get_default_method_for_file_type(input%forcing_file_type)
-            end if
+            input%method = select_spatial_field_method(input%forcing_file_type, input%interpolation_method, input%is_extrapolation_allowed)
             if (input%method == -1) cycle
-            call update_method_in_case_extrapolation(input%method, input%is_extrapolation_allowed)
 
             if (.not. is_static_file_type(input%forcing_file_type, input%method)) then
                call register_time_dependent_spatial_quantity(input%quantity)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -40,7 +40,7 @@ module m_spatial_field
    private
 
    public :: t_spatial_field_input, t_averaging_input
-   public :: read_spatial_field_block, validate_spatial_field_input
+   public :: read_spatial_field_block, validate_spatial_field_input, select_spatial_field_method
    public :: read_averaging_input, averaging_params_to_transformcoef
    public :: allocate_time_dependent_spatial_quantities, deallocate_time_dependent_spatial_quantities, &
              register_time_dependent_spatial_quantity
@@ -199,13 +199,32 @@ contains
 
    end function is_static_file_type
 
+   !> Select the interpolation method for a spatial field input.
+   function select_spatial_field_method(forcing_file_type, interpolation_method, is_extrapolation_allowed) result(method)
+      use timespace, only: convert_method_string_to_integer, get_default_method_for_file_type, &
+                           update_method_with_weightfactor_fallback, update_method_in_case_extrapolation
+
+      character(len=*), intent(in) :: forcing_file_type !< File type used to select the default method and apply fallbacks.
+      character(len=*), intent(in) :: interpolation_method !< Explicit interpolation method, or empty to use the file type default.
+      logical, intent(in) :: is_extrapolation_allowed !< Whether to select the extrapolating variant of the method.
+      integer :: method
+
+      if (len_trim(interpolation_method) > 0) then
+         method = convert_method_string_to_integer(interpolation_method)
+         call update_method_with_weightfactor_fallback(forcing_file_type, method)
+      else
+         method = get_default_method_for_file_type(forcing_file_type)
+      end if
+      if (method /= -1) then
+         call update_method_in_case_extrapolation(method, is_extrapolation_allowed)
+      end if
+   end function select_spatial_field_method
+
    !> Validate a t_spatial_field_input. Derives method and filetype.
    !! Returns .false. and writes error messages on failure.
    function validate_spatial_field_input(input, file_name, group_name, base_dir) result(is_successful)
       use messageHandling, only: err_flush, warn_flush, msgbuf
-      use timespace, only: convert_method_string_to_integer, get_default_method_for_file_type, &
-                           update_method_with_weightfactor_fallback, update_method_in_case_extrapolation, &
-                           convert_file_type_string_to_integer
+      use timespace, only: convert_file_type_string_to_integer
       use timespace_parameters, only: DATAVALUE, FILE_TYPE_UNKNOWN
       use m_wind, only: jaQext
       use string_module, only: strcmpi
@@ -304,12 +323,7 @@ contains
       end if
 
       has_interpolation_method = len_trim(input%interpolation_method) > 0
-      if (has_interpolation_method) then
-         input%method = convert_method_string_to_integer(input%interpolation_method)
-         call update_method_with_weightfactor_fallback(input%forcing_file_type, input%method)
-      else
-         input%method = get_default_method_for_file_type(input%forcing_file_type)
-      end if
+      input%method = select_spatial_field_method(input%forcing_file_type, input%interpolation_method, input%is_extrapolation_allowed)
 
       if (input%method == -1) then
          if (has_interpolation_method) then
@@ -322,8 +336,6 @@ contains
          call err_flush()
          return
       end if
-      call update_method_in_case_extrapolation(input%method, input%is_extrapolation_allowed)
-
       input%is_static_field = is_static_file_type(input%forcing_file_type, input%method, input%quantity)
 
       select case (trim(input%quantity))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -34,7 +34,7 @@ module m_spatial_field
    use timespace_parameters, only: OPERAND_OVERRIDE
    use m_ec_interpolationsettings, only: RCEL_DEFAULT
    use m_missing, only: dmiss
-   
+
    implicit none(type, external)
 
    private
@@ -42,8 +42,14 @@ module m_spatial_field
    public :: t_spatial_field_input, t_averaging_input
    public :: read_spatial_field_block, validate_spatial_field_input
    public :: read_averaging_input, averaging_params_to_transformcoef
+   public :: allocate_time_dependent_spatial_quantities, deallocate_time_dependent_spatial_quantities, &
+             register_time_dependent_spatial_quantity
+   public :: is_static_file_type
 
    integer, parameter :: INI_VALUE_LEN = 256
+
+   character(len=INI_VALUE_LEN), dimension(:), allocatable :: time_dependent_spatial_quantities
+   integer :: num_time_dependent_spatial_quantities = 0
 
    !> Averaging parameters, only meaningful when method = averaging.
    type :: t_averaging_input
@@ -166,19 +172,25 @@ contains
    end subroutine averaging_params_to_transformcoef
 
    !> Returns .true. when the given forcingFileType string describes a static
-   !! spatial field (no time dimension). Static fields are read once at
-   !! initialisation; the EC relation is never updated during the time loop.
-   pure function is_static_file_type(forcing_file_type, method) result(is_static)
+   !! spatial field (no time dimension). Contains two exceptions for ambiguous file types.
+   function is_static_file_type(forcing_file_type, method, quantity) result(is_static)
       use string_module, only: str_tolower
       use timespace_parameters, only: SPACEANDTIME, SPACEFIRST, WEIGHTFACTORS, WEIGHTFACTORS_EXTRAPOLATION, JUSTUPDATE
 
-      character(len=*), intent(in) :: forcing_file_type
-      integer, intent(in) :: method
+      character(len=*), intent(in) :: forcing_file_type !< Most forcing file types uniquely determine time-dependence.
+      integer, intent(in) :: method !< arcinfo time-dependence is determind by method (currently)
+      character(len=*), intent(in), optional :: quantity !< datavalue time-dependence is determined by quantity, not file type.
       logical :: is_static
 
       select case (str_tolower(trim(forcing_file_type)))
       case ('sample', 'geotiff', 'polygon', '1dfield')
          is_static = .true.
+      case ('datavalue')
+         if (present(quantity)) then
+            is_static = .not. quantity_has_time_dependent_input(quantity)
+         else
+            is_static = .false.
+         end if
       case ('arcinfo') ! TODO: change this approach once more file types can be both time-varying and static
          is_static = .not. any(method == [SPACEANDTIME, SPACEFIRST, WEIGHTFACTORS, WEIGHTFACTORS_EXTRAPOLATION, JUSTUPDATE])
       case default
@@ -252,7 +264,7 @@ contains
             call err_flush()
             return
          end if
-   
+
          if (file_extension_conflicts_with_type(input%forcing_file, input%forcing_file_type)) then
             write (msgbuf, '(9a)') 'Invalid block in file ''', trim(file_name), ''': [', trim(group_name), &
                ']. forcingFile ''', trim(input%forcing_file), ''' has a file extension that conflicts with forcingFileType ''', &
@@ -260,7 +272,7 @@ contains
             call err_flush()
             return
          end if
-   
+
          call resolvePath(input%forcing_file, base_dir)
       end if
 
@@ -311,8 +323,8 @@ contains
          return
       end if
       call update_method_in_case_extrapolation(input%method, input%is_extrapolation_allowed)
-      
-      input%is_static_field = is_static_file_type(input%forcing_file_type, input%method)
+
+      input%is_static_field = is_static_file_type(input%forcing_file_type, input%method, input%quantity)
 
       select case (trim(input%quantity))
       case ('qext')
@@ -355,5 +367,45 @@ contains
       end select
 
    end function file_extension_conflicts_with_type
+
+   !> Helper routine to avoid cyclic dependencies
+   subroutine allocate_time_dependent_spatial_quantities(max_num_quantities)
+      integer, intent(in) :: max_num_quantities !< Maximum number of quantities to register.
+
+      call deallocate_time_dependent_spatial_quantities()
+      allocate (time_dependent_spatial_quantities(max(1, max_num_quantities)))
+      time_dependent_spatial_quantities = ''
+   end subroutine allocate_time_dependent_spatial_quantities
+
+   !> Helper routine to avoid cyclic dependencies
+   subroutine deallocate_time_dependent_spatial_quantities()
+      if (allocated(time_dependent_spatial_quantities)) then
+         deallocate (time_dependent_spatial_quantities)
+      end if
+      num_time_dependent_spatial_quantities = 0
+   end subroutine deallocate_time_dependent_spatial_quantities
+
+   !> Register a quantity that has at least one time-dependent spatial input.
+   subroutine register_time_dependent_spatial_quantity(quantity)
+      use string_module, only: strcmpi
+
+      character(len=*), intent(in) :: quantity !< Canonical spatial quantity name.
+
+      if (any(strcmpi(time_dependent_spatial_quantities, quantity))) return
+      num_time_dependent_spatial_quantities = num_time_dependent_spatial_quantities + 1
+      time_dependent_spatial_quantities(num_time_dependent_spatial_quantities) = quantity
+   end subroutine register_time_dependent_spatial_quantity
+
+   function quantity_has_time_dependent_input(quantity) result(has_time_dependent_input)
+      use string_module, only: strcmpi
+
+      character(len=*), intent(in) :: quantity
+      logical :: has_time_dependent_input
+
+      has_time_dependent_input = .false.
+      if (allocated(time_dependent_spatial_quantities)) then
+         has_time_dependent_input = any(strcmpi(time_dependent_spatial_quantities, quantity))
+      end if
+   end function quantity_has_time_dependent_input
 
 end module m_spatial_field

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -22,20 +22,20 @@ module test_init_spatial_fields_integration
    character(len=*), parameter :: BASE_DIR = "."
    integer, parameter :: NUM_SCALAR_METEO_CASES = 15
    character(len=32), dimension(NUM_SCALAR_METEO_CASES), parameter :: SCALAR_METEO_QUANTITIES = [character(len=32) :: &
-      'airdensity', 'airpressure', 'airtemperature', 'cloudiness', 'dewpoint', 'humidity', &
-      'latentheatflux', 'longwaveradiation', 'netsolarradiation', 'solarradiation', &
-      'sensibleheatflux', 'stressx', 'stressy', 'windx', 'windy']
+                                                                                                 'airdensity', 'airpressure', 'airtemperature', 'cloudiness', 'dewpoint', 'humidity', &
+                                                                                                 'latentheatflux', 'longwaveradiation', 'netsolarradiation', 'solarradiation', &
+                                                                                                 'sensibleheatflux', 'stressx', 'stressy', 'windx', 'windy']
    character(len=48), dimension(NUM_SCALAR_METEO_CASES), parameter :: SCALAR_METEO_VARIABLES = [character(len=48) :: &
-      'p140209', 'msl', 't2m', 'tcc', 'd2m', 'rhum', 'slhf', 'strd', 'ssr', 'ssrd', &
-      'sshf', 'tauu', 'tauv', 'u10', 'v10']
+                                                                                                'p140209', 'msl', 't2m', 'tcc', 'd2m', 'rhum', 'slhf', 'strd', 'ssr', 'ssrd', &
+                                                                                                'sshf', 'tauu', 'tauv', 'u10', 'v10']
    character(len=64), dimension(NUM_SCALAR_METEO_CASES), parameter :: SCALAR_METEO_STANDARD_NAMES = [character(len=64) :: &
-      'air_density', 'air_pressure', 'air_temperature', 'cloud_area_fraction', 'dew_point_temperature', 'relative_humidity', &
-      'surface_upward_latent_heat_flux', 'surface_net_downward_longwave_flux', 'surface_net_downward_shortwave_flux', &
-      'surface_downwelling_shortwave_flux_in_air', 'surface_upward_sensible_heat_flux', &
-      'surface_downward_eastward_stress', 'surface_downward_northward_stress', 'eastward_wind', 'northward_wind']
+                                                                                                     'air_density', 'air_pressure', 'air_temperature', 'cloud_area_fraction', 'dew_point_temperature', 'relative_humidity', &
+                                                                                                     'surface_upward_latent_heat_flux', 'surface_net_downward_longwave_flux', 'surface_net_downward_shortwave_flux', &
+                                                                                                     'surface_downwelling_shortwave_flux_in_air', 'surface_upward_sensible_heat_flux', &
+                                                                                                     'surface_downward_eastward_stress', 'surface_downward_northward_stress', 'eastward_wind', 'northward_wind']
    real(dp), dimension(NUM_SCALAR_METEO_CASES), parameter :: SCALAR_METEO_VALUES = [ &
-      1.2_dp, 101325.0_dp, 20.0_dp, 0.4_dp, 10.0_dp, 60.0_dp, 120.0_dp, 80.0_dp, 200.0_dp, 250.0_dp, &
-      50.0_dp, 0.1_dp, 0.2_dp, 3.0_dp, 4.0_dp]
+                                                             1.2_dp, 101325.0_dp, 20.0_dp, 0.4_dp, 10.0_dp, 60.0_dp, 120.0_dp, 80.0_dp, 200.0_dp, 250.0_dp, &
+                                                             50.0_dp, 0.1_dp, 0.2_dp, 3.0_dp, 4.0_dp]
 
 contains
 
@@ -322,7 +322,7 @@ contains
       call f90_expect_eq(real(painp(1, 1), kind=dp), 4.0_dp, "the 2D representative should receive the polygon value")
       call f90_expect_eq(real(painp(1, 2), kind=dp), 4.0_dp, "the bottom layer should receive the polygon value")
       call f90_expect_eq(real(painp(1, 3), kind=dp), 4.0_dp, &
-                "the inactive layer above the water surface should receive the polygon value")
+                         "the inactive layer above the water surface should receive the polygon value")
 
       num_spatial_parameters = 0
       kmx = 0
@@ -675,9 +675,9 @@ contains
       integer ierr
 
       ! ARRANGE: one sample point exactly at the single grid cell (0,0) with value 1.5.
-            call create_file(SAMPLE_FILE, ["-1.0 -1.0  1.5", &
-                                      " 1.0 -1.0  1.5", &
-                                      " 0.0  1.0  1.5"])
+      call create_file(SAMPLE_FILE, ["-1.0 -1.0  1.5", &
+                                     " 1.0 -1.0  1.5", &
+                                     " 0.0  1.0  1.5"])
 
       call create_file(QEXT_EXT, [ &
                        "[Spatial]", &
@@ -885,18 +885,21 @@ contains
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_windxy_scalar_netcdf_override_and_multiply, test_windxy_scalar_netcdf_override_and_multiply,
    subroutine test_windxy_scalar_netcdf_override_and_multiply() bind(C)
+      use dfm_error, only: DFM_NOERR
+      use fm_external_forcings, only: init_new
       use m_meteo, only: ecInstancePtr, ec_gettimespacevalue_by_itemID, initialize_ec_module, item_windxy_x
       use m_sferic, only: jsferic
       use m_wind, only: jawind, wx, wy
       use m_flow, only: wdsu, wdsu_x, wdsu_y
       use m_flowgeom, only: lnx, xu, yu
       use m_flowtimes, only: irefdate, tunit, tzone, tstart_user
+      use m_unstruc_model_data, only: extfile_new_list
 
       character(len=*), parameter :: NC_FILE = 'test_windxy_uniform.nc'
       character(len=*), parameter :: EXT_FILE = 'test_windxy_uniform.ext'
       character(len=*), parameter :: FACTOR_EXT_FILE = 'test_windxy_factor.ext'
-      type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
+      integer :: iresult
 
       call create_windxy_netcdf(NC_FILE)
       call create_file(EXT_FILE, [ &
@@ -930,16 +933,11 @@ contains
       jsferic = 0
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
+      extfile_new_list = [character(len=64) :: EXT_FILE, FACTOR_EXT_FILE]
 
-      call parse_spatial_block(EXT_FILE, bnd_ptr, block_ptr)
-      success = init_spatial_fields(block_ptr, BASE_DIR, EXT_FILE, 'Spatial')
-      call tree_destroy(bnd_ptr)
-      call f90_expect_true(success, 'scalar NetCDF windxy initialization should succeed')
-
-      call parse_spatial_block(FACTOR_EXT_FILE, bnd_ptr, block_ptr)
-      success = init_spatial_fields(block_ptr, BASE_DIR, FACTOR_EXT_FILE, 'Spatial')
-      call tree_destroy(bnd_ptr)
-      call f90_expect_true(success, 'windxy dataValue multiply initialization should succeed')
+      iresult = DFM_NOERR
+      call init_new(iresult)
+      call f90_expect_eq(iresult, DFM_NOERR, 'windxy NetCDF and dataValue inputs should initialize')
 
       success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_windxy_x, &
                                                irefdate, tzone, tunit, 0.0_dp)
@@ -1173,7 +1171,7 @@ contains
       logical :: success
       integer :: ierr
       character(len=*), parameter :: SAMPLE_FILE = "test_wl.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_wl.ext"
+      character(len=*), parameter :: EXT_FILE = "test_wl.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  1.5", &
                                      " 1.0 -1.0  1.5", &
@@ -1192,8 +1190,8 @@ contains
       call realloc(bl, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(s1, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(hs, ndx, fill=0.0_dp, keepExisting=.false.)
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
@@ -1210,11 +1208,11 @@ contains
       call f90_expect_near(s1(1), 1.5_dp, 1.0e-6_dp, "s1(1) should match the sample value")
 
       ! CLEANUP
-      ndxi  = 0
+      ndxi = 0
       ndx2D = 0
-      if (allocated(bl)) deallocate(bl)
-      if (allocated(s1)) deallocate(s1)
-      if (allocated(hs)) deallocate(hs)
+      if (allocated(bl)) deallocate (bl)
+      if (allocated(s1)) deallocate (s1)
+      if (allocated(hs)) deallocate (hs)
       call teardown_minimal_grid()
    end subroutine test_initialwaterlevel_static_field_populated_at_init
    !$f90tw)
@@ -1235,7 +1233,7 @@ contains
       logical :: success
       integer :: ierr
       character(len=*), parameter :: SAMPLE_FILE = "test_fr.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_fr.ext"
+      character(len=*), parameter :: EXT_FILE = "test_fr.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  0.02", &
                                      " 1.0 -1.0  0.02", &
@@ -1249,18 +1247,18 @@ contains
 
       ! ARRANGE: s-point grid for kcs/xz/yz plus a single u-point at (0,0)
       call setup_minimal_grid()
-      ndxi  = ndx
+      ndxi = ndx
       ndx2D = 0
-      lnx   = 1
+      lnx = 1
       call realloc(bl, ndx, fill=0.0_dp, keepExisting=.false.)
-      if (allocated(xu)) deallocate(xu)
-      if (allocated(yu)) deallocate(yu)
-      allocate(xu(lnx), yu(lnx))
-      call realloc(frcu,ndx, fill=0.0_dp, keepExisting=.false.)
+      if (allocated(xu)) deallocate (xu)
+      if (allocated(yu)) deallocate (yu)
+      allocate (xu(lnx), yu(lnx))
+      call realloc(frcu, ndx, fill=0.0_dp, keepExisting=.false.)
       xu = [0.0_dp]
       yu = [0.0_dp]
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
@@ -1277,15 +1275,81 @@ contains
       call f90_expect_near(frcu(1), 0.02_dp, 1.0e-6_dp, "frcu(1) should match the sample value")
 
       ! CLEANUP
-      ndxi  = 0
+      ndxi = 0
       ndx2D = 0
-      lnx   = 0
-      if (allocated(bl))   deallocate(bl)
-      if (allocated(xu))   deallocate(xu)
-      if (allocated(yu))   deallocate(yu)
-      if (allocated(frcu)) deallocate(frcu)
+      lnx = 0
+      if (allocated(bl)) deallocate (bl)
+      if (allocated(xu)) deallocate (xu)
+      if (allocated(yu)) deallocate (yu)
+      if (allocated(frcu)) deallocate (frcu)
       call teardown_minimal_grid()
    end subroutine test_frictioncoefficient_static_field_populated_at_init
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_datavalue_with_static_input_is_applied_once, test_datavalue_with_static_input_is_applied_once,
+   subroutine test_datavalue_with_static_input_is_applied_once() bind(C)
+      use dfm_error, only: DFM_NOERR
+      use fm_external_forcings, only: init_new
+      use m_flow, only: frcu
+      use m_flowgeom, only: ndx2D, bl, lnx, xu, yu
+      use m_flowparameters, only: ja_friction_coefficient_time_dependent
+      use m_flowtimes, only: irefdate, tzone, tstart_user
+      use m_polygon, only: m_polygon_destructor
+      use m_unstruc_model_data, only: extfile_new_list
+
+      character(len=*), parameter :: SAMPLE_FILE = 'test_static_datavalue_friction.xyz'
+      character(len=*), parameter :: EXT_FILE = 'test_static_datavalue_friction.ext'
+      integer :: ierr, iresult
+
+      call create_file(SAMPLE_FILE, ['-1.0 -1.0  0.02', &
+                                     ' 1.0 -1.0  0.02', &
+                                     ' 0.0  1.0  0.02'])
+      call create_file(EXT_FILE, [character(len=80) :: &
+                                  '[Spatial]', &
+                                  '    quantity        = frictioncoefficient', &
+                                  '    dataValue       = 0.04', &
+                                  '    operand         = override', &
+                                  '', &
+                                  '[Spatial]', &
+                                  '    quantity            = frictioncoefficient', &
+                                  '    forcingFile         = '//SAMPLE_FILE, &
+                                  '    forcingFileType     = sample', &
+                                  '    interpolationMethod = triangulation', &
+                                  '    operand             = override'])
+
+      call setup_minimal_grid()
+      ndx2D = 0
+      lnx = 1
+      call realloc(bl, ndx, fill=0.0_dp, keepExisting=.false.)
+      call realloc(xu, lnx, fill=0.0_dp, keepExisting=.false.)
+      call realloc(yu, lnx, fill=0.0_dp, keepExisting=.false.)
+      call realloc(frcu, ndx, fill=0.0_dp, keepExisting=.false.)
+      irefdate = 20000101
+      tzone = 0.0_dp
+      tstart_user = 0.0_dp
+      ja_friction_coefficient_time_dependent = 0
+      threshold_abort = LEVEL_FATAL
+      call initialize_ec_module()
+      ierr = m_polygon_destructor()
+      extfile_new_list = [EXT_FILE]
+
+      iresult = DFM_NOERR
+      call init_new(iresult)
+
+      call f90_expect_eq(iresult, DFM_NOERR, 'combined static friction fields should initialize')
+      call f90_expect_eq(ja_friction_coefficient_time_dependent, 0, &
+                         'datavalue should remain static when all other inputs are static')
+      call f90_expect_near(frcu(1), 0.02_dp, 1.0e-6_dp, &
+                           'the later sample field should override the one-shot datavalue')
+
+      ndx2D = 0
+      lnx = 0
+      if (allocated(bl)) deallocate (bl)
+      if (allocated(xu)) deallocate (xu)
+      if (allocated(yu)) deallocate (yu)
+      if (allocated(frcu)) deallocate (frcu)
+      call teardown_minimal_grid()
+   end subroutine test_datavalue_with_static_input_is_applied_once
    !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialwaterdepth_derives_s1, test_initialwaterdepth_derives_s1,
@@ -1303,7 +1367,7 @@ contains
       logical :: success
       integer :: ierr
       character(len=*), parameter :: SAMPLE_FILE = "test_wd.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_wd.ext"
+      character(len=*), parameter :: EXT_FILE = "test_wd.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  2.0", &
                                      " 1.0 -1.0  2.0", &
@@ -1316,14 +1380,14 @@ contains
                        "    interpolationMethod = triangulation"])
 
       ! ARRANGE: bl=0 everywhere, so expected hs=2.0 and s1 = bl + hs = 2.0
-      ndx  = 1
+      ndx = 1
       ndxi = ndx
       ndx2D = 0
       call realloc(bl, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(s1, ndx, fill=0.0_dp, keepExisting=.false.)
       call realloc(hs, ndx, fill=0.0_dp, keepExisting=.false.)
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call setup_minimal_grid()
@@ -1342,7 +1406,7 @@ contains
       call f90_expect_near(s1(1), 2.0_dp, 1.0e-6_dp, &
                            "s1(1) must equal bl+hs=2.0 via enable_quantity post-processing")
 
-      ndxi  = 0
+      ndxi = 0
       ndx2D = 0
       if (allocated(bl)) deallocate (bl)
       if (allocated(s1)) deallocate (s1)
@@ -1365,7 +1429,7 @@ contains
       logical :: success
       integer :: ierr
       character(len=*), parameter :: SAMPLE_FILE = "test_sd.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_sd.ext"
+      character(len=*), parameter :: EXT_FILE = "test_sd.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  3.5", &
                                      " 1.0 -1.0  3.5", &
@@ -1377,8 +1441,8 @@ contains
                        "    forcingFileType     = sample", &
                        "    interpolationMethod = triangulation"])
 
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       secchi_depth_is_spatially_varying = .false.
       threshold_abort = LEVEL_FATAL
@@ -1424,7 +1488,7 @@ contains
       logical :: success
       integer :: ierr, expected_friction_type
       character(len=*), parameter :: SAMPLE_FILE = "test_frtype.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_frtype.ext"
+      character(len=*), parameter :: EXT_FILE = "test_frtype.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  0.02", &
                                      " 1.0 -1.0  0.02", &
@@ -1454,8 +1518,8 @@ contains
       allocate (ifrcutp(lnx), stat=ierr)
       call aerr('ifrcutp(lnx)', ierr, lnx)
       ifrcutp = 0
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
@@ -1473,9 +1537,9 @@ contains
                          "ifrcutp(1) must equal the Manning integer from frictionTypeStringToInteger")
 
       lnx = 0
-      if (allocated(xu))     deallocate (xu)
-      if (allocated(yu))     deallocate (yu)
-      if (allocated(frcu))   deallocate (frcu)
+      if (allocated(xu)) deallocate (xu)
+      if (allocated(yu)) deallocate (yu)
+      if (allocated(frcu)) deallocate (frcu)
       if (allocated(ifrcutp)) deallocate (ifrcutp)
       call teardown_minimal_grid()
    end subroutine test_frictioncoefficient_with_explicit_frictiontype
@@ -1519,9 +1583,9 @@ contains
                        "    value           = 3"])
 
       call setup_minimal_grid()
-      ndxi  = ndx
+      ndxi = ndx
       ndx2D = 0
-      lnx   = 1
+      lnx = 1
       if (allocated(xu)) deallocate (xu)
       if (allocated(yu)) deallocate (yu)
       allocate (xu(lnx), yu(lnx), stat=ierr)
@@ -1531,8 +1595,8 @@ contains
       ! iadv is only pointered to by resolve_integer_target, not allocated there.
       ! Pre-allocate here so the pointer assignment does not dereference garbage.
       call realloc(iadv, lnx, fill=0, keepExisting=.false.)
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
@@ -1548,11 +1612,11 @@ contains
       call f90_expect_eq(iadv(1), 3, "iadv(1) should be 3 (value= keyword via transformcoef(1))")
 
       ! CLEANUP
-      lnx   = 0
-      ndxi  = 0
+      lnx = 0
+      ndxi = 0
       ndx2D = 0
-      if (allocated(xu))   deallocate (xu)
-      if (allocated(yu))   deallocate (yu)
+      if (allocated(xu)) deallocate (xu)
+      if (allocated(yu)) deallocate (yu)
       if (allocated(iadv)) deallocate (iadv)
       call teardown_minimal_grid()
    end subroutine test_advectiontype_integer_field_populated
@@ -1691,11 +1755,11 @@ contains
       logical :: success
       integer :: ierr
       character(len=*), parameter :: SAMPLE_FILE = "test_sal.xyz"
-      character(len=*), parameter :: EXT_FILE    = "test_sal.ext"
+      character(len=*), parameter :: EXT_FILE = "test_sal.ext"
 
       call create_file(SAMPLE_FILE, ["-1.0 -1.0  1.5", &
-                                      " 1.0 -1.0  1.5", &
-                                      " 0.0  1.0  1.5"])
+                                     " 1.0 -1.0  1.5", &
+                                     " 0.0  1.0  1.5"])
       call create_file(EXT_FILE, [ &
                        "[Initial]", &
                        "    quantity            = initialsalinity", &
@@ -1705,20 +1769,20 @@ contains
 
       ! ARRANGE
       call setup_minimal_grid()
-      ndxi    = ndx
-      ndx2D   = 0
-      kmx     = 0
-      ndkx    = ndx   ! for kmx=0: ndkx == ndx, one layer per cell
+      ndxi = ndx
+      ndx2D = 0
+      kmx = 0
+      ndkx = ndx ! for kmx=0: ndkx == ndx, one layer per cell
       NUMCONST = 1
-      ISALT    = 1
-      jasal    = 1
+      ISALT = 1
+      jasal = 1
 
       constituents = 0.0_dp
       call realloc(kbot, ndx, fill=1, keepExisting=.false.)
       call realloc(ktop, ndx, fill=1, keepExisting=.false.)
       call realloc(sa1, ndx, fill=0.0_dp, keepExisting=.false.)
-      irefdate    = 20000101
-      tzone       = 0.0_dp
+      irefdate = 20000101
+      tzone = 0.0_dp
       tstart_user = 0.0_dp
       threshold_abort = LEVEL_FATAL
       call initialize_ec_module()
@@ -1735,16 +1799,16 @@ contains
                            "sa1 should match the sample value after 2D interp + 3D expansion")
 
       ! CLEANUP
-      jasal    = 0
+      jasal = 0
       NUMCONST = 0
-      ISALT    = 0
-      ndkx     = 0
-      kmx      = 0
-      ndxi     = 0
-      ndx2D    = 0
+      ISALT = 0
+      ndkx = 0
+      kmx = 0
+      ndxi = 0
+      ndx2D = 0
       if (allocated(constituents)) deallocate (constituents)
-      if (allocated(kbot))         deallocate (kbot)
-      if (allocated(ktop))         deallocate (ktop)
+      if (allocated(kbot)) deallocate (kbot)
+      if (allocated(ktop)) deallocate (ktop)
       call teardown_minimal_grid()
    end subroutine test_initialsalinity_3d_field_populated
    !$f90tw)
@@ -1786,14 +1850,14 @@ contains
 
       ! Minimal flow geometry: 1 node, 1 sigma layer.
       call setup_minimal_grid()
-      ndxi = ndx        ! ndx == 1, set by setup_minimal_grid
+      ndxi = ndx ! ndx == 1, set by setup_minimal_grid
       ndx2D = 0
-      ndkx = ndx        ! for kmx=1 and 1 node: ndkx = 1
+      ndkx = ndx ! for kmx=1 and 1 node: ndkx = 1
 
       ! Resolver guard: jasal>0 and kmx>0 are required by resolve_initial_target.
       jasal = 1
       kmx = 1
-      layertype = 0      ! sigma layers, avoids the LAYTP_Z branch
+      layertype = 0 ! sigma layers, avoids the LAYTP_Z branch
 
       call realloc(kbot, ndxi, fill=1, keepExisting=.false.)
       call realloc(ktop, ndxi, fill=1, keepExisting=.false.)
@@ -1831,10 +1895,10 @@ contains
       ndkx = 0
       ndxi = 0
       ndx2D = 0
-      if (allocated(sa1))  deallocate (sa1)
+      if (allocated(sa1)) deallocate (sa1)
       if (allocated(kbot)) deallocate (kbot)
       if (allocated(ktop)) deallocate (ktop)
-      if (allocated(zws))  deallocate (zws)
+      if (allocated(zws)) deallocate (zws)
       call teardown_minimal_grid()
    end subroutine test_initialverticalsalinityprofile
    !$f90tw)
@@ -1852,7 +1916,7 @@ contains
       type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
       character(len=*), parameter :: FIELD1D_FILE = "test_fr1d.ini"
-      character(len=*), parameter :: EXT_FILE     = "test_fr1d.ext"
+      character(len=*), parameter :: EXT_FILE = "test_fr1d.ext"
 
       call create_file(FIELD1D_FILE, [ &
                        "[General]", &
@@ -1871,7 +1935,7 @@ contains
                        "    forcingFileType = 1dField"])
 
       ! ARRANGE: one 1D flow link; no 1D network needed because there are no [Branch] blocks.
-      lnx   = 1
+      lnx = 1
       lnx1d = 1
       call realloc(frcu, lnx, fill=0.0_dp, keepExisting=.false.)
       threshold_abort = LEVEL_FATAL
@@ -1890,13 +1954,12 @@ contains
                            "frcu(1) should equal the global value from the [Global] block")
 
       ! CLEANUP
-      lnx   = 0
+      lnx = 0
       lnx1d = 0
       if (allocated(frcu)) deallocate (frcu)
       call teardown_minimal_grid()
    end subroutine test_field1d_global_value_applied_to_frictioncoefficient
    !$f90tw)
-
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_scalar_meteo_bcascii_matrix, test_scalar_meteo_bcascii_matrix,
    subroutine test_scalar_meteo_bcascii_matrix() bind(C)
@@ -1987,7 +2050,7 @@ contains
       call f90_expect_true(success, trim(quantity)//' should update at t=0')
       if (trim(forcing_file_type) == 'netcdf') then
          call f90_expect_near(ecInstancePtr%ecFileReadersPtr(1)%ptr%items(1)%ptr%sourceT0FieldPtr%arr1dPtr(1), expected_value, &
-                  1.0e-6_dp, trim(quantity)//' source value at t=0')
+                              1.0e-6_dp, trim(quantity)//' source value at t=0')
       end if
       call f90_expect_near(target_data(1), expected_value, 1.0e-6_dp, trim(quantity)//' value at t=0')
 
@@ -2114,18 +2177,18 @@ contains
       do i = 1, NUM_SCALAR_METEO_CASES
          if (scalar_source) then
             call check_meteo_netcdf(nf90_def_var(ncid, trim(SCALAR_METEO_VARIABLES(i)), NF90_DOUBLE, &
-                                                         [time_dimid], variable_ids(i)), &
-                                           'define '//trim(SCALAR_METEO_VARIABLES(i)))
+                                                 [time_dimid], variable_ids(i)), &
+                                    'define '//trim(SCALAR_METEO_VARIABLES(i)))
          else
             call check_meteo_netcdf(nf90_def_var(ncid, trim(SCALAR_METEO_VARIABLES(i)), NF90_DOUBLE, &
-                                                         [x_dimid, y_dimid, time_dimid], variable_ids(i)), &
-                                           'define '//trim(SCALAR_METEO_VARIABLES(i)))
+                                                 [x_dimid, y_dimid, time_dimid], variable_ids(i)), &
+                                    'define '//trim(SCALAR_METEO_VARIABLES(i)))
          end if
          call check_meteo_netcdf(nf90_put_att(ncid, variable_ids(i), 'standard_name', trim(SCALAR_METEO_STANDARD_NAMES(i))), &
-                                        'set '//trim(SCALAR_METEO_VARIABLES(i))//' standard name')
+                                 'set '//trim(SCALAR_METEO_VARIABLES(i))//' standard name')
          if (.not. scalar_source) then
             call check_meteo_netcdf(nf90_put_att(ncid, variable_ids(i), 'coordinates', 'x y'), &
-                                           'set '//trim(SCALAR_METEO_VARIABLES(i))//' coordinates')
+                                    'set '//trim(SCALAR_METEO_VARIABLES(i))//' coordinates')
          end if
       end do
 


### PR DESCRIPTION
…ty is time-dependent, otherwise time-independent.

# What was done 

<a short description with bullets> 

- scan extfiles and register whether quantities are time dependent
- datavalue checks registry and takes registry value for time dependence
- added static field datavalue path, that adds timespacerelation and updates it once
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
