### PR TITLE
UNST-4935/UNST-10269: Missing sedfrac name, morft and morfac in mapmerge

### DIFF
--- a/src/tools_gpl/dfmoutput/src/dfm_merge.F90
+++ b/src/tools_gpl/dfmoutput/src/dfm_merge.F90
@@ -80,7 +80,7 @@ contains
       integer, dimension(nfiles + 1) :: ncids, id_time, id_timestep, id_mappingVar
       integer, allocatable :: id_timedim(:, :), id_morft(:), id_morfac(:), id_frac_name(:), id_susfrac_name(:)
       double precision :: convversion
-      integer :: jaugrid, iconvtype, formatCode, new_ndx
+      integer :: jaugrid, iconvtype, formatCode, new_ndx, jasedmor, jamorfac
       integer, dimension(nfiles) :: jaugridi, ioncids
       logical :: isNetCDF4
       integer, allocatable :: dimids(:, :, :) !<(nDims, maxTopodim,nfiles+1) Used for storing any remaining vectormax dimension IDs
@@ -630,11 +630,13 @@ contains
                      ! check if it is a dimension for sediment variables.
                      ! The sediment related dimensions cannot be dinstinguished on mesh 1d or 2d.
                      if (strcmpi(dimname, 'nSedTot')) then
+                        jasedmor = 1
                         id_sedtotdim(itopo, ii) = id
                         dimids(id, itopo, ii) = id
                         nsedtot(ii) = nlen
                         cycle
                      else if (strcmpi(dimname, 'nSedSus')) then
+                        jasedmor = 1
                         id_sedsusdim(itopo, ii) = id
                         dimids(id, itopo, ii) = id
                         nsedsus(ii) = nlen
@@ -731,8 +733,10 @@ contains
 
                      ! check if it is a dimension for sediment variables
                      if (strcmpi(dimname, 'nSedTot')) then
+                        jasedmor = 1
                         id_sedtotdim(itopo, ii) = id
                      else if (strcmpi(dimname, 'nSedSus')) then
+                        jasedmor = 1
                         id_sedsusdim(itopo, ii) = id
                      else if (strcmpi(dimname, 'nBedLayers')) then
                         id_nlyrdim(itopo, ii) = id
@@ -1089,22 +1093,25 @@ contains
                end if
             end if
             
-            ierr = nf90_inq_varid(ncids(ifileScan), 'morft', id_morft(ifileScan))
-            ! if morft doesn't exist -> no copy
-            ierr = nf90_def_var(ncids(noutfile), 'morft', nf90_double, (/id_timedim(itopo, noutfile)/), id_morft(noutfile))
-            ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
-            if (isNetCDF4) then
-               ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
-            end if
+            ! copy attributes of morft and morfac if they exist
+            if (jasedmor == 1) then
+               ierr = nf90_inq_varid(ncids(ifileScan), 'morft', id_morft(ifileScan))
+               ierr = nf90_def_var(ncids(noutfile), 'morft', nf90_double, (/id_timedim(itopo, noutfile)/), id_morft(noutfile))
+               ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
+                  if (isNetCDF4) then
+                     ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
+                  end if
             
-            ierr = nf90_inq_varid(ncids(ifileScan), 'morfac', id_morfac(ifileScan))
-            ! if morfac doesn't exist -> no copy
-            ierr = nf90_def_var(ncids(noutfile), 'morfac', nf90_double, (/id_timedim(itopo, noutfile)/), id_morfac(noutfile))
-            ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
-            if (isNetCDF4) then
-               ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
+               ierr = nf90_inq_varid(ncids(ifileScan), 'morfac', id_morfac(ifileScan))
+               if  (ierr == nf90_noerr) then
+                  jamorfac = 1
+                  ierr = nf90_def_var(ncids(noutfile), 'morfac', nf90_double, (/id_timedim(itopo, noutfile)/), id_morfac(noutfile))
+                  ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
+                  if (isNetCDF4) then
+                     ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
+                  end if
+               end if
             end if
-            
 
             ! Only for ugrid format, because this variable will be defined in step 4 for old format
             if (jaugrid == 1) then
@@ -1838,6 +1845,26 @@ contains
                ierr = nf90_put_att(ncids(noutfile), varids_out(iv, itopo), '_FillValue', fill_value_int)
             end if
          end do
+      
+      ! copy the attrubutes of sedfrac_name and sussedfrac_name
+      if (jasedmor == 1) then
+         !!define sedfrac_name and sussedfrac_name variables and copy their attributes!!
+         ierr = nf90_inq_varid(ncids(ifileScan), 'sedfrac_name', id_frac_name(ifileScan))
+         ierr = nf90_def_dim(ncids(noutfile), 'nStringlen', 100, id_strlendim(itopo, noutfile))
+         ierr = nf90_def_var(ncids(noutfile), 'sedfrac_name', nf90_char, (/id_strlendim(itopo, noutfile), id_sedtotdim(itopo, noutfile)/), id_frac_name(noutfile)) !TODO: relocate somewhere such that itopo=1?
+         ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
+         if (isNetCDF4) then
+            ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
+         end if
+      
+         ierr = nf90_inq_varid(ncids(ifileScan), 'sussedfrac_name', id_susfrac_name(ifileScan))
+         ierr = nf90_def_var(ncids(noutfile), 'sussedfrac_name', nf90_char, (/id_strlendim(itopo, noutfile), id_sedsusdim(itopo, noutfile)/), id_susfrac_name(noutfile))
+         ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
+         if (isNetCDF4) then
+            ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
+         end if
+      end if
+            
       end do ! itopo
 
       ! When both 1D and 2D meshes are present, the global numbering of 1D nodes (read from input files) includes the 2D faces.
@@ -2003,22 +2030,6 @@ contains
          continue ! non-UGRID 1D2D links not supported.
       end if
 
-      !!define sedfrac_name and sussedfrac_name variables and copy their attributes!!
-      ierr = nf90_inq_varid(ncids(ifileScan), 'sedfrac_name', id_frac_name(ifileScan))
-      ierr = nf90_def_dim(ncids(noutfile), 'nStringlen', 100, id_strlendim(1, noutfile))
-      ierr = nf90_def_var(ncids(noutfile), 'sedfrac_name', nf90_char, (/id_strlendim(1, noutfile), id_sedtotdim(1, noutfile)/), id_frac_name(noutfile)) !TODO: relocate somewhere such that itopo=1?
-      ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
-      if (isNetCDF4) then
-         ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
-      end if
-      
-      ierr = nf90_inq_varid(ncids(ifileScan), 'sussedfrac_name', id_susfrac_name(ifileScan))
-      ierr = nf90_def_var(ncids(noutfile), 'sussedfrac_name', nf90_char, (/id_strlendim(1, noutfile), id_sedsusdim(1, noutfile)/), id_susfrac_name(noutfile))
-      ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
-      if (isNetCDF4) then
-         ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
-      end if
-            
       ierr = nf90_enddef(ncids(noutfile))
 
    !! 6. Write new flow geom to output file
@@ -2036,40 +2047,44 @@ contains
          do it = 1, ntsel
             ierr = nf90_get_var(ncids(ifileScan), id_time(ifileScan), times(it), start=(/itimsel(it)/)) ! count=1
             ierr = nf90_get_var(ncids(ifileScan), id_timestep(ifileScan), timestep(it), start=(/itimsel(it)/)) ! count=1
-            !make an additional condition to read morft/morfac -> copy & put it into nc
-            ierr = nf90_get_var(ncids(ifileScan), id_morft(ifileScan), morft(it), start=(/itimsel(it)/))
-            ierr = nf90_get_var(ncids(ifileScan), id_morfac(ifileScan), morfac(it), start=(/itimsel(it)/))
+            ! if it contains sedtrans/mor variables
+            if (jasedmor == 1) then
+               ierr = nf90_get_var(ncids(ifileScan), id_morft(ifileScan), morft(it), start=(/itimsel(it)/))
+               if (jamorfac == 1) then
+                  ierr = nf90_get_var(ncids(ifileScan), id_morfac(ifileScan), morfac(it), start=(/itimsel(it)/))
+               end if
+            end if
          end do
 
          ierr = nf90_put_var(ncids(noutfile), id_time(noutfile), times, count=(/ntsel/))
          ierr = nf90_put_var(ncids(noutfile), id_timestep(noutfile), timestep, count=(/ntsel/))
-         !make an additional condition to read morft/morfac -> copy & put it into nc
-         ierr = nf90_put_var(ncids(noutfile), id_morft(noutfile), morft, count=(/ntsel/))
-         ierr = nf90_put_var(ncids(noutfile), id_morfac(noutfile), morfac, count=(/ntsel/))
+         ! if it contains sedtrans/mor variables
+         if (jasedmor == 1) then
+            ierr = nf90_put_var(ncids(noutfile), id_morft(noutfile), morft, count=(/ntsel/))
+            if (jamorfac == 1) then
+               ierr = nf90_put_var(ncids(noutfile), id_morfac(noutfile), morfac, count=(/ntsel/))
+            end if
+         end if
       end if
       
-      !!copy the sediment fraction name to the merged file!!
-      nsedtotsel = nsedtot(ifileScan)
-      nsedtot(noutfile) = nsedtotsel
+      !copy the sediment fraction name to the merged file
+      if (jasedmor == 1) then
+         nsedtotsel = nsedtot(ifileScan)
+         nsedtot(noutfile) = nsedtotsel
+         allocate (sedfrac_name(nsedtotsel))
+         do it = 1, nsedtotsel
+             ierr = nf90_get_var(ncids(ifileScan), id_frac_name(ifileScan), sedfrac_name(it))
+         end do
+         ierr = nf90_put_var(ncids(noutfile), id_frac_name(noutfile), sedfrac_name)
       
-      allocate (sedfrac_name(nsedtotsel))
-      
-      do it = 1, nsedtotsel
-          ierr = nf90_get_var(ncids(ifileScan), id_frac_name(ifileScan), sedfrac_name(it))
-      end do
-      
-      ierr = nf90_put_var(ncids(noutfile), id_frac_name(noutfile), sedfrac_name)
-      
-      nsedsussel = nsedsus(ifileScan)
-      nsedsus(noutfile) = nsedsussel
-      
-      allocate (sussedfrac_name(nsedsussel))
-      
-      do it = 1, nsedsussel
-          ierr = nf90_get_var(ncids(ifileScan), id_susfrac_name(ifileScan), sussedfrac_name(it))
-      end do
-      
-      ierr = nf90_put_var(ncids(noutfile), id_susfrac_name(noutfile), sussedfrac_name)
+         nsedsussel = nsedsus(ifileScan)
+         nsedsus(noutfile) = nsedsussel
+         allocate (sussedfrac_name(nsedsussel))
+         do it = 1, nsedsussel
+             ierr = nf90_get_var(ncids(ifileScan), id_susfrac_name(ifileScan), sussedfrac_name(it))
+         end do
+         ierr = nf90_put_var(ncids(noutfile), id_susfrac_name(noutfile), sussedfrac_name)
+      end if
       
       ! 6b. A loop on meshe topology to write the merged variables to the output file.
       do itopo = minTopodim, maxTopodim

--- a/src/tools_gpl/dfmoutput/src/dfm_merge.F90
+++ b/src/tools_gpl/dfmoutput/src/dfm_merge.F90
@@ -76,15 +76,15 @@ contains
       integer, parameter :: ikx0 = 1
 
       integer, allocatable :: id_facedim(:, :), id_edgedim(:, :), id_laydim(:, :), id_wdim(:, :), id_nodedim(:, :), id_sedtotdim(:, :), id_sedsusdim(:, :), id_nlyrdim(:, :), &
-                              id_netedgedim(:, :), id_netfacedim(:, :), id_netfacemaxnodesdim(:, :), id_bnddim(:, :) !< dim and var ids, maintained for all input files + 1 output file.
+                              id_netedgedim(:, :), id_netfacedim(:, :), id_netfacemaxnodesdim(:, :), id_bnddim(:, :), id_strlendim(:, :) !< dim and var ids, maintained for all input files + 1 output file.
       integer, dimension(nfiles + 1) :: ncids, id_time, id_timestep, id_mappingVar
-      integer, allocatable :: id_timedim(:, :)
+      integer, allocatable :: id_timedim(:, :), id_morft(:), id_morfac(:), id_frac_name(:), id_susfrac_name(:)
       double precision :: convversion
       integer :: jaugrid, iconvtype, formatCode, new_ndx
       integer, dimension(nfiles) :: jaugridi, ioncids
       logical :: isNetCDF4
       integer, allocatable :: dimids(:, :, :) !<(nDims, maxTopodim,nfiles+1) Used for storing any remaining vectormax dimension IDs
-      integer, allocatable, target :: ndx(:, :), lnx(:, :), ndxg(:, :), lnxg(:, :), kmx(:, :), numk(:, :), numl(:, :), nump(:, :), numkg(:, :), numlg(:, :), netfacemaxnodes(:, :), ndxbnd(:, :), nt(:) !< counters, maintained for all input files + 1 output file.
+      integer, allocatable, target :: ndx(:, :), lnx(:, :), ndxg(:, :), lnxg(:, :), kmx(:, :), numk(:, :), numl(:, :), nump(:, :), numkg(:, :), numlg(:, :), netfacemaxnodes(:, :), ndxbnd(:, :), nt(:), nsedtot(:), nsedsus(:) !< counters, maintained for all input files + 1 output file.
       integer, dimension(:), pointer :: item_counts !< Generalized count pointer, will point to ndx, lnx, numl, or numk during var data reading + writing.
       integer :: noutfile !< array index/position of output file ids, by default the last, i.e., nfiles + 1.
       integer, allocatable, target :: face_domain(:, :), facebnd_domain(:, :), edge_domain(:, :), node_domain(:, :), netedge_domain(:, :) !< Global face/edge/node numbers and their domain number.
@@ -112,7 +112,7 @@ contains
 !netface_g2c(:)
       integer :: id_flownodedomain, id_flownodeglobnr, id_edgefaces, id_netfacenodes, id_edgenodes, id_netedgefaces, id_netfaceedges
       integer :: ierri
-      integer :: maxlen, nlen, plen, mlen, ii, id, iv, it, itm, ip, ik, is, ie, ntsel, ndims, nvardims, vartype
+      integer :: maxlen, nlen, plen, mlen, ii, id, iv, it, itm, ip, ik, is, ie, ntsel, ndims, nvardims, vartype, nsedtotsel, nsedsussel
       integer :: netfacemaxnodesg, numkt, lnxt, ndxt, numlt
       integer, allocatable :: ndxc(:), lnxc(:), numkc(:), numlc(:), ndx_bndc(:) ! number of ndx, lnx,... of all input files on a certain mesh
       integer :: ndxMax, lnxMax, numkMax, numlMax, ndx_bndMax
@@ -205,12 +205,15 @@ contains
       integer, allocatable :: itimsel(:)
       double precision, allocatable :: times(:)
       double precision, allocatable :: timestep(:)
+      double precision, allocatable :: morft(:)
+      double precision, allocatable :: morfac(:)
       logical :: isfound, needshift, exist
       integer :: size_btmp
       character(len=1) :: answer
       character(len=8) :: cdate
       character(len=10) :: ctime
       character(len=5) :: czone
+      character(len=20), allocatable :: sedfrac_name(:), sussedfrac_name(:)
       integer :: nMaxMeshes, nMeshOld, ifileScan, ivScan, jaTopLevel, maxnvars, nvarsScan
       integer, allocatable :: ifile(:), nvars(:, :), max_nvars(:), varids_itopo(:)
       integer :: isOnMesh
@@ -425,8 +428,16 @@ contains
       call realloc(id_netfacedim, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=-1)
       call realloc(id_netfacemaxnodesdim, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=-1)
       call realloc(id_bnddim, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=-1)
+      call realloc(id_strlendim, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=-1)
+      
+      call realloc(id_morft, nfiles + 1, keepExisting=.false., fill=-1)
+      call realloc(id_morfac, nfiles + 1, keepExisting=.false., fill=-1)
+      call realloc(id_frac_name, nfiles + 1, keepExisting=.false., fill=-1)
+      call realloc(id_susfrac_name, nfiles + 1, keepExisting=.false., fill=-1)
 
       call realloc(nt, nfiles + 1, keepExisting=.false., fill=0)
+      call realloc(nsedtot, nfiles + 1, keepExisting=.false., fill=0)
+      call realloc(nsedsus, nfiles + 1, keepExisting=.false., fill=0)
       call realloc(ndx, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=0)
       call realloc(lnx, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=0)
       call realloc(ndxg, (/maxTopodim, nfiles + 1/), keepExisting=.false., fill=0)
@@ -621,10 +632,12 @@ contains
                      if (strcmpi(dimname, 'nSedTot')) then
                         id_sedtotdim(itopo, ii) = id
                         dimids(id, itopo, ii) = id
+                        nsedtot(ii) = nlen
                         cycle
                      else if (strcmpi(dimname, 'nSedSus')) then
                         id_sedsusdim(itopo, ii) = id
                         dimids(id, itopo, ii) = id
+                        nsedsus(ii) = nlen
                         cycle
                      else if (strcmpi(dimname, 'nBedLayers')) then
                         id_nlyrdim(itopo, ii) = id
@@ -861,6 +874,18 @@ contains
                elseif (tmpdimids(1) == id_timedim(itopo, ifileScan) .and. trim(varname) == 'timestep') then
                   id_timestep(ifileScan) = ivScan ! TODO: AvD: do this for all ii files, not only for 'ifileScan'
                   cycle
+               elseif (tmpdimids(1) == id_timedim(itopo, ifileScan) .and. trim(varname) == 'morft') then
+                   id_morft(ifileScan) = ivScan
+                   cycle
+               elseif (tmpdimids(1) == id_timedim(itopo, ifileScan) .and. trim(varname) == 'morfac') then
+                   id_morfac(ifileScan) = ivScan
+                   cycle
+               elseif (tmpdimids(1) == id_sedtotdim(itopo, ifileScan) .and. trim(varname) == 'sedfrac_name') then
+                   id_frac_name(ifileScan) = ivScan
+                   cycle
+               elseif (tmpdimids(1) == id_sedsusdim(itopo, ifileScan) .and. trim(varname) == 'sussedfrac_name') then
+                   id_susfrac_name(ifileScan) = ivScan
+                   cycle
                end if
             end if
 !
@@ -1063,6 +1088,23 @@ contains
                   if (ierr /= 0) write (*, *) 'nf90_def_var_chunking failed for var timestep'
                end if
             end if
+            
+            ierr = nf90_inq_varid(ncids(ifileScan), 'morft', id_morft(ifileScan))
+            ! if morft doesn't exist -> no copy
+            ierr = nf90_def_var(ncids(noutfile), 'morft', nf90_double, (/id_timedim(itopo, noutfile)/), id_morft(noutfile))
+            ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
+            if (isNetCDF4) then
+               ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morft(ifileScan), id_morft(noutfile))
+            end if
+            
+            ierr = nf90_inq_varid(ncids(ifileScan), 'morfac', id_morfac(ifileScan))
+            ! if morfac doesn't exist -> no copy
+            ierr = nf90_def_var(ncids(noutfile), 'morfac', nf90_double, (/id_timedim(itopo, noutfile)/), id_morfac(noutfile))
+            ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
+            if (isNetCDF4) then
+               ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_morfac(ifileScan), id_morfac(noutfile))
+            end if
+            
 
             ! Only for ugrid format, because this variable will be defined in step 4 for old format
             if (jaugrid == 1) then
@@ -1703,7 +1745,7 @@ contains
                end if
 
                if (ierr == nf90_noerr) then
-                  ierr = nf90_def_dim(ncids(noutfile), trim(dimname), nlen, dimids(id, itopo, noutfile))
+                     ierr = nf90_def_dim(ncids(noutfile), trim(dimname), nlen, dimids(id, itopo, noutfile))
                end if
                if (ierr /= nf90_noerr) then
                   write (*, '(a,i0,a,i0)') 'Error: mapmerge: Could not copy dimension #', dimids(id, itopo, ifileScan), &
@@ -1711,6 +1753,10 @@ contains
                   if (.not. verbose_mode) goto 888
                else if (dimname == 'Two') then
                   id_dimTwo = dimids(id, itopo, noutfile)
+               else if (dimname == 'nSedTot') then
+                  id_sedtotdim(itopo, noutfile) = dimids(id, itopo, noutfile)
+               else if (dimname == 'nSedSus') then
+                  id_sedsusdim(itopo, noutfile) = dimids(id, itopo, noutfile)
                end if
             end if
          end do
@@ -1957,6 +2003,22 @@ contains
          continue ! non-UGRID 1D2D links not supported.
       end if
 
+      !!define sedfrac_name and sussedfrac_name variables and copy their attributes!!
+      ierr = nf90_inq_varid(ncids(ifileScan), 'sedfrac_name', id_frac_name(ifileScan))
+      ierr = nf90_def_dim(ncids(noutfile), 'nStringlen', 100, id_strlendim(1, noutfile))
+      ierr = nf90_def_var(ncids(noutfile), 'sedfrac_name', nf90_char, (/id_strlendim(1, noutfile), id_sedtotdim(1, noutfile)/), id_frac_name(noutfile)) !TODO: relocate somewhere such that itopo=1?
+      ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
+      if (isNetCDF4) then
+         ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_frac_name(ifileScan), id_frac_name(noutfile))
+      end if
+      
+      ierr = nf90_inq_varid(ncids(ifileScan), 'sussedfrac_name', id_susfrac_name(ifileScan))
+      ierr = nf90_def_var(ncids(noutfile), 'sussedfrac_name', nf90_char, (/id_strlendim(1, noutfile), id_sedsusdim(1, noutfile)/), id_susfrac_name(noutfile))
+      ierr = ncu_copy_atts(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
+      if (isNetCDF4) then
+         ierr = ncu_copy_chunking_deflate(ncids(ifileScan), ncids(noutfile), id_susfrac_name(ifileScan), id_susfrac_name(noutfile))
+      end if
+            
       ierr = nf90_enddef(ncids(noutfile))
 
    !! 6. Write new flow geom to output file
@@ -1970,16 +2032,45 @@ contains
          nt(noutfile) = ntsel
          allocate (itimsel(ntsel))
          itimsel = (/(it, it=1, ntsel)/)
-         allocate (times(ntsel), timestep(ntsel))
+         allocate (times(ntsel), timestep(ntsel), morft(ntsel), morfac(ntsel))
          do it = 1, ntsel
             ierr = nf90_get_var(ncids(ifileScan), id_time(ifileScan), times(it), start=(/itimsel(it)/)) ! count=1
             ierr = nf90_get_var(ncids(ifileScan), id_timestep(ifileScan), timestep(it), start=(/itimsel(it)/)) ! count=1
+            !make an additional condition to read morft/morfac -> copy & put it into nc
+            ierr = nf90_get_var(ncids(ifileScan), id_morft(ifileScan), morft(it), start=(/itimsel(it)/))
+            ierr = nf90_get_var(ncids(ifileScan), id_morfac(ifileScan), morfac(it), start=(/itimsel(it)/))
          end do
 
          ierr = nf90_put_var(ncids(noutfile), id_time(noutfile), times, count=(/ntsel/))
          ierr = nf90_put_var(ncids(noutfile), id_timestep(noutfile), timestep, count=(/ntsel/))
+         !make an additional condition to read morft/morfac -> copy & put it into nc
+         ierr = nf90_put_var(ncids(noutfile), id_morft(noutfile), morft, count=(/ntsel/))
+         ierr = nf90_put_var(ncids(noutfile), id_morfac(noutfile), morfac, count=(/ntsel/))
       end if
-
+      
+      !!copy the sediment fraction name to the merged file!!
+      nsedtotsel = nsedtot(ifileScan)
+      nsedtot(noutfile) = nsedtotsel
+      
+      allocate (sedfrac_name(nsedtotsel))
+      
+      do it = 1, nsedtotsel
+          ierr = nf90_get_var(ncids(ifileScan), id_frac_name(ifileScan), sedfrac_name(it))
+      end do
+      
+      ierr = nf90_put_var(ncids(noutfile), id_frac_name(noutfile), sedfrac_name)
+      
+      nsedsussel = nsedsus(ifileScan)
+      nsedsus(noutfile) = nsedsussel
+      
+      allocate (sussedfrac_name(nsedsussel))
+      
+      do it = 1, nsedsussel
+          ierr = nf90_get_var(ncids(ifileScan), id_susfrac_name(ifileScan), sussedfrac_name(it))
+      end do
+      
+      ierr = nf90_put_var(ncids(noutfile), id_susfrac_name(noutfile), sussedfrac_name)
+      
       ! 6b. A loop on meshe topology to write the merged variables to the output file.
       do itopo = minTopodim, maxTopodim
          if (verbose_mode .and. jaugrid == 1) then


### PR DESCRIPTION
# What was done 

- fixed routine in mapmerge to merge `sedfrac_name`, `sussedfrac_name`, `morft` and `morfac` in partitioned files
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [X]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [X]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [X]	Not applicable 

# Issue link
UNST-4935/UNST-10269