### PR TITLE
UNST-10281 Lower MinTimestepBreak to prevent error in e02_f901_c202

### DIFF
--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -1612,7 +1612,7 @@
       </file>
     </checks>
   </testCase>
-  <testCase name="e02_f901_c202_tidal_flume_kepsilon_zmodel_equi_3d" ref="platform_specific">
+  <testCase name="e02_f901_c202_tidal_flume_kepsilon_zmodel_equi_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d</path>
 
     <checks>

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 71bd3bcabbd3aa5fc752e2c80bdea141.dir
-  size: 58613
+- md5: 81a8a97ffc50a58924b4c9e1cb9021bc.dir
+  size: 58640
   nfiles: 11
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/reference_lnx64.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/reference_lnx64.dvc
@@ -1,6 +1,0 @@
-outs:
-- md5: b6c2bd1454fe369507a3f4c8454aac1f.dir
-  size: 30881624
-  nfiles: 1
-  hash: md5
-  path: reference_lnx64

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/reference_win64.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f901_tidal_flume/c202_tidal_flume_kepsilon_zmodel_equi_3d/reference_win64.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: fa323595ae97299ef5f3d855be58a1f9.dir
-  size: 15560704
-  nfiles: 7
+- md5: 959d9d1029b4854ec2267841c161d734.dir
+  size: 16621282
+  nfiles: 10
   hash: md5
   path: reference_win64


### PR DESCRIPTION

# What was done 
Set MinTimestepBreak = 0.0005 s, this prevents the error that the time step becomes too small on both windows and linux with OneAPI 2026.

Testcase: e02_f901_c202_tidal_flume_kepsilon_zmodel_equi_3d


# Issue link
UNST-10281
