### PR TITLE
convert fm_parallel, swantau_to_waq, tutorial & waq_structures xmls

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_data/unstruc_model.f90
@@ -2435,6 +2435,10 @@ contains
             ti_mba = md_dt_waqbal
          end if
       end if
+      if (ti_mba > 0.0_dp .and. len_trim(md_mbafile) == 0 .and. len_trim(md_extfile) == 0) then
+         call mess(LEVEL_WARN, 'MbaInterval is positive, but no MbaFile was specified. Mass balance area output has been disabled.')
+         ti_mba = 0.0_dp
+      end if
       if (ti_mba > 0.0_dp .and. md_dt_waqproc > 0.0_dp) then
          if (ti_mba < md_dt_waqproc .or. modulo(ti_mba, md_dt_waqproc) /= 0.0_dp) then
             ti_mba = max(1, floor(ti_mba / md_dt_waqproc)) * dt_user

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute_waq/fm_wq_processes.f90
@@ -1487,6 +1487,10 @@ contains
 
       process_space_real(ipoidefa + 1) = time
 
+      if (.not. allocated(mbadefdomain)) then ! todo make wq_proceesses_proces callable without mdadefdomain
+         allocate (mbadefdomain(ktx), source=-999)
+      end if
+
       call wq_processes_proces(num_substances_total, num_cells, process_space_real(ipoiconc), vol1(kbx:ktx - kbx), time, dt, deriv, ndmpar, &
                                num_processes_activated, num_fluxes, process_space_int, prvnio, promnr, iflux, increm, process_space_real(ipoiflux), flxdmp, stochi, &
                                ibflag, bloom_status_ind, bloom_ind, amass, num_substances_transported, isfact, itfact, iexpnt, iknmrk, num_exchanges_u_dir, &

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c001_trench_EH_par_crs/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c001_trench_EH_par_crs/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 1db6c294069e5ce10b6a107c77469376.dir
-  size: 192463
+- md5: 33d1df157100d169fa39fcc35c8b8326.dir
+  size: 192101
   nfiles: 18
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c102_baltic_bedlevtype1_on_netfile/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c102_baltic_bedlevtype1_on_netfile/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 2bc3ef3900c1449139be7b43a76ce36b.dir
-  size: 4583994
+- md5: d65958f84483f8eeeef5ce3577b8f3e4.dir
+  size: 4589723
   nfiles: 43
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c103_baltic_bedlevtype1_on_netfile_partpoly/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f014_parallel/c103_baltic_bedlevtype1_on_netfile_partpoly/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 2bc3ef3900c1449139be7b43a76ce36b.dir
-  size: 4583994
+- md5: d65958f84483f8eeeef5ce3577b8f3e4.dir
+  size: 4589723
   nfiles: 43
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f029_hyd_file/c205_westerschelde_3d_z_hag_structures/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f029_hyd_file/c205_westerschelde_3d_z_hag_structures/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 26b88785ba6af802e7815cc7b5b89fbd.dir
-  size: 2681374
-  nfiles: 60
+- md5: 28d9d8a4bd0af9a3c1605d289ef855a2.dir
+  size: 2683817
+  nfiles: 64
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f041_SWAN-tau_to_WAQ/c01_FriesianInlet_schematic/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f041_SWAN-tau_to_WAQ/c01_FriesianInlet_schematic/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: bfd98bbeb1356a593bf81a343ae9212b.dir
-  size: 125383
-  nfiles: 21
+- md5: 31f1c02c771abb0e820f6e4a37feae01.dir
+  size: 128340
+  nfiles: 23
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f041_SWAN-tau_to_WAQ/c02_California/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f041_SWAN-tau_to_WAQ/c02_California/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 0a03eee14a6dba69a83824eb1226c878.dir
-  size: 7330924
-  nfiles: 29
+- md5: ac2e1a26973172c8cdd1853fa9aeb52d.dir
+  size: 7339781
+  nfiles: 33
   hash: md5
   path: input

--- a/test/deltares_testbench/data/cases/e02_dflowfm/f092_tutorial_course_models/c01_harlingen/input.dvc
+++ b/test/deltares_testbench/data/cases/e02_dflowfm/f092_tutorial_course_models/c01_harlingen/input.dvc
@@ -1,6 +1,6 @@
 outs:
-- md5: 7f05f604153517cc8a2bbaa50dd26cb7.dir
-  size: 13944712
-  nfiles: 184
+- md5: 3c2c172e76fb8845f1347f55c347ab15.dir
+  size: 20572326
+  nfiles: 193
   hash: md5
   path: input


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- converted cases in fm_parallel, swantau_to_waq, tutorial and waq_structures xmls.
- swantau to waq exposed a bug: waq code expects MBA arrays to always be initialized. Fixed this, and no longer allow an mbainterval > 0 without an old ext file or an mbafile specified.
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
