### PR TITLE
support initialverticalsedfrac profiles, both Z and sigma

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -477,7 +477,7 @@ contains
          istat, &
          prefix='While reading '''//trim(filename)//'''', &
          print_context_keywords=['quantity', 'dataFile'] &
-      )
+         )
       ! No errors
       write (msgbuf, '(a, i10,a)') 'Finish initializing 1dField file '''//trim(filename)//''':', ib, &
          ' [Branch] blocks have been read and handled.'
@@ -831,7 +831,7 @@ contains
 !! Returns .true. if the quantity was recognized and target_array is associated.
    function resolve_initial_3d_target(quantity, target_location_type, target_array_3d, first_index) result(success)
       use string_module, only: str_tolower
-      use messagehandling, only: mess, LEVEL_WARN
+      use messagehandling, only: mess, LEVEL_ERROR
       use m_flow, only: sa1
       use m_flowparameters, only: jasal
       use m_transport, only: const_names
@@ -870,6 +870,7 @@ contains
       select case (str_tolower(qid_base))
       case ('initialsalinity')
          if (jasal <= 0) then
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' requires salinity to be enabled.')
             success = .false.
             return
          end if
@@ -878,27 +879,13 @@ contains
 
       case ('initialsedfrac')
          if (.not. stm_included) then
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' requires suspended sediment transport to be enabled.')
             success = .false.
             return
          end if
          iconst = find_name(const_names, qid_specific)
          if (iconst <= 0) then
-            call mess(LEVEL_WARN, 'resolve_initial_3d_target: unknown sediment fraction '''//trim(qid_specific)//'''.')
-            success = .false.
-            return
-         end if
-         first_index = iconst
-         target_array_3d => constituents
-
-      case ('initialverticalsedfracprofile', 'initialverticalsigmasedfracprofile')
-         target_location_type = UNC_LOC_3DV
-         if (.not. stm_included) then
-            success = .false.
-            return
-         end if
-         iconst = find_name(const_names, qid_specific)
-         if (iconst <= 0) then
-            call mess(LEVEL_WARN, 'resolve_initial_3d_target: unknown sediment fraction '''//trim(qid_specific)//'''.')
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' refers to unknown sediment fraction '''//trim(qid_specific)//'''.')
             success = .false.
             return
          end if
@@ -906,7 +893,8 @@ contains
          target_array_3d => constituents
 
       case ('initialsediment')
-         if (jased /= 1 .or. jased /= 2 .or. jased /= 3) then
+         if (jased <= 0) then
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' requires a supported sediment transport model.')
             success = .false.
             return
          end if
@@ -923,7 +911,7 @@ contains
          call add_tracer(qid_specific, iconst)
          itrac = find_name(trnames, qid_specific)
          if (itrac == 0) then
-            call mess(LEVEL_WARN, 'resolve_initial_3d_target: tracer '''//trim(qid_specific)//''' not found.')
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' refers to unknown tracer '''//trim(qid_specific)//'''.')
             success = .false.
             return
          end if
@@ -933,7 +921,7 @@ contains
       case ('initialwaqbot')
          iwqbot = find_name(wqbotnames, qid_specific)
          if (iwqbot == 0) then
-            call mess(LEVEL_WARN, 'resolve_initial_3d_target: WAQ bottom variable '''//trim(qid_specific)//''' not found.')
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(quantity)//''' refers to unknown WAQ bottom variable '''//trim(qid_specific)//'''.')
             success = .false.
             return
          end if
@@ -967,6 +955,10 @@ contains
       use m_flowgeom, only: ndx, lnx
       use m_flowparameters, only: jasal, inisal2D, uniformsalinityabovez, uniformsalinitybelowz, &
                                   temperature_model, TEMPERATURE_MODEL_NONE, initem2D, inivel
+      use m_sediment, only: stm_included
+      use m_transportdata, only: constituents, const_names
+      use m_find_name, only: find_name
+      use fm_external_forcings_utils, only: get_sedfracname
       use unstruc_model, only: md_extfile
       use string_module, only: str_tolower
 
@@ -976,7 +968,9 @@ contains
       character(len=*), intent(in) :: inifilename !< Name of the ini file, used for warning messages.
       integer, intent(out) :: target_location_type !< Location type (UNC_LOC_S, UNC_LOC_U or UNC_LOC_3DV).
       real(kind=dp), dimension(:), pointer, intent(out) :: target_array !< Pointer to the model array. Null if not handled here.
-      logical :: success !< true if the quantity was recognized.
+      logical :: success !< true if the quantity was recognized and target_array is associated.
+      character(len=256) :: qid_base, qid_specific
+      integer :: iconst
 
       target_array => null()
       target_location_type = 0
@@ -1014,6 +1008,10 @@ contains
             uniformsalinityabovez = dmiss
             target_location_type = UNC_LOC_S
             target_array => satop
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires salinity to be enabled.')
+            success = .false.
+            return
          end if
 
       case ('initialsalinitybot')
@@ -1027,6 +1025,10 @@ contains
             uniformsalinitybelowz = dmiss
             target_location_type = UNC_LOC_S
             target_array => sabot
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires salinity to be enabled.')
+            success = .false.
+            return
          end if
 
       case ('initialtemperature')
@@ -1034,6 +1036,10 @@ contains
             target_location_type = UNC_LOC_S
             target_array => tem1
             initem2D = 1
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires a temperature model to be enabled.')
+            success = .false.
+            return
          end if
 
       case ('initialvelocityx')
@@ -1054,12 +1060,37 @@ contains
          if (temperature_model /= TEMPERATURE_MODEL_NONE .and. kmx > 0) then
             target_location_type = UNC_LOC_3DV
             target_array => tem1
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires a temperature model and a 3D flow model.')
+            success = .false.
+            return
          end if
 
       case ('initialverticalsalinityprofile')
          if (jasal > 0 .and. kmx > 0) then
             target_location_type = UNC_LOC_3DV
             target_array => sa1
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires salinity and a 3D flow model.')
+            success = .false.
+            return
+         end if
+
+      case ('initialverticalsedfracprofile', 'initialverticalsigmasedfracprofile')
+         if (stm_included .and. kmx > 0) then
+            call get_sedfracname(qid, qid_specific, qid_base)
+            iconst = find_name(const_names, qid_specific)
+            if (iconst <= 0) then
+               call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' refers to unknown sediment fraction '''//trim(qid_specific)//'''.')
+               success = .false.
+               return
+            end if
+            target_location_type = UNC_LOC_3DV
+            target_array => constituents(iconst, :)
+         else
+            call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' requires sediment transport and a 3D flow model.')
+            success = .false.
+            return
          end if
 
       case default
@@ -1086,8 +1117,8 @@ contains
       use unstruc_model, only: md_ptr
       use m_fm_icecover, only: ja_ice_area_fraction_read, ja_ice_thickness_read, fm_ice_activate_by_ext_forces
       use m_waveconst, only: WAVE_NC_OFFLINE, WAVE_INPUT_SIGNIFICANT_HEIGHT, WAVE_INPUT_PERIOD, WAVE_INPUT_DIRECTION, &
-                    WAVE_INPUT_FORCE_X, WAVE_INPUT_FORCE_Y, WAVE_INPUT_DISSIPATION_TOTAL, &
-                    WAVE_INPUT_DISSIPATION_SURFACE, WAVE_INPUT_DISSIPATION_WHITE_CAPPING, wave_input_is_required
+                             WAVE_INPUT_FORCE_X, WAVE_INPUT_FORCE_Y, WAVE_INPUT_DISSIPATION_TOTAL, &
+                             WAVE_INPUT_DISSIPATION_SURFACE, WAVE_INPUT_DISSIPATION_WHITE_CAPPING, wave_input_is_required
       use m_waves, only: offline_wave_input_requirements
       use processes_input, only: sfunname, sfuninp, num_spatial_time_fuctions
       use fm_external_forcings_utils, only: split_qid
@@ -1684,7 +1715,7 @@ contains
                kb = kbot(n)
                kt = ktop(n)
                call operate(output_array_3d(n), input_array_2d(n), operand)
-               ! intentionally fill all levels, even those above the water surface. 
+               ! intentionally fill all levels, even those above the water surface.
                ! This is necessary for waq variables, and is harmless for quantities like salinity.
                do k = kb, kb + kmxn(n) - 1
                   level_at_pressure_point = 0.5_dp * (zws(k) + zws(k - 1))

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -33,7 +33,7 @@
 !! frictioncoefficient, etc.
 module unstruc_inifields
 
-   use m_setinitialverticalprofile, only: setinitialverticalprofile
+   use m_setinitialverticalprofile, only: setinitialverticalprofilez
    use m_add_tracer, only: add_tracer
    use m_setzcs, only: setzcs
    use messagehandling, only: msgbuf, warn_flush, err_flush
@@ -846,7 +846,7 @@ contains
       use m_find_name, only: find_name
       use m_add_bndtracer, only: add_bndtracer
       use m_add_tracer, only: add_tracer
-      use fm_location_types, only: UNC_LOC_S
+      use fm_location_types, only: UNC_LOC_S, UNC_LOC_3DV
       use processes_input, only: paname, painp, num_spatial_parameters
 
       character(len=*), intent(in) :: quantity !< Name of the quantity
@@ -877,6 +877,21 @@ contains
          first_index = 1
 
       case ('initialsedfrac')
+         if (.not. stm_included) then
+            success = .false.
+            return
+         end if
+         iconst = find_name(const_names, qid_specific)
+         if (iconst <= 0) then
+            call mess(LEVEL_WARN, 'resolve_initial_3d_target: unknown sediment fraction '''//trim(qid_specific)//'''.')
+            success = .false.
+            return
+         end if
+         first_index = iconst
+         target_array_3d => constituents
+
+      case ('initialverticalsedfracprofile', 'initialverticalsigmasedfracprofile')
+         target_location_type = UNC_LOC_3DV
          if (.not. stm_included) then
             success = .false.
             return

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_inifields.f90
@@ -958,7 +958,7 @@ contains
       use m_sediment, only: stm_included
       use m_transportdata, only: constituents, const_names
       use m_find_name, only: find_name
-      use fm_external_forcings_utils, only: get_sedfracname
+      use fm_external_forcings_utils, only: split_qid
       use unstruc_model, only: md_extfile
       use string_module, only: str_tolower
 
@@ -975,7 +975,8 @@ contains
       target_array => null()
       target_location_type = 0
       success = .true.
-      select case (str_tolower(qid))
+      call split_qid(qid, qid_base, qid_specific)
+      select case (str_tolower(qid_base))
       case ('waterlevel', 'initialwaterlevel')
          if (str_tolower(qid) == 'waterlevel') then
             call mess(LEVEL_WARN, 'Initial field quantity '''//trim(qid)//''' found in file '''//trim(inifilename) &
@@ -1078,7 +1079,6 @@ contains
 
       case ('initialverticalsedfracprofile', 'initialverticalsigmasedfracprofile')
          if (stm_included .and. kmx > 0) then
-            call get_sedfracname(qid, qid_specific, qid_base)
             iconst = find_name(const_names, qid_specific)
             if (iconst <= 0) then
                call mess(LEVEL_ERROR, 'Initial quantity '''//trim(qid)//''' refers to unknown sediment fraction '''//trim(qid_specific)//'''.')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_flowinit.f90
@@ -37,7 +37,7 @@ module m_flow_flowinit
    use m_setupwslopes, only: setupwslopes
    use m_setstruclink, only: setstruclink
    use m_setpillars, only: setpillars
-   use m_setinitialverticalprofile, only: setinitialverticalprofile
+   use m_setinitialverticalprofile, only: setinitialverticalprofilez
    use m_setfixedweirs, only: setfixedweirs
    use m_setbobs_fixedweirs, only: setbobs_fixedweirs
    use m_flow_setstarttime, only: flow_setstarttime
@@ -1188,7 +1188,7 @@ contains
             inquire (file='verticalsalinityprofile.pli', exist=success)
             call set_kbot_ktop(jazws0=1)
             if (success) then
-               call setinitialverticalprofile(sa1, ndkx, 'verticalsalinityprofile.pli')
+               call setinitialverticalprofilez(sa1, ndkx, 'verticalsalinityprofile.pli')
             end if
          end if
       end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/setinitialverticalprofile.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/setinitialverticalprofile.f90
@@ -36,12 +36,31 @@ module m_setinitialverticalprofile
 
    private
 
+   public :: setinitialverticalprofilez
    public :: setinitialverticalprofile
 
 contains
 
+   !> Set an initial vertical profile using the coordinate system encoded in the quantity name.
+   subroutine setinitialverticalprofile(quantity, target_array, ndkx, filename)
+      use precision, only: dp
+      use string_module, only: str_tolower
+      use m_setinitialverticalprofilesigma, only: setinitialverticalprofilesigma
+
+      character(len=*), intent(in) :: quantity !< External-forcing quantity name.
+      real(kind=dp), dimension(ndkx), intent(inout) :: target_array !< Values at 3D flow nodes.
+      integer, intent(in) :: ndkx !< Number of 3D flow nodes.
+      character(len=*), intent(in) :: filename !< Name of the profile polygon file.
+
+      if (index(str_tolower(quantity), 'initialverticalsigma') == 1) then
+         call setinitialverticalprofilesigma(target_array, ndkx, filename)
+      else
+         call setinitialverticalprofilez(target_array, ndkx, filename)
+      end if
+   end subroutine setinitialverticalprofile
+
    !> Sets initial vertical profile of e.g., salinity and temperature
-   subroutine setinitialverticalprofile(target_array, ndkx, filename)
+   subroutine setinitialverticalprofilez(target_array, ndkx, filename)
       use precision, only: dp
       use m_flowgeom, only: ndxi
       use m_flow, only: zws, layertype, LAYTP_Z, keepzlayeringatbed, zslay, kmxx
@@ -52,7 +71,7 @@ contains
       use m_filez, only: oldfil
       use m_add_baroclinic_pressure, only: BAROC_ORIGINAL, rhointerfaces
 
-      real(kind=dp), intent(in), dimension(ndkx) :: target_array !< Target array - e.g., sa1 (salinity) or tem1 (temperature)
+      real(kind=dp), dimension(ndkx), intent(inout) :: target_array !< Target array - e.g., sa1 (salinity) or tem1 (temperature)
       integer, intent(in) :: ndkx !< Dimension of 3d flow nodes (internal + boundary)
       character(len=*), intent(in) :: filename !< Filename of polygonfile
 
@@ -81,6 +100,6 @@ contains
 
       call restorepol()
 
-   end subroutine setinitialverticalprofile
+   end subroutine setinitialverticalprofilez
 
 end module m_setinitialverticalprofile

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/setinitialverticalprofilesigma.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/setinitialverticalprofilesigma.f90
@@ -49,10 +49,10 @@ contains
       use m_get_kbot_ktop, only: getkbotktop
       use m_filez, only: oldfil
 
-      integer :: ny
+      integer, intent(in) :: ny
       real(kind=dp) :: xx(kmxx), xxx(kmxx)
-      real(kind=dp) :: yy(ny)
-      character(*), intent(in) :: filename ! file name for polygonfile
+      real(kind=dp), dimension(ny), intent(inout) :: yy
+      character(len=*), intent(in) :: filename ! file name for polygonfile
 
       integer :: minp0, n, k, kb, kt, ktx
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1074,7 +1074,7 @@ contains
             end if
          end if
          if (.not. res) then
-            write (msgbuf, '(a)') 'Unknown quantity '''//trim(quantity)//' in file '''//trim(file_name)//''': ['//trim(group_name)//'].'
+            write (msgbuf, '(a)') 'Could not initialize quantity '''//trim(quantity)//' from file '''//trim(file_name)//''': ['//trim(group_name)//']. It is either unknown or invalid.'
             call err_flush()
             return
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -1059,6 +1059,9 @@ contains
          end if
          if (.not. res) then
             res = resolve_initial_3D_target(quantity, target_location_type, target_array_3d, first_index)
+            if (res .and. target_location_type == UNC_LOC_3DV .and. associated(target_array_3d)) then
+               target_data => target_array_3d(first_index, :)
+            end if
          end if
          if (.not. res) then
             res = resolve_integer_target(quantity, target_location_type, target_data_integer)
@@ -1084,7 +1087,7 @@ contains
 
          if (is_static_field) then
             if (target_location_type == UNC_LOC_3DV) then ! vertical profiles are special
-               call setinitialverticalprofile(target_data, size(target_data), forcing_file)
+               call setinitialverticalprofile(quantity, target_data, size(target_data), forcing_file)
                res = .true.
             else ! normal spatial field
                block

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -38,7 +38,7 @@ contains
    !> Initialize external forcings from an 'old' format ext file. Only to be called once as part of fm_initexternalforcings.
    module subroutine init_old(iresult)
       use m_setinitialverticalprofilesigma, only: setinitialverticalprofilesigma
-      use m_setinitialverticalprofile, only: setinitialverticalprofile
+      use m_setinitialverticalprofile, only: setinitialverticalprofilez
       use precision, only: dp
       use m_source_sink, only: addsorsin_from_polyline_file, source_sinks
       use m_add_tracer, only: add_tracer
@@ -481,12 +481,12 @@ contains
 
             else if (temperature_model /= TEMPERATURE_MODEL_NONE .and. qid == 'initialverticaltemperatureprofile' .and. kmx > 0) then
 
-               call setinitialverticalprofile(tem1, ndkx, filename)
+               call setinitialverticalprofilez(tem1, ndkx, filename)
                success = .true.
 
             else if (jasal > 0 .and. qid == 'initialverticalsalinityprofile' .and. kmx > 0) then
 
-               call setinitialverticalprofile(sa1, ndkx, filename)
+               call setinitialverticalprofilez(sa1, ndkx, filename)
                success = .true.
 
             else if (janudge > 0 .and. qid == 'nudgetime') then
@@ -547,7 +547,7 @@ contains
                if (iconst > 0) then
                   allocate (tt(1:ndkx))
                   tt = dmiss
-                  call setinitialverticalprofile(tt, ndkx, filename)
+                  call setinitialverticalprofilez(tt, ndkx, filename)
                   success = .true.
                   constituents(iconst, :) = tt
                   deallocate (tt)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -1900,19 +1900,86 @@ contains
    !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialverticalsedfracprofile, test_initialverticalsedfracprofile,
+   !> Verifies that an initialverticalsedfracprofile [Spatial] block populates
+   !! the selected sediment constituent using absolute z coordinates.
    subroutine test_initialverticalsedfracprofile() bind(C)
-      call test_initial_vertical_sediment_profile(.false.)
+      use m_flow, only: kmx, kbot, ktop, zws, ndkx
+      use m_flowgeom, only: ndx2D, ndxi
+      use m_sediment, only: stm_included
+      use m_transportdata, only: constituents, const_names, NUMCONST
+      use m_flowtimes, only: irefdate, tzone, tstart_user
+      use m_polygon, only: m_polygon_destructor
+
+      type(tree_data), pointer :: bnd_ptr, block_ptr
+      logical :: success
+      integer :: ierr
+      character(len=*), parameter :: PROFILE_FILE = "test_sedfrac_z_profile.pol"
+      character(len=*), parameter :: EXT_FILE = "test_sedfrac_z_profile.ext"
+
+      call create_file(PROFILE_FILE, [ &
+                       "sedfracprofile", &
+                       "2  2", &
+                       "-10.0  2.0", &
+                       "  0.0  4.0"])
+      call create_file(EXT_FILE, [character(len=128) :: &
+                       "[Spatial]", &
+                       "    quantity        = initialverticalsedfracprofileSediment_sand", &
+                       "    forcingFile     = "//PROFILE_FILE, &
+                       "    forcingFileType = Polygon"])
+
+      call setup_minimal_grid()
+      ndxi = ndx
+      ndx2D = 0
+      ndkx = ndx
+      kmx = 1
+      stm_included = .true.
+      NUMCONST = 1
+
+      call realloc(kbot, ndxi, fill=1, keepExisting=.false.)
+      call realloc(ktop, ndxi, fill=1, keepExisting=.false.)
+      if (allocated(zws)) deallocate (zws)
+      allocate (zws(0:ndkx))
+      zws = [-10.0_dp, 0.0_dp]
+      if (allocated(constituents)) deallocate (constituents)
+      allocate (constituents(NUMCONST, ndkx), source=0.0_dp)
+      if (allocated(const_names)) deallocate (const_names)
+      allocate (const_names(NUMCONST))
+      const_names(1) = "Sediment_sand"
+
+      irefdate = 20000101
+      tzone = 0.0_dp
+      tstart_user = 0.0_dp
+      threshold_abort = LEVEL_FATAL
+      call initialize_ec_module()
+      ierr = m_polygon_destructor()
+
+      call parse_spatial_block(EXT_FILE, bnd_ptr, block_ptr)
+      success = init_spatial_fields(block_ptr, BASE_DIR, EXT_FILE, 'Spatial')
+      call tree_destroy(bnd_ptr)
+
+      call f90_expect_true(success, "z sediment profile initialization should succeed")
+      call f90_expect_near(constituents(1, 1), 3.0_dp, 1.0e-10_dp, &
+                           "z profile should be evaluated at the absolute layer-center elevation")
+
+      stm_included = .false.
+      NUMCONST = 0
+      kmx = 0
+      ndkx = 0
+      ndxi = 0
+      ndx2D = 0
+      if (allocated(kbot)) deallocate (kbot)
+      if (allocated(ktop)) deallocate (ktop)
+      if (allocated(zws)) deallocate (zws)
+      if (allocated(constituents)) deallocate (constituents)
+      if (allocated(const_names)) deallocate (const_names)
+      call teardown_minimal_grid()
    end subroutine test_initialverticalsedfracprofile
    !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialverticalsigmasedfracprofile, test_initialverticalsigmasedfracprofile,
+   !> Verifies that an initialverticalsigmasedfracprofile [Spatial] block populates
+   !! the selected sediment constituent using sigma coordinates.
    subroutine test_initialverticalsigmasedfracprofile() bind(C)
-      call test_initial_vertical_sediment_profile(.true.)
-   end subroutine test_initialverticalsigmasedfracprofile
-   !$f90tw)
-
-   !> Verify that a vertical sediment profile populates its named constituent using z or sigma coordinates.
-   subroutine test_initial_vertical_sediment_profile(use_sigma)
       use m_flow, only: kmx, kbot, ktop, zws, ndkx, s1
       use m_flowgeom, only: ndx2D, ndxi, bl
       use m_sediment, only: stm_included
@@ -1920,33 +1987,20 @@ contains
       use m_flowtimes, only: irefdate, tzone, tstart_user
       use m_polygon, only: m_polygon_destructor
 
-      logical, intent(in) :: use_sigma
-
       type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
       integer :: ierr
-      character(len=64) :: quantity
-      character(len=*), parameter :: PROFILE_FILE = "test_sedfrac_profile.pol"
-      character(len=*), parameter :: EXT_FILE = "test_sedfrac_profile.ext"
+      character(len=*), parameter :: PROFILE_FILE = "test_sedfrac_sigma_profile.pol"
+      character(len=*), parameter :: EXT_FILE = "test_sedfrac_sigma_profile.ext"
 
-      if (use_sigma) then
-         quantity = "initialverticalsigmasedfracprofileSediment_sand"
-         call create_file(PROFILE_FILE, [ &
-                          "sedfracprofile", &
-                          "2  2", &
-                          "0.0  10.0", &
-                          "1.0  20.0"])
-      else
-         quantity = "initialverticalsedfracprofileSediment_sand"
-         call create_file(PROFILE_FILE, [ &
-                          "sedfracprofile", &
-                          "2  2", &
-                          "-10.0  2.0", &
-                          "  0.0  4.0"])
-      end if
+      call create_file(PROFILE_FILE, [ &
+                       "sedfracprofile", &
+                       "2  2", &
+                       "0.0  10.0", &
+                       "1.0  20.0"])
       call create_file(EXT_FILE, [character(len=128) :: &
                        "[Spatial]", &
-                       "    quantity        = "//trim(quantity), &
+                       "    quantity        = initialverticalsigmasedfracprofileSediment_sand", &
                        "    forcingFile     = "//PROFILE_FILE, &
                        "    forcingFileType = Polygon"])
 
@@ -1982,14 +2036,9 @@ contains
       success = init_spatial_fields(block_ptr, BASE_DIR, EXT_FILE, 'Spatial')
       call tree_destroy(bnd_ptr)
 
-      call f90_expect_true(success, "vertical sediment profile initialization should succeed")
-      if (use_sigma) then
-         call f90_expect_near(constituents(1, 1), 15.0_dp, 1.0e-10_dp, &
-                              "sigma profile should be evaluated at the layer-center sigma coordinate")
-      else
-         call f90_expect_near(constituents(1, 1), 3.0_dp, 1.0e-10_dp, &
-                              "z profile should be evaluated at the absolute layer-center elevation")
-      end if
+      call f90_expect_true(success, "sigma sediment profile initialization should succeed")
+      call f90_expect_near(constituents(1, 1), 15.0_dp, 1.0e-10_dp, &
+                           "sigma profile should be evaluated at the layer-center sigma coordinate")
 
       stm_included = .false.
       NUMCONST = 0
@@ -2005,7 +2054,8 @@ contains
       if (allocated(constituents)) deallocate (constituents)
       if (allocated(const_names)) deallocate (const_names)
       call teardown_minimal_grid()
-   end subroutine test_initial_vertical_sediment_profile
+   end subroutine test_initialverticalsigmasedfracprofile
+   !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_field1d_global_value_applied_to_frictioncoefficient, test_field1d_global_value_applied_to_frictioncoefficient,
    !> Verifies that a frictioncoefficient block with forcingFileType=1dField applies

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -1812,7 +1812,7 @@ contains
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialverticalsalinityprofile, test_initialverticalsalinityprofile,
    !> Verifies that an initialverticalsalinityprofile [Spatial] block populates sa1
    !! via the UNC_LOC_3DV path in init_spatial_fields, which bypasses EC entirely and
-   !! calls setinitialverticalprofile directly with the polygon profile file..
+   !! calls setinitialverticalprofilez directly with the polygon profile file..
    subroutine test_initialverticalsalinityprofile() bind(C)
       use m_flow, only: sa1, kmx, kmxx, kbot, ktop, zws, layertype, ndkx
       use m_flowgeom, only: ndx2D, ndxi
@@ -1860,7 +1860,7 @@ contains
       call realloc(sa1, ndkx, fill=0.0_dp, keepExisting=.false.)
 
       ! zws(0:ndkx): zws(0)=bed interface, zws(1)=surface interface.
-      ! setinitialverticalprofile computes z_center(1) = 0.5*(zws(1)+zws(0)) = -5 m.
+      ! setinitialverticalprofilez computes z_center(1) = 0.5*(zws(1)+zws(0)) = -5 m.
       if (allocated(zws)) deallocate (zws)
       allocate (zws(0:ndkx))
       zws(0) = -10.0_dp
@@ -1898,6 +1898,114 @@ contains
       call teardown_minimal_grid()
    end subroutine test_initialverticalsalinityprofile
    !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialverticalsedfracprofile, test_initialverticalsedfracprofile,
+   subroutine test_initialverticalsedfracprofile() bind(C)
+      call test_initial_vertical_sediment_profile(.false.)
+   end subroutine test_initialverticalsedfracprofile
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_initialverticalsigmasedfracprofile, test_initialverticalsigmasedfracprofile,
+   subroutine test_initialverticalsigmasedfracprofile() bind(C)
+      call test_initial_vertical_sediment_profile(.true.)
+   end subroutine test_initialverticalsigmasedfracprofile
+   !$f90tw)
+
+   !> Verify that a vertical sediment profile populates its named constituent using z or sigma coordinates.
+   subroutine test_initial_vertical_sediment_profile(use_sigma)
+      use m_flow, only: kmx, kbot, ktop, zws, ndkx, s1
+      use m_flowgeom, only: ndx2D, ndxi, bl
+      use m_sediment, only: stm_included
+      use m_transportdata, only: constituents, const_names, NUMCONST
+      use m_flowtimes, only: irefdate, tzone, tstart_user
+      use m_polygon, only: m_polygon_destructor
+
+      logical, intent(in) :: use_sigma
+
+      type(tree_data), pointer :: bnd_ptr, block_ptr
+      logical :: success
+      integer :: ierr
+      character(len=64) :: quantity
+      character(len=*), parameter :: PROFILE_FILE = "test_sedfrac_profile.pol"
+      character(len=*), parameter :: EXT_FILE = "test_sedfrac_profile.ext"
+
+      if (use_sigma) then
+         quantity = "initialverticalsigmasedfracprofileSediment_sand"
+         call create_file(PROFILE_FILE, [ &
+                          "sedfracprofile", &
+                          "2  2", &
+                          "0.0  10.0", &
+                          "1.0  20.0"])
+      else
+         quantity = "initialverticalsedfracprofileSediment_sand"
+         call create_file(PROFILE_FILE, [ &
+                          "sedfracprofile", &
+                          "2  2", &
+                          "-10.0  2.0", &
+                          "  0.0  4.0"])
+      end if
+      call create_file(EXT_FILE, [character(len=128) :: &
+                       "[Spatial]", &
+                       "    quantity        = "//trim(quantity), &
+                       "    forcingFile     = "//PROFILE_FILE, &
+                       "    forcingFileType = Polygon"])
+
+      call setup_minimal_grid()
+      ndxi = ndx
+      ndx2D = 0
+      ndkx = ndx
+      kmx = 1
+      stm_included = .true.
+      NUMCONST = 1
+
+      call realloc(kbot, ndxi, fill=1, keepExisting=.false.)
+      call realloc(ktop, ndxi, fill=1, keepExisting=.false.)
+      call realloc(bl, ndxi, fill=-10.0_dp, keepExisting=.false.)
+      call realloc(s1, ndxi, fill=0.0_dp, keepExisting=.false.)
+      if (allocated(zws)) deallocate (zws)
+      allocate (zws(0:ndkx))
+      zws = [-10.0_dp, 0.0_dp]
+      if (allocated(constituents)) deallocate (constituents)
+      allocate (constituents(NUMCONST, ndkx), source=0.0_dp)
+      if (allocated(const_names)) deallocate (const_names)
+      allocate (const_names(NUMCONST))
+      const_names(1) = "Sediment_sand"
+
+      irefdate = 20000101
+      tzone = 0.0_dp
+      tstart_user = 0.0_dp
+      threshold_abort = LEVEL_FATAL
+      call initialize_ec_module()
+      ierr = m_polygon_destructor()
+
+      call parse_spatial_block(EXT_FILE, bnd_ptr, block_ptr)
+      success = init_spatial_fields(block_ptr, BASE_DIR, EXT_FILE, 'Spatial')
+      call tree_destroy(bnd_ptr)
+
+      call f90_expect_true(success, "vertical sediment profile initialization should succeed")
+      if (use_sigma) then
+         call f90_expect_near(constituents(1, 1), 15.0_dp, 1.0e-10_dp, &
+                              "sigma profile should be evaluated at the layer-center sigma coordinate")
+      else
+         call f90_expect_near(constituents(1, 1), 3.0_dp, 1.0e-10_dp, &
+                              "z profile should be evaluated at the absolute layer-center elevation")
+      end if
+
+      stm_included = .false.
+      NUMCONST = 0
+      kmx = 0
+      ndkx = 0
+      ndxi = 0
+      ndx2D = 0
+      if (allocated(kbot)) deallocate (kbot)
+      if (allocated(ktop)) deallocate (ktop)
+      if (allocated(bl)) deallocate (bl)
+      if (allocated(s1)) deallocate (s1)
+      if (allocated(zws)) deallocate (zws)
+      if (allocated(constituents)) deallocate (constituents)
+      if (allocated(const_names)) deallocate (const_names)
+      call teardown_minimal_grid()
+   end subroutine test_initial_vertical_sediment_profile
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_field1d_global_value_applied_to_frictioncoefficient, test_field1d_global_value_applied_to_frictioncoefficient,
    !> Verifies that a frictioncoefficient block with forcingFileType=1dField applies


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- case ('initialverticalsedfracprofile', 'initialverticalsigmasedfracprofile') added to initial 3D target resolver
- setinitialverticalprofile renamed to setinitialverticalprofilez
- setinitialverticalprofile now scans the quantity name to determine z or sigma layers (note, this is very awful, but making z or sigma a separate field for initial vertical profile quantities requires work from the hydrolib core team (@JulienGroenenboom thoughts?)
- two small vibe coded unit tests

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
