### PR TITLE
All/release/2027.01 cherry picking

### DIFF
--- a/.github/instructions/fortran.instructions.md
+++ b/.github/instructions/fortran.instructions.md
@@ -41,6 +41,8 @@ pain.
   local variables, derived-type components, allocatables, pointers, and fixed-size arrays.
   For example, use `real(kind=dp), dimension(:), intent(in) :: values` instead of
   `real(kind=dp), intent(in) :: values(:)`.
+- Do not use single-line `if` statements. Use a block `if ... then` construct terminated
+  by `end if`, even when the body contains only one statement.
 
 ## Documentation
 

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/unstruc_netcdf.f90
@@ -913,15 +913,23 @@ contains
 
 !> Creates or opens a NetCDF file for writing.
 !! The file is maintained in the open-file-list.
-   function unc_create(filename, cmode, ncid)
+   function unc_create(filename, cmode, ncid, overwrite_cmode)
       character(len=*), intent(in) :: filename !< Filename to be created
       integer, intent(in) :: cmode !< Creation mode, must be a valid NetCDF flags integer.
       integer, intent(out) :: ncid !< Resulting NetCDF data set id, undefined in case an error occurred.
+      logical, optional, intent(in) :: overwrite_cmode !< Flag indicating whether to overwrite existing cmode (or perform ior).
       integer :: unc_create !< Integer result status (nf90_noerr if successful).
 
       integer :: cmode_
-
-      cmode_ = ior(cmode, unc_cmode)
+      if (present(overwrite_cmode)) then
+         if (overwrite_cmode) then
+            cmode_ = cmode
+         else
+            cmode_ = ior(cmode, unc_cmode)
+         end if
+      else
+         cmode_ = ior(cmode, unc_cmode)
+      end if
 
       unc_create = nf90_create(filename, cmode_, ncid)
       if (unc_create == nf90_noerr) then

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wricom.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_io/wricom.f90
@@ -70,6 +70,7 @@ contains
          ! com file already exists
          !
          ierr = nf90_open(filnam, NF90_WRITE, comids%ncid)
+         call check_error(ierr, "Error opening existing com file: " // trim(filnam), LEVEL_ERROR)
       elseif (comids%ncid == 0 .and. jawave == WAVE_SWAN_ONLINE) then
          !
          ! No communication yet via com file:
@@ -84,8 +85,12 @@ contains
             ierr = nf90_open(filnam, NF90_WRITE, comids%ncid)
          else
             ! No com file yet. Create a new one and write FLOW parameters
-            !
-            ierr = unc_create(filnam, 0, comids%ncid)
+            ! keep netcdf on classic (3). HDF5 (mode 4) will cause a lot of problems
+            ! due to the fact that you can't have the same file open in WRITE and READ mode
+            ! in the same time (due to some HDF5/NetCDF library cache stuff).
+            ! We need to keep this file open in EC Module and we 
+            ! don't have a practical mode to open and close it as needed without performance impact
+            ierr = unc_create(filnam, NF90_CLASSIC_MODEL, comids%ncid, .true.)
             if (ierr /= nf90_noerr) then
                call mess(LEVEL_WARN, 'Could not create com file.')
                comids%ncid = 0

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_longculverts.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/compute/m_longculverts.f90
@@ -54,6 +54,7 @@ module m_longculverts
    public LongCulvertsToProfs
    public setFrictionForLongculverts
    public reduceFlowAreaAtLongculverts
+   public remove_longculvert_flowlinks
    public get_valve_relative_opening_c_loc
    public find1d2dculvertlinks
    public initialize_Long_Culverts
@@ -65,6 +66,50 @@ module m_longculverts
    end interface
    
 contains
+
+   !> Removes flow links administered by long culverts from a link list.
+   !! The list is compacted in place, preserving the orientation of retained links.
+   pure subroutine remove_longculvert_flowlinks(numlinks, links)
+      integer, intent(inout) :: numlinks !< Number of flow links in links.
+      integer, dimension(:), intent(inout) :: links !< Flow links to be filtered.
+
+      integer, allocatable :: longculvert_links(:)
+      integer, dimension(size(links)) :: filtered_links
+      integer :: i, j, k, num_longculvert_links
+
+      num_longculvert_links = 0
+      do i = 1, nlongculverts
+         if (allocated(longculverts(i)%flowlinks)) then
+            num_longculvert_links = num_longculvert_links + count(longculverts(i)%flowlinks /= 0)
+         end if
+      end do
+
+      allocate (longculvert_links(num_longculvert_links))
+      k = 0
+      do i = 1, nlongculverts
+         if (allocated(longculverts(i)%flowlinks)) then
+            do j = 1, size(longculverts(i)%flowlinks)
+               if (longculverts(i)%flowlinks(j) /= 0) then
+                  k = k + 1
+                  longculvert_links(k) = abs(longculverts(i)%flowlinks(j))
+               end if
+            end do
+         end if
+      end do
+
+      k = 0
+      do i = 1, numlinks
+         if (links(i) == 0 .or. .not. any(longculvert_links == abs(links(i)))) then
+            k = k + 1
+            filtered_links(k) = links(i)
+         end if
+      end do
+
+      if (k > 0) then
+         links(1:k) = filtered_links(1:k)
+      end if
+      numlinks = k
+   end subroutine remove_longculvert_flowlinks
 
    !> Sets ALL (scalar) variables in this module to their default values.
    !! For a reinit prior to flow computation, call reset_longculverts() instead.
@@ -865,47 +910,65 @@ contains
 
    !> Reconstruct the flow link orientation based on input polyline
    subroutine set_longculvert_flow_direction(ilongc)
-      use network_data, only: kn, xk, yk
+      use m_flowparameters, only: EPS10
+      use m_flowgeom, only: ln
+      use network_data, only: xzw, yzw
       use precision_basics, only: equal
 
       integer, intent(in) :: ilongc
-      integer :: L_net, netnode_1, netnode_2
-      logical :: netnode_1_is_LC_node_2, netnode_2_is_LC_node_2
+      integer :: L_flow, flownode_1, flownode_2, coordinate_index
+      logical :: flownode_1_is_coordinate_1, flownode_1_is_coordinate_2
+      logical :: flownode_2_is_coordinate_1, flownode_2_is_coordinate_2
 
+      if (.not. newculverts) then ! old long culverts cannot use coordinate matching, but also don't need direction detection
+         return
+      end if
+
+      ! todo: remove defensive guards and make sure our long culvert objcect is always in a valid state
       if (longculverts(ilongc)%numlinks <= 0) then
          return
       end if
-      if (.not. allocated(longculverts(ilongc)%flowlinks) .or. .not. allocated(longculverts(ilongc)%netlinks) .or. &
+      if (.not. allocated(longculverts(ilongc)%flowlinks) .or. &
           .not. allocated(longculverts(ilongc)%xcoords) .or. .not. allocated(longculverts(ilongc)%ycoords)) then
          return
       end if
-      if (size(longculverts(ilongc)%flowlinks) < 1 .or. size(longculverts(ilongc)%netlinks) < 1 .or. &
+      if (size(longculverts(ilongc)%flowlinks) < 1 .or. &
           size(longculverts(ilongc)%xcoords) < 2 .or. size(longculverts(ilongc)%ycoords) < 2) then
          return
       end if
 
-      L_net = longculverts(ilongc)%netlinks(1)
-      if (L_net <= 0 .or. L_net > size(kn, dim=2)) then
+      L_flow = abs(longculverts(ilongc)%flowlinks(1))
+      if (L_flow <= 0 .or. L_flow > size(ln, dim=2)) then
          return
       end if
 
-      netnode_1 = kn(1, L_net)
-      netnode_2 = kn(2, L_net)
-      if (netnode_1 <= 0 .or. netnode_2 <= 0) then
+      flownode_1 = ln(1, L_flow)
+      flownode_2 = ln(2, L_flow)
+      if (flownode_1 <= 0 .or. flownode_2 <= 0) then
          return
       end if
 
-      netnode_1_is_LC_node_2 = equal(xk(netnode_1), longculverts(ilongc)%xcoords(2)) .and. equal(yk(netnode_1), longculverts(ilongc)%ycoords(2))
-      netnode_2_is_LC_node_2 = equal(xk(netnode_2), longculverts(ilongc)%xcoords(2)) .and. equal(yk(netnode_2), longculverts(ilongc)%ycoords(2))
+      do coordinate_index = 1, size(longculverts(ilongc)%xcoords) - 1
+         flownode_1_is_coordinate_1 = equal(xzw(flownode_1), longculverts(ilongc)%xcoords(coordinate_index), EPS10) .and. &
+                                      equal(yzw(flownode_1), longculverts(ilongc)%ycoords(coordinate_index), EPS10)
+         flownode_1_is_coordinate_2 = equal(xzw(flownode_1), longculverts(ilongc)%xcoords(coordinate_index + 1), EPS10) .and. &
+                                      equal(yzw(flownode_1), longculverts(ilongc)%ycoords(coordinate_index + 1), EPS10)
+         flownode_2_is_coordinate_1 = equal(xzw(flownode_2), longculverts(ilongc)%xcoords(coordinate_index), EPS10) .and. &
+                                      equal(yzw(flownode_2), longculverts(ilongc)%ycoords(coordinate_index), EPS10)
+         flownode_2_is_coordinate_2 = equal(xzw(flownode_2), longculverts(ilongc)%xcoords(coordinate_index + 1), EPS10) .and. &
+                                      equal(yzw(flownode_2), longculverts(ilongc)%ycoords(coordinate_index + 1), EPS10)
 
-      if (netnode_1_is_LC_node_2 .and. .not. netnode_2_is_LC_node_2) then
-         longculverts(ilongc)%orientation = -1
-      else if (.not. netnode_1_is_LC_node_2 .and. netnode_2_is_LC_node_2) then
-         longculverts(ilongc)%orientation = 1
-      else ! neither or both match, which is an error
-         call mess(LEVEL_ERROR, 'Cannot match the second coordinate of long culvert '//trim(longculverts(ilongc)%id)// &
-                   ' to either endpoint of its first flow link;')
-      end if
+         if (flownode_1_is_coordinate_1 .and. flownode_2_is_coordinate_2) then
+            longculverts(ilongc)%orientation = 1
+            return
+         else if (flownode_2_is_coordinate_1 .and. flownode_1_is_coordinate_2) then
+            longculverts(ilongc)%orientation = -1
+            return
+         end if
+      end do
+
+      call mess(LEVEL_ERROR, 'Cannot match any coordinate pair of long culvert '//trim(longculverts(ilongc)%id)// &
+                ' to the endpoints of its first local flow link;')
    end subroutine set_longculvert_flow_direction
 
    !> Fill frcu and icrctyp for the corresponding flow link numbers of the long culverts

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/prepost/flow_init_structurecontrol_implementation.f90
@@ -52,6 +52,7 @@ contains
       use unstruc_files, only: resolvePath
       use string_module, only: strcmpi
       use m_longculverts_data, only: nlongculverts
+      use m_longculverts, only: remove_longculvert_flowlinks
       use m_partitioninfo, only: jampi
       use messagehandling, only: IDLEN
       use m_dambreak_breach, only: update_counters_for_dambreaks, update_dambreak_administration, remove_1d_links_from_dambreak_polygon_list
@@ -116,6 +117,10 @@ contains
             call selectelset_internal_links(lnx, kegen(1:numl), numgen, loc_spec_type, nump=pstru%numCoordinates, &
                                             xpin=pstru%xCoordinates, ypin=pstru%yCoordinates, &
                                             branchindex=pstru%ibran, chainage=pstru%chainage, sortLinks=1, lftopol=lftopol(num_dambreak_links + 1:numl))
+            select case (pstru%type)
+            case (ST_GENERAL_ST, ST_WEIR, ST_ORIFICE, ST_GATE)
+               call remove_longculvert_flowlinks(numgen, kegen)
+            end select
             call reallocp(pstru%linknumbers, numgen)
             pstru%linknumbers = kegen(1:numgen)
 
@@ -252,6 +257,7 @@ contains
       use unstruc_files, only: resolvePath
       use string_module, only: str_tolower, strcmpi
       use m_longculverts_data, only: nlongculverts
+      use m_longculverts, only: remove_longculvert_flowlinks
       use m_partitioninfo, only: jampi
       use m_qnerror, only: qnerror
       use m_read_property, only: read_property
@@ -552,6 +558,7 @@ contains
             else
                call selectelset_internal_links(lnx, kegen(ncgen + 1:numl), numgen, LOCTP_POLYLINE_FILE, plifile, sortLinks=1)
             end if
+            call remove_longculvert_flowlinks(numgen, kegen(ncgen + 1:numl))
 
             success = .true.
             write (msgbuf, '(a,1x,a,i8,a)') trim(qid), trim(plifile), numgen, ' nr of '//trim(strtype)//' cells'

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/ec_addtimespacerelation.f90
@@ -578,7 +578,7 @@ contains
          end if
          ! Each qhbnd polytim file replaces exactly one element in the target data array.
          ! Converter will put qh value in target_array(n_qhbnd)
-      case ('windx', 'windy', 'windxy', 'stressxy', 'airpressure', 'atmosphericpressure', 'airpressure_windx_windy', 'airdensity', &
+      case ('windx', 'windy', 'windxy', 'stressxy', 'airpressure', 'airpressure_windx_windy', 'airdensity', &
             'airpressure_windx_windy_charnock', 'charnock', 'airpressure_stressx_stressy', 'humidity', 'dewpoint', 'airtemperature', &
             'cloudiness', 'solarradiation', 'longwaveradiation', 'sensibleheatflux', 'latentheatflux')
          if (present(srcmaskfile)) then
@@ -893,7 +893,7 @@ contains
             goto 1234
          end if
          source_connection_created = .true.
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          if (ec_filetype == provFile_spiderweb) then ! other filetypes are handled generically
             sourceItemName = 'p_drop'
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings.f90
@@ -223,9 +223,9 @@ contains
             ! Retrieve stress's y-component for ext-file quantity 'stressy'.
          else if (ec_item_id == item_stressy) then
             call get_timespace_value_by_item(item_stressy)
-            ! Retrieve wind's p-component for ext-file quantity 'atmosphericpressure'.
-         else if (ec_item_id == item_atmosphericpressure) then
-            call get_timespace_value_by_item(item_atmosphericpressure)
+            ! Retrieve wind's p-component for ext-file quantity 'airpressure'.
+         else if (ec_item_id == item_airpressure) then
+            call get_timespace_value_by_item(item_airpressure)
             ! Retrieve value for ext-file quantity 'pseudo_air_pressure'.
          else if (ec_item_id == item_pseudo_air_pressure) then
             call get_timespace_value_by_item(item_pseudo_air_pressure)
@@ -283,7 +283,7 @@ contains
          end do
       end if
 
-      if (item_atmosphericpressure /= ec_undef_int) then
+      if (item_airpressure /= ec_undef_int) then
          do k = 1, ndx
             if (comparereal(air_pressure(k), dmiss, EPS10) == 0) then
                air_pressure(k) = BACKGROUND_AIR_PRESSURE
@@ -2868,7 +2868,7 @@ contains
       end if
 
       if (ja_computed_airdensity == 1) then
-         if ((item_apwxwy_p == ec_undef_int) .and. (item_atmosphericpressure == ec_undef_int)) then
+         if ((item_apwxwy_p == ec_undef_int) .and. (item_airpressure == ec_undef_int)) then
             call mess(LEVEL_ERROR, 'When "computedAirdensity = 1", quantity airpressure must be provided in the .ext file.')
          end if
          if ((item_hac_air_temperature == ec_undef_int) .and. (item_hacs_air_temperature == ec_undef_int) .and. &

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -822,7 +822,7 @@ contains
       case ('airdensity')
          call realloc(air_density, ndx, fill=0.0_dp, keepexisting=.true.)
 
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          call realloc(air_pressure, ndx, keepExisting=.true., fill=0.0_dp)
 
       case ('pseudoairpressure')
@@ -1250,7 +1250,7 @@ contains
       case ('airdensity')
          ja_airdensity = 1
 
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          air_pressure_available = .true.
 
       case ('pseudoAirPressure')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -68,6 +68,7 @@ contains
       use m_flowgeom_mask, only: construct_mask
       use fm_external_forcings_utils, only: get_tracername, get_sedfracname
       use fm_location_types, only: parse_spatial_location_type, UNC_LOC_S, UNC_LOC_U, UNC_LOC_CN, SPATIAL_LOCATION_1D, SPATIAL_LOCATION_2D, SPATIAL_LOCATION_ALL
+      use m_longculverts, only: remove_longculvert_flowlinks
       use m_qnerror
       use m_delpol
       use m_get_kbot_ktop
@@ -1156,6 +1157,7 @@ contains
             else if (jaoldstr > 0 .and. qid == 'generalstructure') then
 
                call selectelset_internal_links(lnx, kegen(ncgen + 1:numl), numgen, LOCTP_POLYLINE_FILE, filename, sortLinks=1)
+               call remove_longculvert_flowlinks(numgen, kegen(ncgen + 1:numl))
                success = .true.
                write (msgbuf, '(a,1x,a,i8,a)') trim(qid), trim(filename), numgen, ' nr of general structure cells'
                call msg_flush()

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init_old.f90
@@ -124,6 +124,7 @@ contains
          maxSearchRadius = -1
          call readprovider(mext, qid, filename, filetype, method, operand, transformcoef, ja, varname, sourcemask, maxSearchRadius)
          if (ja == 1) then
+            qid = quantity_name_config_file_to_internal_name(qid)
             call resolvePath(filename, md_extfile_dir)
 
             call mess(LEVEL_INFO, 'External Forcing or Initialising '''//trim(qid)//''' from file '''//trim(filename)//'''.')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_update.f90
@@ -32,7 +32,7 @@ submodule(fm_external_forcings) fm_external_forcings_update
    use m_flowtimes, only: handle_ext, irefdate, tunit, time1
    use m_flowgeom, only: ndx, lnx
    use m_meteo, only: ec_gettimespacevalue, ecgetvalues, twav, success, air_pressure, pavbnd, ja_airdensity, item_air_density, &
-                      air_density, ja_computed_airdensity, item_atmosphericpressure, item_air_temperature, air_temperature, &
+                      air_density, ja_computed_airdensity, item_airpressure, item_air_temperature, air_temperature, &
                       item_dew_point_temperature, dew_point_temperature, update_wind_stress_each_time_step, temperature_model, &
                       TEMPERATURE_MODEL_EXCESS, TEMPERATURE_MODEL_COMPOSITE, ja_friction_coefficient_time_dependent, item_frcu, frcu, tzone, &
                       ecsupporttimeunitconversionfactor, ncdamsg, item_damlevel, zcdam, ncgensg, item_generalstructure, zcgen, npumpsg, &
@@ -945,14 +945,14 @@ contains
 
 !> prepare_air_pressure_temperature_dew_point_temperature
    module subroutine prepare_air_pressure_temperature_dew_point_temperature(time_in_seconds)
-      use m_meteo, only: item_apwxwy_p, item_atmosphericpressure, item_hac_air_temperature, item_hacs_air_temperature, item_dac_air_temperature, &
+      use m_meteo, only: item_apwxwy_p, item_airpressure, item_hac_air_temperature, item_hacs_air_temperature, item_dac_air_temperature, &
                          item_dacs_air_temperature, item_air_temperature, item_dac_dew_point_temperature, item_dacs_dew_point_temperature, item_dew_point_temperature
 
       real(kind=dp), intent(in) :: time_in_seconds !< Time in seconds
 
       ! air pressure items
       call get_timespace_value_by_item_and_consider_success_value(item_apwxwy_p, time_in_seconds)
-      call get_timespace_value_by_item_and_consider_success_value(item_atmosphericpressure, time_in_seconds)
+      call get_timespace_value_by_item_and_consider_success_value(item_airpressure, time_in_seconds)
 
       ! air temperature items
       call get_timespace_value_by_item_and_consider_success_value(item_hac_air_temperature, time_in_seconds)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/meteo1.f90
@@ -3749,7 +3749,7 @@ module m_meteo
    integer, target :: item_apwxwy_c !< Unique Item id of the ext-file's 'airpressure_windx_windy_charnock' quantity 'c' (space var Charnock).
    integer, target :: item_charnock !< Unique Item id of the ext-file's 'space var Charnock' quantity 'C'.
    integer, target :: item_waterlevelbnd !< Unique Item id of the ext-file's 'waterlevelbnd' quantity's ...-component.
-   integer, target :: item_atmosphericpressure !< Unique Item id of the ext-file's 'atmosphericpressure' quantity
+   integer, target :: item_airpressure !< Unique Item id of the ext-file's 'atmosphericpressure' quantity
    integer, target :: item_pseudo_air_pressure !< Unique Item id of the ext-file's 'pseudo_air_pressure' quantity
    integer, target :: item_water_level_correction !< Unique Item id of the ext-file's 'water_level_correction' quantity
    integer, target :: item_sea_ice_area_fraction !< Unique Item id of the ext-file's 'sea_ice_area_fraction' quantity
@@ -3933,7 +3933,7 @@ contains
       item_apwxwy_c = ec_undef_int
       item_charnock = ec_undef_int
       item_waterlevelbnd = ec_undef_int
-      item_atmosphericpressure = ec_undef_int
+      item_airpressure = ec_undef_int
       item_pseudo_air_pressure = ec_undef_int
       item_water_level_correction = ec_undef_int
       item_sea_ice_area_fraction = ec_undef_int
@@ -4194,6 +4194,8 @@ contains
          quantity_internal_name = 'sea_ice_thickness'
       case ('bedrocksurfaceelevation')
          quantity_internal_name = 'bedrock_surface_elevation'
+      case ('atmosphericpressure')
+         quantity_internal_name = 'airpressure'
       case default
          ! keep other names unchanged
       end select
@@ -4339,8 +4341,8 @@ contains
       case ('normalvelocitybnd')
          itemPtr1 => item_normalvelocitybnd
          dataPtr1 => zbndn
-      case ('airpressure', 'atmosphericpressure')
-         itemPtr1 => item_atmosphericpressure
+      case ('airpressure')
+         itemPtr1 => item_airpressure
          dataPtr1 => air_pressure
       case ('pseudoairpressure')
          itemPtr1 => item_pseudo_air_pressure

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field_integration.f90
@@ -522,7 +522,7 @@ contains
    !! connection when its provider-specific source mapping does not support BC.
    subroutine test_airpressure_bcascii_uses_generic_source_fallback() bind(C)
       use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
-      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_atmosphericpressure
+      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_airpressure
 
       type(tree_data), pointer :: bnd_ptr, block_ptr
       logical :: success
@@ -564,11 +564,11 @@ contains
       call tree_destroy(bnd_ptr)
 
       call f90_expect_true(success, "init_spatial_fields should use the generic fallback for bcascii airpressure")
-      call f90_expect_true(item_atmosphericpressure /= -999, "airpressure should have an EC target item")
+      call f90_expect_true(item_airpressure /= -999, "airpressure should have an EC target item")
 
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 0.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 0.0_dp)
       value_at_t0 = air_pressure(1)
-      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_atmosphericpressure, irefdate, tzone, tunit, 50.0_dp)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 50.0_dp)
       value_at_t50 = air_pressure(1)
 
       call f90_expect_near(value_at_t0, 101325.0_dp, 1.0e-6_dp, "airpressure at t=0 should be read from the BC file")
@@ -576,6 +576,66 @@ contains
 
       call teardown_minimal_grid()
    end subroutine test_airpressure_bcascii_uses_generic_source_fallback
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_atmosphericpressure_alias_works_as_airpressure, test_atmosphericpressure_alias_works_as_airpressure,
+   !> Verifies that the 'atmosphericpressure' ext alias correctly works with 'airpressure' .bc data.
+   subroutine test_atmosphericpressure_alias_works_as_airpressure() bind(C)
+      use m_flowtimes, only: irefdate, tzone, tunit, tstart_user
+      use m_meteo, only: ec_gettimespacevalue_by_itemID, ecInstancePtr, item_airpressure
+
+      type(tree_data), pointer :: bnd_ptr, block_ptr
+      logical :: success
+      real(dp) :: value_at_t0, value_at_t50
+      character(len=*), parameter :: AIRPRESSURE_BC = "test_airpressure.bc"
+      character(len=*), parameter :: AIRPRESSURE_EXT = "test_atmosphericpressure.ext"
+
+      call create_file(AIRPRESSURE_BC, [ &
+                       "[General]", &
+                       "    fileVersion           = 1.01", &
+                       "    fileType              = boundConds", &
+                       "", &
+                       "[forcing]", &
+                       "    name                  = global", &
+                       "    function              = timeseries", &
+                       "    timeInterpolation     = linear", &
+                       "    quantity              = time", &
+                       "    unit                  = seconds since 2000-01-01 00:00:00", &
+                       "    quantity              = airpressure", &
+                       "    unit                  = Pa", &
+                       "    0    101325.0", &
+                       "    100  101300.0"])
+
+      call create_file(AIRPRESSURE_EXT, [ &
+                       "[Spatial]", &
+                       "    quantity        = atmosphericpressure", &
+                       "    dataFile     = "//AIRPRESSURE_BC, &
+                       "    dataFileType = bcascii"])
+
+      irefdate = 20000101
+      tzone = 0.0_dp
+      tstart_user = 0.0_dp
+      threshold_abort = LEVEL_FATAL
+      call setup_minimal_grid()
+      call initialize_ec_module()
+
+      call parse_spatial_block(AIRPRESSURE_EXT, bnd_ptr, block_ptr)
+      success = init_spatial_fields(block_ptr, BASE_DIR, AIRPRESSURE_EXT, 'Spatial')
+      call tree_destroy(bnd_ptr)
+
+      call f90_expect_true(success, "init_spatial_fields should map atmosphericpressure alias to airpressure")
+      call f90_expect_true(item_airpressure /= -999, "atmosphericpressure should have an EC target item")
+
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 0.0_dp)
+      value_at_t0 = air_pressure(1)
+      success = ec_gettimespacevalue_by_itemID(ecInstancePtr, item_airpressure, irefdate, tzone, tunit, 50.0_dp)
+      value_at_t50 = air_pressure(1)
+
+      call f90_expect_near(value_at_t0, 101325.0_dp, 1.0e-6_dp, "atmosphericpressure at t=0 should be read from the BC file")
+      call f90_expect_near(value_at_t50, 101312.5_dp, 1.0e-6_dp, "atmosphericpressure at t=50 should be linearly interpolated")
+
+      call teardown_minimal_grid()
+   end subroutine test_atmosphericpressure_alias_works_as_airpressure
    !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_fields_integration, test_unknown_quantity_returns_error, test_unknown_quantity_returns_error,
@@ -1997,7 +2057,7 @@ contains
    end subroutine run_scalar_meteo_case
 
    subroutine scalar_meteo_target(quantity, item_id, target_data)
-      use m_meteo, only: item_air_density, item_atmosphericpressure, item_air_temperature, item_cloudiness, &
+      use m_meteo, only: item_air_density, item_airpressure, item_air_temperature, item_cloudiness, &
                          item_dew_point_temperature, item_relative_humidity, item_latent_heat_flux, item_long_wave_radiation, &
                          item_solar_radiation, item_sensible_heat_flux, item_stressx, item_stressy, item_windx, item_windy
       use m_wind, only: air_density, air_pressure, air_temperature, cloudiness, dew_point_temperature, relative_humidity, &
@@ -2016,7 +2076,7 @@ contains
          item_id = item_air_density
          target_data => air_density
       case ('airpressure')
-         item_id = item_atmosphericpressure
+         item_id = item_airpressure
          target_data => air_pressure
       case ('airtemperature')
          item_id = item_air_temperature

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_longculverts.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_longculverts.f90
@@ -1,191 +1,271 @@
 module test_longculverts
-    use assertions_gtest
-    use m_longculverts, only: convert1D2DLongCulverts, default_longculverts
-    use m_network_helpers, only: t_grid_helper
-    use iso_c_utils, only: cstr
-    use m_file_helpers, only: create_file
+   use assertions_gtest
+   use m_longculverts, only: convert1D2DLongCulverts, default_longculverts
+   use m_network_helpers, only: t_grid_helper
+   use iso_c_utils, only: cstr
+   use m_file_helpers, only: create_file
+   use precision, only: dp
 
-    implicit none(type, external)
-   
+   implicit none(type, external)
+
+   real(kind=dp), dimension(2, 2), parameter :: LC2_X = reshape([50.0_dp, 350.0_dp, 50.0_dp, 350.0_dp], [2, 2])
+   real(kind=dp), dimension(2, 2), parameter :: LC2_Y = reshape([50.0_dp, 50.0_dp, 150.0_dp, 150.0_dp], [2, 2])
+   real(kind=dp), dimension(2, 2), parameter :: LC2_Z = -5.0_dp
+   real(kind=dp), dimension(3, 2), parameter :: LC3_X = reshape([50.0_dp, 200.0_dp, 350.0_dp, 50.0_dp, 200.0_dp, 350.0_dp], [3, 2])
+   real(kind=dp), dimension(3, 2), parameter :: LC3_Y = reshape([50.0_dp, 50.0_dp, 50.0_dp, 150.0_dp, 150.0_dp, 150.0_dp], [3, 2])
+   real(kind=dp), dimension(3, 2), parameter :: LC3_Z = -5.0_dp
+   real(kind=dp), dimension(4, 2), parameter :: LC4_X = reshape([50.0_dp, 150.0_dp, 250.0_dp, 350.0_dp, 50.0_dp, 150.0_dp, 250.0_dp, 350.0_dp], [4, 2])
+   real(kind=dp), dimension(4, 2), parameter :: LC4_Y = reshape([50.0_dp, 50.0_dp, 50.0_dp, 50.0_dp, 150.0_dp, 150.0_dp, 150.0_dp, 150.0_dp], [4, 2])
+   real(kind=dp), dimension(4, 2), parameter :: LC4_Z = -5.0_dp
+
 contains
-    !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__single_four_point, test_convert1d2dlongculverts__single_four_point,
-    subroutine test_convert1d2dlongculverts__single_four_point() bind(C)
-        use precision, only: dp
-        use network_data, only: numk, numl, kn
-        use m_missing, only: dmiss
-        use m_polygon, only: xpl, ypl, zpl, npl
-        use m_longculverts, only: convert1D2DLongCulverts
-        use m_longculverts_data, only: longculverts
+   !> Create a structures.ini file from long-culvert coordinates and properties.
+   subroutine create_longculvert_structure_file(filename, x_coordinates, y_coordinates, z_coordinates, ids, &
+                                                allowed_flowdirs, widths, heights, friction_types, friction_values, &
+                                                valve_openings)
+      use precision, only: dp
 
-        integer, parameter :: COORD_COUNT = 4
-        type(t_grid_helper) :: grid_helper
-        real(kind=dp) :: x_coords(COORD_COUNT)
-        real(kind=dp) :: y_coords(COORD_COUNT)
-        real(kind=dp) :: z_coords(COORD_COUNT)
-        integer :: i
+      character(len=*), intent(in) :: filename
+      real(kind=dp), dimension(:, :), intent(in) :: x_coordinates, y_coordinates, z_coordinates
+      character(len=*), dimension(:), optional, intent(in) :: ids, allowed_flowdirs, friction_types
+      real(kind=dp), dimension(:), optional, intent(in) :: widths, heights, friction_values, valve_openings
 
-        ! Arrange
-        grid_helper = t_grid_helper()
-        call grid_helper%make_square_grid( &
-            bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, &
-            rows=1, columns=2, side_length=10.0_dp, array_size_margin=16 &
-        )
+      character(len=256), allocatable :: lines(:)
+      character(len=64) :: id, allowed_flowdir, friction_type
+      integer :: i, num_culverts, num_coordinates, structure_start
+      real(kind=dp) :: width, height, friction_value, valve_opening
 
-        x_coords = [5._dp, 9._dp, 11._dp, 15._dp]
-        y_coords = [6._dp, 6._dp, 4._dp, 4._dp]
-        z_coords = -1.0_dp
+      num_coordinates = size(x_coordinates, 1)
+      num_culverts = size(x_coordinates, 2)
+      if (any(shape(y_coordinates) /= shape(x_coordinates)) .or. any(shape(z_coordinates) /= shape(x_coordinates))) then
+         error stop "Long-culvert coordinate arrays must have equal shapes"
+      end if
 
-        ! Subroutine `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
-        xpl = x_coords
-        ypl = y_coords
-        zpl = z_coords
-        npl = COORD_COUNT
+      allocate (lines(3 + 14 * num_culverts))
+      lines(1:4) = [character(len=256) :: "[General]", "    fileVersion     = 3.00", "    fileType        = structures", ""]
 
-        allocate(longculverts(1))
-        allocate(longculverts(1)%netlinks(3))
-        ! Act
-        call convert1D2DLongCulverts(x_coords, y_coords, z_coords, COORD_COUNT)
+      do i = 1, num_culverts
+         write (id, '("lc",i2.2)') i
+         allowed_flowdir = "both"
+         width = 2.0_dp
+         height = 2.0_dp
+         friction_type = "Manning"
+         friction_value = 0.02_dp
+         valve_opening = 1.0_dp
 
-        ! Assert
-        call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
-        call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
-        call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT), 15._dp)
-        call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT), 5._dp)
-        
-        call F90_ASSERT_EQ(numk, 10) ! 6 Netnodes for the grid, 4 For the long culvert.
-        call F90_ASSERT_EQ(numl, 10) ! 7 Netlinks for the grid, 3 For the long culvert.
+         if (present(ids)) then
+            id = ids(i)
+         end if
+         if (present(allowed_flowdirs)) then
+            allowed_flowdir = allowed_flowdirs(i)
+         end if
+         if (present(widths)) then
+            width = widths(i)
+         end if
+         if (present(heights)) then
+            height = heights(i)
+         end if
+         if (present(friction_types)) then
+            friction_type = friction_types(i)
+         end if
+         if (present(friction_values)) then
+            friction_value = friction_values(i)
+         end if
+         if (present(valve_openings)) then
+            valve_opening = valve_openings(i)
+         end if
 
-        call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(1)), 5, cstr("Expected first new link to be a 1D2D link."))
-        call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(2)), 1, cstr("Expected middle link to be a 1D link."))
-        call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(3)), 5, cstr("Expected last new link to be a 1D2D link."))
-    end subroutine test_convert1d2dlongculverts__single_four_point
-    !$f90tw )
+         structure_start = 4 + (i - 1) * 14
+         if (i > 1) then
+            lines(structure_start) = ""
+         end if
+         lines(structure_start + 1) = "[Structure]"
+         lines(structure_start + 2) = "    id              = "//trim(id)
+         lines(structure_start + 3) = "    type            = longCulvert"
+         write (lines(structure_start + 4), '(a,i0)') "    numCoordinates  = ", num_coordinates
+         write (lines(structure_start + 5), '(a,*(g0,1x))') "    xCoordinates    = ", x_coordinates(:, i)
+         write (lines(structure_start + 6), '(a,*(g0,1x))') "    yCoordinates    = ", y_coordinates(:, i)
+         write (lines(structure_start + 7), '(a,*(g0,1x))') "    zCoordinates    = ", z_coordinates(:, i)
+         lines(structure_start + 8) = "    allowedFlowDir  = "//trim(allowed_flowdir)
+         write (lines(structure_start + 9), '(a,g0)') "    width           = ", width
+         write (lines(structure_start + 10), '(a,g0)') "    height          = ", height
+         lines(structure_start + 11) = "    frictionType    = "//trim(friction_type)
+         write (lines(structure_start + 12), '(a,g0)') "    frictionValue   = ", friction_value
+         write (lines(structure_start + 13), '(a,g0)') "    valveRelativeOpening = ", valve_opening
+      end do
 
-    !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__single_two_point, test_convert1d2dlongculverts__single_two_point,
-    subroutine test_convert1d2dlongculverts__single_two_point() bind(C)
-        use precision, only: dp
-        use network_data, only: numk, numl, kn
-        use m_missing, only: dmiss
-        use m_polygon, only: xpl, ypl, zpl, npl
-        use m_longculverts, only: convert1D2DLongCulverts
-        use m_longculverts_data, only: longculverts
+      call create_file(filename, lines)
+   end subroutine create_longculvert_structure_file
 
-        implicit none
+   !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__single_four_point, test_convert1d2dlongculverts__single_four_point,
+   subroutine test_convert1d2dlongculverts__single_four_point() bind(C)
+      use precision, only: dp
+      use network_data, only: numk, numl, kn
+      use m_missing, only: dmiss
+      use m_polygon, only: xpl, ypl, zpl, npl
+      use m_longculverts, only: convert1D2DLongCulverts
+      use m_longculverts_data, only: longculverts
 
-        integer, parameter :: COORD_COUNT = 2
-        type(t_grid_helper) :: grid_helper
-        real(kind=dp) :: x_coords(COORD_COUNT)
-        real(kind=dp) :: y_coords(COORD_COUNT)
-        real(kind=dp) :: z_coords(COORD_COUNT)
-        integer :: i
+      integer, parameter :: COORD_COUNT = 4
+      type(t_grid_helper) :: grid_helper
+      real(kind=dp) :: x_coords(COORD_COUNT)
+      real(kind=dp) :: y_coords(COORD_COUNT)
+      real(kind=dp) :: z_coords(COORD_COUNT)
+      integer :: i
 
-        npl = 0
-        ! Arrange
-        grid_helper = t_grid_helper()
-        call grid_helper%make_square_grid( &
-            bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, &
-            rows=1, columns=2, side_length=10.0_dp, array_size_margin=16 &
-        )
+      ! Arrange
+      grid_helper = t_grid_helper()
+      call grid_helper%make_square_grid(bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, rows=1, columns=2, side_length=10.0_dp, array_size_margin=16)
 
-        x_coords = [5._dp, 15._dp]
-        y_coords = [6._dp, 4._dp]
-        z_coords = -1.0_dp
+      x_coords = [5._dp, 9._dp, 11._dp, 15._dp]
+      y_coords = [6._dp, 6._dp, 4._dp, 4._dp]
+      z_coords = -1.0_dp
 
-        ! `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
-        xpl = x_coords
-        ypl = y_coords
-        zpl = z_coords
-        npl = COORD_COUNT
-        if (allocated(longculverts)) then
-            deallocate(longculverts)
-        end if
-        allocate(longculverts(1))
-        allocate(longculverts(1)%netlinks(1))
-        ! Act
-        call convert1D2DLongCulverts(x_coords, y_coords, z_coords, COORD_COUNT)
+      ! Subroutine `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
+      xpl = x_coords
+      ypl = y_coords
+      zpl = z_coords
+      npl = COORD_COUNT
 
-        ! Assert
-        call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
-        call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
-        call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT), 15._dp)
-        call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT), 5._dp)
-        
-        call F90_ASSERT_EQ(numk, 8) ! 6 Netnodes for the grid, 2 For the long culvert.
-        call F90_ASSERT_EQ(numl, 8) ! 7 Netlinks for the grid, 1 For the long culvert.
+      allocate (longculverts(1))
+      allocate (longculverts(1)%netlinks(3))
+      ! Act
+      call convert1D2DLongCulverts(x_coords, y_coords, z_coords, COORD_COUNT)
 
-        call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(1)), 5, cstr("Expected first new link to be a 1D2D link."))
-    end subroutine test_convert1d2dlongculverts__single_two_point
-    !$f90tw )
+      ! Assert
+      call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
+      call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
+      call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT), 15._dp)
+      call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT), 5._dp)
 
-    !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__multiple_culverts, test_convert1d2dlongculverts__multiple_culverts,
-    subroutine test_convert1d2dlongculverts__multiple_culverts() bind(C)
-        use precision, only: dp
-        use network_data, only: numk, numl, kn
-        use m_missing, only: dmiss
-        use m_polygon, only: xpl, ypl, zpl, npl
-        use m_longculverts, only: convert1D2DLongCulverts
-         use m_longculverts_data, only: longculverts
-        use m_save_ugrid_state, only: meshgeom1d
+      call F90_ASSERT_EQ(numk, 10) ! 6 Netnodes for the grid, 4 For the long culvert.
+      call F90_ASSERT_EQ(numl, 10) ! 7 Netlinks for the grid, 3 For the long culvert.
 
-        implicit none
+      call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(1)), 5, cstr("Expected first new link to be a 1D2D link."))
+      call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(2)), 1, cstr("Expected middle link to be a 1D link."))
+      call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(3)), 5, cstr("Expected last new link to be a 1D2D link."))
+   end subroutine test_convert1d2dlongculverts__single_four_point
+   !$f90tw )
 
-        integer, parameter :: COORD_COUNT_LC1 = 4
-        integer, parameter :: COORD_COUNT_LC2 = 2
-        integer, parameter :: ARRAY_SIZE = COORD_COUNT_LC1 + COORD_COUNT_LC2 + 1
-        type(t_grid_helper) :: grid_helper
-        real(kind=dp) :: x_coords(ARRAY_SIZE)
-        real(kind=dp) :: y_coords(ARRAY_SIZE)
-        real(kind=dp) :: z_coords(ARRAY_SIZE)
-        integer :: i
+   !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__single_two_point, test_convert1d2dlongculverts__single_two_point,
+   subroutine test_convert1d2dlongculverts__single_two_point() bind(C)
+      use precision, only: dp
+      use network_data, only: numk, numl, kn
+      use m_missing, only: dmiss
+      use m_polygon, only: xpl, ypl, zpl, npl
+      use m_longculverts, only: convert1D2DLongCulverts
+      use m_longculverts_data, only: longculverts
 
-        npl = 0
-        ! Arrange
-        ! 2 x 2 grid.
-        grid_helper = t_grid_helper()
-        call grid_helper%make_square_grid( &
-            bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, &
-            rows=2, columns=2, side_length=10.0_dp, array_size_margin=16 &
-        )
+      implicit none
 
-        x_coords = [5._dp, 9._dp, 11._dp, 15._dp, dmiss, 5._dp, 15._dp]
-        y_coords = [6._dp, 6._dp, 4._dp, 4._dp, dmiss, 16._dp, 14._dp]
-        z_coords = -1.0_dp
-        z_coords(5) = dmiss
+      integer, parameter :: COORD_COUNT = 2
+      type(t_grid_helper) :: grid_helper
+      real(kind=dp) :: x_coords(COORD_COUNT)
+      real(kind=dp) :: y_coords(COORD_COUNT)
+      real(kind=dp) :: z_coords(COORD_COUNT)
+      integer :: i
 
-        ! Subroutine `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
-        xpl = x_coords
-        ypl = y_coords
-        zpl = z_coords
-        npl = ARRAY_SIZE
+      npl = 0
+      ! Arrange
+      grid_helper = t_grid_helper()
+      call grid_helper%make_square_grid(bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, rows=1, columns=2, side_length=10.0_dp, array_size_margin=16)
 
-        !> ensure meshgeom1d state is disregarded
-        meshgeom1d%numnode = -1 
-        meshgeom1d%nnodes = -1
+      x_coords = [5._dp, 15._dp]
+      y_coords = [6._dp, 4._dp]
+      z_coords = -1.0_dp
 
-        if (allocated(longculverts)) then
-            deallocate(longculverts)
-        end if
-        allocate(longculverts(2))
-        allocate(longculverts(1)%netlinks(3))
-        allocate(longculverts(2)%netlinks(1))
+      ! `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
+      xpl = x_coords
+      ypl = y_coords
+      zpl = z_coords
+      npl = COORD_COUNT
+      if (allocated(longculverts)) then
+         deallocate (longculverts)
+      end if
+      allocate (longculverts(1))
+      allocate (longculverts(1)%netlinks(1))
+      ! Act
+      call convert1D2DLongCulverts(x_coords, y_coords, z_coords, COORD_COUNT)
 
-        ! Act
-        call convert1D2DLongCulverts(x_coords, y_coords, z_coords, ARRAY_SIZE)
+      ! Assert
+      call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
+      call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
+      call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT), 15._dp)
+      call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT), 5._dp)
 
-        ! Assert
-        call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
-        call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
-        call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT_LC1), 15._dp)
-        call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT_LC1), 5._dp)
-        call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT_LC1 + 2), 5._dp) ! First and last point snapped to cell centers.
-        call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT_LC1 + 2), 15._dp)
-        call F90_ASSERT_DOUBLE_EQ(x_coords(ARRAY_SIZE), 15._dp)
-        call F90_ASSERT_DOUBLE_EQ(y_coords(ARRAY_SIZE), 15._dp)
-        
-        call F90_ASSERT_EQ(numk, 9 + 4 + 2) ! 9 Netnodes for the grid, 4 for LC1, 2 for LC2.
-        call F90_ASSERT_EQ(numl, 12 + 3 + 1) ! 12 Netlinks for the grid, 3 for LC1, 1 for LC2.
-    end subroutine test_convert1d2dlongculverts__multiple_culverts
-    !$f90tw )
+      call F90_ASSERT_EQ(numk, 8) ! 6 Netnodes for the grid, 2 For the long culvert.
+      call F90_ASSERT_EQ(numl, 8) ! 7 Netlinks for the grid, 1 For the long culvert.
+
+      call F90_ASSERT_EQ(kn(3, longculverts(1)%netlinks(1)), 5, cstr("Expected first new link to be a 1D2D link."))
+   end subroutine test_convert1d2dlongculverts__single_two_point
+   !$f90tw )
+
+   !$f90tw TESTCODE(TEST, test_longculvert, test_convert1d2dlongculverts__multiple_culverts, test_convert1d2dlongculverts__multiple_culverts,
+   subroutine test_convert1d2dlongculverts__multiple_culverts() bind(C)
+      use precision, only: dp
+      use network_data, only: numk, numl, kn
+      use m_missing, only: dmiss
+      use m_polygon, only: xpl, ypl, zpl, npl
+      use m_longculverts, only: convert1D2DLongCulverts
+      use m_longculverts_data, only: longculverts
+      use m_save_ugrid_state, only: meshgeom1d
+
+      implicit none
+
+      integer, parameter :: COORD_COUNT_LC1 = 4
+      integer, parameter :: COORD_COUNT_LC2 = 2
+      integer, parameter :: ARRAY_SIZE = COORD_COUNT_LC1 + COORD_COUNT_LC2 + 1
+      type(t_grid_helper) :: grid_helper
+      real(kind=dp) :: x_coords(ARRAY_SIZE)
+      real(kind=dp) :: y_coords(ARRAY_SIZE)
+      real(kind=dp) :: z_coords(ARRAY_SIZE)
+      integer :: i
+
+      npl = 0
+      ! Arrange
+      ! 2 x 2 grid.
+      grid_helper = t_grid_helper()
+      call grid_helper%make_square_grid(bottom_left_x=0.0_dp, bottom_left_y=0.0_dp, rows=2, columns=2, side_length=10.0_dp, array_size_margin=16)
+
+      x_coords = [5._dp, 9._dp, 11._dp, 15._dp, dmiss, 5._dp, 15._dp]
+      y_coords = [6._dp, 6._dp, 4._dp, 4._dp, dmiss, 16._dp, 14._dp]
+      z_coords = -1.0_dp
+      z_coords(5) = dmiss
+
+      ! Subroutine `longculvert_create_endpiont` requires these arrays in `m_polygon` to be allocated.
+      xpl = x_coords
+      ypl = y_coords
+      zpl = z_coords
+      npl = ARRAY_SIZE
+
+      !> ensure meshgeom1d state is disregarded
+      meshgeom1d%numnode = -1
+      meshgeom1d%nnodes = -1
+
+      if (allocated(longculverts)) then
+         deallocate (longculverts)
+      end if
+      allocate (longculverts(2))
+      allocate (longculverts(1)%netlinks(3))
+      allocate (longculverts(2)%netlinks(1))
+
+      ! Act
+      call convert1D2DLongCulverts(x_coords, y_coords, z_coords, ARRAY_SIZE)
+
+      ! Assert
+      call F90_ASSERT_DOUBLE_EQ(x_coords(1), 5._dp) ! First and last point snapped to cell centers.
+      call F90_ASSERT_DOUBLE_EQ(y_coords(1), 5._dp)
+      call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT_LC1), 15._dp)
+      call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT_LC1), 5._dp)
+      call F90_ASSERT_DOUBLE_EQ(x_coords(COORD_COUNT_LC1 + 2), 5._dp) ! First and last point snapped to cell centers.
+      call F90_ASSERT_DOUBLE_EQ(y_coords(COORD_COUNT_LC1 + 2), 15._dp)
+      call F90_ASSERT_DOUBLE_EQ(x_coords(ARRAY_SIZE), 15._dp)
+      call F90_ASSERT_DOUBLE_EQ(y_coords(ARRAY_SIZE), 15._dp)
+
+      call F90_ASSERT_EQ(numk, 9 + 4 + 2) ! 9 Netnodes for the grid, 4 for LC1, 2 for LC2.
+      call F90_ASSERT_EQ(numl, 12 + 3 + 1) ! 12 Netlinks for the grid, 3 for LC1, 1 for LC2.
+   end subroutine test_convert1d2dlongculverts__multiple_culverts
+   !$f90tw )
 
    !> Create a minimal UGRID 2D net file: a simple channel of 4 quads in a row.
    !! Nodes form a 5x2 grid (10 nodes), edges connect them into 4 rectangular cells.
@@ -301,59 +381,30 @@ contains
       ierr = nf90_close(ncid)
    end subroutine create_minimal_netfile
 
-   !> Create a structures.ini file containing a single long culvert
-   !! that runs through the middle of the mesh (y=50) from x=50 to x=350.
-   subroutine create_structure_file(filename)
-      character(len=*), intent(in) :: filename
-
-      call create_file(filename, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0       ", &
-                       "    yCoordinates    = 50.0 50.0         ", &
-                       "    zCoordinates    = -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                "])
-   end subroutine create_structure_file
-
    !> Create a minimal MDU file that references the net file and structure file.
    subroutine create_mdu_file(mdu_file, net_file, str_file)
       character(len=*), intent(in) :: mdu_file, net_file, str_file
-      integer :: mout, ierr
 
-      open (newunit=mout, file=mdu_file, status='replace', action='write', iostat=ierr)
-
-      write (mout, '(a)') '[General]'
-      write (mout, '(a)') '    fileVersion           = 1.09'
-      write (mout, '(a)') '    fileType              = modelDef'
-      write (mout, '(a)') '    program               = D-Flow FM'
-      write (mout, '(a)') '    ConvertLongCulverts   = 1'
-      write (mout, '(a)') ''
-      write (mout, '(a)') '[geometry]'
-      write (mout, '(2a)') '    netFile               = ', trim(net_file)
-      write (mout, '(2a)') '    StructureFile         = ', trim(str_file)
-      write (mout, '(a)') '    UseCaching             = 0'
-      write (mout, '(a)') ''
-      write (mout, '(a)') '[time]'
-      write (mout, '(a)') '    refDate               = 20000101'
-      write (mout, '(a)') '    tUnit                 = S'
-      write (mout, '(a)') '    tStart                = 0.0'
-      write (mout, '(a)') '    tStop                 = 100.0'
-      write (mout, '(a)') '    dtMax                 = 10.0'
-      write (mout, '(a)') '    dtUser                = 10.0'
-      write (mout, '(a)') '    dtInit                = 1.0'
-
-      close (mout)
+      call create_file(mdu_file, [character(len=512) :: &
+                                  "[General]", &
+                                  "    fileVersion           = 1.09", &
+                                  "    fileType              = modelDef", &
+                                  "    program               = D-Flow FM", &
+                                  "    ConvertLongCulverts   = 1", &
+                                  "", &
+                                  "[geometry]", &
+                                  "    netFile               = "//trim(net_file), &
+                                  "    StructureFile         = "//trim(str_file), &
+                                  "    UseCaching             = 0", &
+                                  "", &
+                                  "[time]", &
+                                  "    refDate               = 20000101", &
+                                  "    tUnit                 = S", &
+                                  "    tStart                = 0.0", &
+                                  "    tStop                 = 100.0", &
+                                  "    dtMax                 = 10.0", &
+                                  "    dtUser                = 10.0", &
+                                  "    dtInit                = 1.0"])
    end subroutine create_mdu_file
 
    !$f90tw TESTCODE(TEST, test_longculvert, test_flow_modelinit_with_longculvert, test_flow_modelinit_with_longculvert,
@@ -393,7 +444,7 @@ contains
       call create_minimal_netfile(NET_FILE, ierr)
       call f90_assert_eq(ierr, nf90_noerr, cstr("NetCDF net file creation should succeed"))
 
-      call create_structure_file(TEST_STR_FILE)
+      call create_longculvert_structure_file(TEST_STR_FILE, LC2_X(:, :1), LC2_Y(:, :1), LC2_Z(:, :1))
       call create_mdu_file(TEST_MDU_FILE, NET_FILE, TEST_STR_FILE)
       md_ident = TEST_MDU_FILE
       threshold_abort = LEVEL_FATAL
@@ -459,7 +510,7 @@ contains
       integer :: ierr
 
       call create_minimal_netfile(NET_FILE, ierr)
-      call create_structure_file(TEST_STR_FILE)
+      call create_longculvert_structure_file(TEST_STR_FILE, LC2_X(:, :1), LC2_Y(:, :1), LC2_Z(:, :1))
       call create_mdu_file(TEST_MDU_FILE, NET_FILE, TEST_STR_FILE)
       md_ident = TEST_MDU_FILE
       threshold_abort = LEVEL_FATAL
@@ -663,8 +714,9 @@ contains
       use m_1d_structures, only: FLOWDIR_POSITIVE
       use m_flow, only: au, u1
       use m_flowgeom, only: ln
-      use m_longculverts, only: default_longculverts, find1d2dculvertlinks, reduceFlowAreaAtLongculverts
+      use m_longculverts, only: default_longculverts, find1d2dculvertlinks, longculvertsToProfs, reduceFlowAreaAtLongculverts
       use m_longculverts_data, only: longculverts
+      use network_data, only: xzw, yzw
       use unstruc_channel_flow, only: network
       use dfm_error, only: DFM_NOERR
       use precision, only: dp
@@ -675,7 +727,7 @@ contains
       character(len=256) :: mdu_file
 
       mdu_file = "test_lc_allowed_flowdir.mdu"
-      call create_structure_file(STR_FILE)
+      call create_longculvert_structure_file(STR_FILE, LC2_X(:, :1), LC2_Y(:, :1), LC2_Z(:, :1))
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
       call convertlongculverts(mdu_file, STR_FILE, NET_FILE)
@@ -690,8 +742,7 @@ contains
       ln(2, lc_link) = node
       call find1d2dculvertlinks(network, longculverts(1), size(longculverts(1)%xcoords))
 
-      call f90_expect_true(longculverts(1)%orientation == -flow_dir_before, &
-                  cstr("reversing the flow link must reverse its mapping to input-coordinate direction"))
+      call f90_expect_true(longculverts(1)%orientation == -flow_dir_before, cstr("reversing the flow link must reverse its mapping to input-coordinate direction"))
 
       longculverts(1)%allowed_flowdir = FLOWDIR_POSITIVE
       longculverts(1)%valve_relative_opening = 1.0_dp
@@ -699,11 +750,115 @@ contains
       u1(lc_link) = real(longculverts(1)%orientation, dp)
       call reduceFlowAreaAtLongculverts()
 
-      call f90_expect_true(au(lc_link) > 0.0_dp, &
-                           cstr("positive flow in input-coordinate direction must remain open"))
+      call f90_expect_true(au(lc_link) > 0.0_dp, cstr("positive flow in input-coordinate direction must remain open"))
+
+      ! Simulate a partition where the first global segment is absent and the
+      ! representative local flowlinks(1) corresponds to coordinate pair 2->3.
+      ! Include the rounding error introduced by writing converted coordinates to an INI file.
+      longculverts(1)%xcoords = [-huge(1.0_dp), &
+                                 xzw(ln(1, lc_link)) + 3.0_dp * epsilon(1.0_dp) * max(abs(xzw(ln(1, lc_link))), 1.0_dp), &
+                                 xzw(ln(2, lc_link)) + 3.0_dp * epsilon(1.0_dp) * max(abs(xzw(ln(2, lc_link))), 1.0_dp)]
+      longculverts(1)%ycoords = [-huge(1.0_dp), yzw(ln(1, lc_link)), yzw(ln(2, lc_link))]
+      longculverts(1)%orientation = -1
+      call longculvertsToProfs(.true.)
+      call f90_expect_eq(longculverts(1)%orientation, 1, cstr("orientation reconstruction must find the second segment as the first local flow link"))
 
       call default_longculverts()
    end subroutine test_allowed_flowdir_follows_coordinate_order
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_longculvert, test_converted_allowed_flowdir_controls_discharge, test_converted_allowed_flowdir_controls_discharge,
+   !> Verifies converted-culvert orientation using actual discharge, then checks
+   !! the complete allowedFlowDir truth table on the initialized flow links.
+   subroutine test_converted_allowed_flowdir_controls_discharge() bind(C)
+      use m_1d_structures, only: FLOWDIR_POSITIVE, FLOWDIR_NEGATIVE
+      use m_flow, only: au, hu, q1, u1
+      use m_longculverts, only: reduceFlowAreaAtLongculverts
+      use m_longculverts_data, only: nlongculverts, longculverts
+      use dfm_error, only: DFM_NOERR
+      use m_flow_spatietimestep, only: flow_spatietimestep
+      use precision, only: dp
+
+      integer :: iresult, i, flow_link, duplicate_flow_link
+      integer :: flow_links(2)
+      character(len=*), parameter :: STR_FILE = "test_lc_flowdir_str.ini"
+      character(len=*), parameter :: NET_FILE = "test_lc_flowdir_net.nc"
+      character(len=256) :: mdu_file = "test_lc_flowdir.mdu"
+
+      call create_longculvert_structure_file(STR_FILE, &
+                                             reshape([50.0_dp, 350.0_dp, 350.0_dp, 50.0_dp, &
+                                                      50.0_dp, 350.0_dp], [2, 3]), &
+                                             reshape([50.0_dp, 50.0_dp, 150.0_dp, 150.0_dp, &
+                                                      50.0_dp, 50.0_dp], [2, 3]), &
+                                             reshape([-5.0_dp, -5.0_dp, -5.0_dp, -5.0_dp, &
+                                                      -5.0_dp, -5.0_dp], [2, 3]), &
+                                             ids=[character(len=32) :: "lc_left_to_right", "lc_right_to_left", &
+                                                  "lc_left_to_right_duplicate"], &
+                                             allowed_flowdirs=[character(len=8) :: "positive", "positive", "positive"])
+      call create_two_row_netfile(NET_FILE)
+      call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
+      call convertlongculverts(mdu_file, STR_FILE, NET_FILE)
+      call init_two_culvert_scenario(mdu_file, iresult)
+
+      call f90_assert_eq(iresult, DFM_NOERR, cstr("converted positive-flow model init must succeed"))
+      call f90_assert_eq(nlongculverts, 3, cstr("three converted positive-flow culverts should be registered"))
+      call f90_assert_eq(longculverts(1)%allowed_flowdir, FLOWDIR_POSITIVE, cstr("left-to-right culvert should retain allowedFlowDir=positive"))
+      call f90_assert_eq(longculverts(2)%allowed_flowdir, FLOWDIR_POSITIVE, cstr("right-to-left culvert should retain allowedFlowDir=positive"))
+      call f90_assert_eq(longculverts(3)%allowed_flowdir, FLOWDIR_POSITIVE, cstr("duplicate culvert should retain allowedFlowDir=positive"))
+
+      call flow_spatietimestep()
+      flow_links = [abs(longculverts(1)%flowlinks(1)), abs(longculverts(2)%flowlinks(1))]
+      duplicate_flow_link = abs(longculverts(3)%flowlinks(1))
+      call f90_assert_true(duplicate_flow_link > 0 .and. duplicate_flow_link /= flow_links(1), &
+                           cstr("identical snapped culverts must retain distinct valid flow links"))
+      call f90_assert_eq(longculverts(3)%orientation, longculverts(1)%orientation, cstr("identical snapped culverts must have identical orientation"))
+      call f90_expect_true(abs(q1(flow_links(1))) > 0.0_dp, cstr("positive must permit left-to-right flow for left-to-right coordinates"))
+      call f90_expect_near(q1(duplicate_flow_link), q1(flow_links(1)), 1.0e-10_dp, cstr("identical snapped culverts must have identical discharge"))
+      call f90_expect_near(q1(flow_links(2)), 0.0_dp, 1.0e-10_dp, cstr("positive must block left-to-right flow for right-to-left coordinates"))
+
+      do i = 1, 2
+         flow_link = flow_links(i)
+         longculverts(i)%allowed_flowdir = FLOWDIR_POSITIVE
+         au(flow_link) = 1.0_dp
+         hu(flow_link) = 1.0_dp
+         u1(flow_link) = real(longculverts(i)%orientation, dp)
+      end do
+      call reduceFlowAreaAtLongculverts()
+      call f90_expect_true(au(flow_links(1)) > 0.0_dp .and. au(flow_links(2)) > 0.0_dp, &
+                           cstr("positive must permit flow in coordinate order for both link orientations"))
+
+      do i = 1, 2
+         flow_link = flow_links(i)
+         au(flow_link) = 1.0_dp
+         hu(flow_link) = 1.0_dp
+         u1(flow_link) = -real(longculverts(i)%orientation, dp)
+      end do
+      call reduceFlowAreaAtLongculverts()
+      call f90_expect_near(au(flow_links(1)), 0.0_dp, 1.0e-10_dp, cstr("positive must block reverse flow for the left-to-right culvert"))
+      call f90_expect_near(au(flow_links(2)), 0.0_dp, 1.0e-10_dp, cstr("positive must block reverse flow for the right-to-left culvert"))
+
+      do i = 1, 2
+         flow_link = flow_links(i)
+         longculverts(i)%allowed_flowdir = FLOWDIR_NEGATIVE
+         au(flow_link) = 1.0_dp
+         hu(flow_link) = 1.0_dp
+         u1(flow_link) = real(longculverts(i)%orientation, dp)
+      end do
+      call reduceFlowAreaAtLongculverts()
+      call f90_expect_near(au(flow_links(1)), 0.0_dp, 1.0e-10_dp, cstr("negative must block forward flow for the left-to-right culvert"))
+      call f90_expect_near(au(flow_links(2)), 0.0_dp, 1.0e-10_dp, cstr("negative must block forward flow for the right-to-left culvert"))
+
+      do i = 1, 2
+         flow_link = flow_links(i)
+         au(flow_link) = 1.0_dp
+         hu(flow_link) = 1.0_dp
+         u1(flow_link) = -real(longculverts(i)%orientation, dp)
+      end do
+      call reduceFlowAreaAtLongculverts()
+      call f90_expect_true(au(flow_links(1)) > 0.0_dp .and. au(flow_links(2)) > 0.0_dp, cstr("negative must permit reverse flow for both link orientations"))
+
+      call default_longculverts()
+   end subroutine test_converted_allowed_flowdir_controls_discharge
    !$f90tw)
 
    !> Create a 5x3-node UGRID net (4 cells wide, 2 rows).
@@ -876,38 +1031,7 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc_valve.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 0.5                "])
+      call create_longculvert_structure_file(STR_FILE, LC2_X, LC2_Y, LC2_Z, valve_openings=[1.0_dp, 0.5_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
@@ -940,38 +1064,7 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc_friction.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.01                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC2_X, LC2_Y, LC2_Z, friction_values=[0.01_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
@@ -1006,38 +1099,7 @@ contains
       character(len=256) :: MDU_FILE = "test_lc2pt_fric_converted.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc_convert_2pt_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.01                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC2_X, LC2_Y, LC2_Z, friction_values=[0.01_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
@@ -1075,36 +1137,36 @@ contains
       character(len=256) :: MDU_FILE = "test_lc2pt_default_friction_converted.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc_convert_2pt_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.023                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_file(STR_FILE, [character(len=64) :: &
+                                  "[General]", &
+                                  "    fileVersion     = 3.00", &
+                                  "    fileType        = structures", &
+                                  "", &
+                                  "[Structure]", &
+                                  "    id              = lc01", &
+                                  "    type            = longCulvert", &
+                                  "    numCoordinates  = 2", &
+                                  "    xCoordinates    = 50.0 350.0", &
+                                  "    yCoordinates    = 50.0 50.0", &
+                                  "    zCoordinates    = -5.0 -5.0", &
+                                  "    allowedFlowDir  = both", &
+                                  "    width           = 2.0", &
+                                  "    height          = 2.0", &
+                                  "    valveRelativeOpening = 1.0", &
+                                  "", &
+                                  "[Structure]", &
+                                  "    id              = lc02", &
+                                  "    type            = longCulvert", &
+                                  "    numCoordinates  = 2", &
+                                  "    xCoordinates    = 50.0 350.0", &
+                                  "    yCoordinates    = 150.0 150.0", &
+                                  "    zCoordinates    = -5.0 -5.0", &
+                                  "    allowedFlowDir  = both", &
+                                  "    width           = 2.0", &
+                                  "    height          = 2.0", &
+                                  "    frictionType    = Manning", &
+                                  "    frictionValue   = 0.023", &
+                                  "    valveRelativeOpening = 1.0"])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
@@ -1142,38 +1204,9 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc_frtype.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = WhiteColebrook          ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC2_X, LC2_Y, LC2_Z, &
+                                             friction_types=[character(len=16) :: "Manning", "WhiteColebrook"], &
+                                             friction_values=[0.05_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
@@ -1189,8 +1222,7 @@ contains
       q_colebrook = q1(longculverts(2)%flowlinks(1))
       call f90_expect_true(q_manning > 0.0_dp, cstr("Manning culvert discharge should be positive"))
       call f90_expect_true(q_colebrook > 0.0_dp, cstr("WhiteColebrook culvert discharge should be positive"))
-      call f90_expect_true(abs(q_manning - q_colebrook) > 1.0e-6_dp, &
-                           cstr("different friction types with same coefficient should give different discharge"))
+      call f90_expect_true(abs(q_manning - q_colebrook) > 1.0e-6_dp, cstr("different friction types with same coefficient should give different discharge"))
       call default_longculverts()
    end subroutine test_friction_type_affects_discharge
    !$f90tw)
@@ -1209,38 +1241,7 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc_cross.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 50.0 50.0               ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 1.0                     ", &
-                       "    height          = 1.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 2                       ", &
-                       "    xCoordinates    = 50.0 350.0              ", &
-                       "    yCoordinates    = 150.0 150.0             ", &
-                       "    zCoordinates    = -5.0 -5.0               ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 4.0                     ", &
-                       "    height          = 4.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC2_X, LC2_Y, LC2_Z, widths=[1.0_dp, 4.0_dp], heights=[1.0_dp, 4.0_dp])
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
       call init_two_culvert_scenario(MDU_FILE, iresult)
@@ -1253,8 +1254,7 @@ contains
       q_large = q1(longculverts(2)%flowlinks(1)) ! lc02: 4x4 m
       call f90_expect_true(q_small > 0.0_dp, "small culvert discharge should be positive")
       call f90_expect_true(q_large > 0.0_dp, "large culvert discharge should be positive")
-      call f90_expect_true(q_large > q_small, &
-                           "larger cross-section should give more discharge")
+      call f90_expect_true(q_large > q_small, "larger cross-section should give more discharge")
       call default_longculverts()
    end subroutine test_larger_cross_section_increases_discharge
    !$f90tw)
@@ -1263,70 +1263,23 @@ contains
    ! 3-POINT LONG CULVERT TESTS
    ! ============================================================================
 
-   !> Create a structure file with a single 3-point long culvert (2 links: kcu=5, kcu=5).
-   subroutine create_structure_file_3pt(filename)
-      character(len=*), intent(in) :: filename
-
-      call create_file(filename, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 50.0 50.0 50.0         ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 150.0 150.0 150.0         ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                "])
-   end subroutine create_structure_file_3pt
-
-   !> Shared helper for 3-point single-culvert tests.
-   subroutine setup_3pt_model(iresult)
-      use m_flow_modelinit, only: flow_modelinit
-      use unstruc_model, only: loadModel, md_ident
-      use dfm_error, only: DFM_NOERR
-      use unstruc_messages, only: threshold_abort
-      use messagehandling, only: LEVEL_FATAL, SetMessageHandling
-      use m_inidat, only: inidat
-      use Timers, only: timini, timon
-      use m_partitioninfo, only: jampi
-      use m_resetfullflowmodel, only: resetfullflowmodel
-      use netcdf, only: nf90_noerr
+   !> Create and initialize a two-row model containing the specified long culverts.
+   subroutine setup_two_row_longculvert_model(file_prefix, x_coordinates, y_coordinates, z_coordinates, iresult)
+      character(len=*), intent(in) :: file_prefix
+      real(kind=dp), dimension(:, :), intent(in) :: x_coordinates, y_coordinates, z_coordinates
       integer, intent(out) :: iresult
 
-      character(len=*), parameter :: NET_FILE = "test_lc3pt_net.nc"
-      character(len=*), parameter :: STR_FILE = "test_lc3pt_structures.ini"
-      character(len=*), parameter :: MDU_FILE = "test_lc3pt.mdu"
-      character(len=256) :: mdu_local
-      integer :: ierr
+      character(len=256) :: mdu_file, net_file, str_file
 
-      call create_structure_file_3pt(STR_FILE)
-      call create_two_row_netfile(NET_FILE)
+      mdu_file = trim(file_prefix)//".mdu"
+      net_file = trim(file_prefix)//"_net.nc"
+      str_file = trim(file_prefix)//"_structures.ini"
+      call create_longculvert_structure_file(STR_FILE, x_coordinates, y_coordinates, z_coordinates)
+      call create_two_row_netfile(net_file)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
-      call init_two_culvert_scenario(MDU_FILE, iresult)
+      call init_two_culvert_scenario(mdu_file, iresult)
 
-   end subroutine setup_3pt_model
+   end subroutine setup_two_row_longculvert_model
 
    !$f90tw TESTCODE(TEST, test_longculvert, test_3pt_modelinit_succeeds, test_3pt_modelinit_succeeds,
    subroutine test_3pt_modelinit_succeeds() bind(C)
@@ -1336,7 +1289,7 @@ contains
 
       integer :: iresult
 
-      call setup_3pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc3pt", LC3_X, LC3_Y, LC3_Z, iresult)
 
       call f90_expect_eq(iresult, DFM_NOERR, cstr("flow_modelinit should succeed for 3-point culvert"))
       call f90_expect_eq(nlongculverts, 2, cstr("two long culverts should be registered"))
@@ -1358,7 +1311,7 @@ contains
 
       integer :: iresult, i, lc_link
 
-      call setup_3pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc3pt", LC3_X, LC3_Y, LC3_Z, iresult)
       call f90_assert_eq(iresult, DFM_NOERR, cstr("model init must succeed"))
 
       call flow_spatietimestep()
@@ -1383,7 +1336,7 @@ contains
 
       integer :: iresult, i, lc_link
 
-      call setup_3pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc3pt", LC3_X, LC3_Y, LC3_Z, iresult)
       call f90_assert_eq(iresult, DFM_NOERR, cstr("model init must succeed"))
 
       longculverts(1)%valve_relative_opening = 0.0_dp
@@ -1412,38 +1365,7 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc3pt_fric.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 50.0 50.0 50.0         ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.01                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 150.0 150.0 150.0      ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC3_X, LC3_Y, LC3_Z, friction_values=[0.01_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
@@ -1459,8 +1381,7 @@ contains
       q_high_friction = q1(longculverts(2)%flowlinks(1))
       call f90_expect_true(q_low_friction > 0.0_dp, cstr("low-friction discharge should be positive"))
       call f90_expect_true(q_high_friction > 0.0_dp, cstr("high-friction discharge should be positive"))
-      call f90_expect_true(q_high_friction < q_low_friction, &
-                           cstr("higher Manning friction should produce less discharge"))
+      call f90_expect_true(q_high_friction < q_low_friction, cstr("higher Manning friction should produce less discharge"))
       call default_longculverts()
    end subroutine test_3pt_friction_higher_value_reduces_discharge
    !$f90tw)
@@ -1479,38 +1400,7 @@ contains
       character(len=256) :: MDU_FILE = "test_lc3pt_fric.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc_convert_3pt_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 50.0 50.0 50.0         ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.01                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 3                       ", &
-                       "    xCoordinates    = 50.0 200.0 350.0       ", &
-                       "    yCoordinates    = 150.0 150.0 150.0      ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0         ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC3_X, LC3_Y, LC3_Z, friction_values=[0.01_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
@@ -1529,70 +1419,6 @@ contains
    ! 4-POINT LONG CULVERT TESTS
    ! ============================================================================
 
-   !> Create a structure file with a single 4-point long culvert (3 links: kcu=5, kcu=1, kcu=5).
-   subroutine create_structure_file_4pt(filename)
-      character(len=*), intent(in) :: filename
-
-      call create_file(filename, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 4                       ", &
-                       "    xCoordinates    = 50.0 150.0 250.0 350.0 ", &
-                       "    yCoordinates    = 50.0 50.0 50.0 50.0    ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0 -5.0   ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 4                       ", &
-                       "    xCoordinates    = 50.0 150.0 250.0 350.0 ", &
-                       "    yCoordinates    = 150.0 150.0 150.0 150.0", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0 -5.0   ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.02                    ", &
-                       "    valveRelativeOpening = 1.0                "])
-
-   end subroutine create_structure_file_4pt
-
-   !> Shared helper for 4-point single-culvert tests.
-   subroutine setup_4pt_model(iresult)
-      use m_flow_modelinit, only: flow_modelinit
-      use unstruc_model, only: loadModel, md_ident
-      use dfm_error, only: DFM_NOERR
-      use unstruc_messages, only: threshold_abort
-      use messagehandling, only: LEVEL_FATAL, SetMessageHandling
-      use m_inidat, only: inidat
-      use Timers, only: timini, timon
-      use m_partitioninfo, only: jampi
-      use m_resetfullflowmodel, only: resetfullflowmodel
-      use netcdf, only: nf90_noerr
-      integer, intent(out) :: iresult
-
-      character(len=*), parameter :: NET_FILE = "test_lc4pt_net.nc"
-      character(len=*), parameter :: STR_FILE = "test_lc4pt_structures.ini"
-      character(len=*), parameter :: MDU_FILE = "test_lc4pt.mdu"
-
-      call create_structure_file_4pt(STR_FILE)
-      call create_two_row_netfile(NET_FILE)
-      call create_mdu_file(mdu_file, NET_FILE, str_file)
-      call init_two_culvert_scenario(MDU_FILE, iresult)
-
-   end subroutine setup_4pt_model
-
    !$f90tw TESTCODE(TEST, test_longculvert, test_4pt_modelinit_succeeds, test_4pt_modelinit_succeeds,
    subroutine test_4pt_modelinit_succeeds() bind(C)
       use m_flowgeom, only: ndx, lnx
@@ -1601,7 +1427,7 @@ contains
 
       integer :: iresult
 
-      call setup_4pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc4pt", LC4_X, LC4_Y, LC4_Z, iresult)
 
       call f90_expect_eq(iresult, DFM_NOERR, cstr("flow_modelinit should succeed for 4-point culvert"))
       call f90_expect_eq(nlongculverts, 2, cstr("two long culverts should be registered"))
@@ -1623,7 +1449,7 @@ contains
 
       integer :: iresult, i, lc_link
 
-      call setup_4pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc4pt", LC4_X, LC4_Y, LC4_Z, iresult)
       call f90_assert_eq(iresult, DFM_NOERR, cstr("model init must succeed"))
 
       call flow_spatietimestep()
@@ -1648,7 +1474,7 @@ contains
 
       integer :: iresult, i, lc_link
 
-      call setup_4pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc4pt", LC4_X, LC4_Y, LC4_Z, iresult)
       call f90_assert_eq(iresult, DFM_NOERR, cstr("model init must succeed"))
 
       longculverts(1)%valve_relative_opening = 0.0_dp
@@ -1677,38 +1503,7 @@ contains
       character(len=*), parameter :: MDU_FILE = "test_lc4pt_fric.mdu"
       character(len=*), parameter :: NET_FILE = "test_lc2_net.nc"
 
-      call create_file(STR_FILE, [ &
-                       "[General]                                     ", &
-                       "    fileVersion     = 3.00                    ", &
-                       "    fileType        = structures              ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc01                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 4                       ", &
-                       "    xCoordinates    = 50.0 150.0 250.0 350.0 ", &
-                       "    yCoordinates    = 50.0 50.0 50.0 50.0    ", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0 -5.0   ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.01                    ", &
-                       "    valveRelativeOpening = 1.0                ", &
-                       "                                              ", &
-                       "[Structure]                                   ", &
-                       "    id              = lc02                    ", &
-                       "    type            = longCulvert             ", &
-                       "    numCoordinates  = 4                       ", &
-                       "    xCoordinates    = 50.0 150.0 250.0 350.0 ", &
-                       "    yCoordinates    = 150.0 150.0 150.0 150.0", &
-                       "    zCoordinates    = -5.0 -5.0 -5.0 -5.0   ", &
-                       "    allowedFlowDir  = both                    ", &
-                       "    width           = 2.0                     ", &
-                       "    height          = 2.0                     ", &
-                       "    frictionType    = Manning                 ", &
-                       "    frictionValue   = 0.05                    ", &
-                       "    valveRelativeOpening = 1.0                "])
+      call create_longculvert_structure_file(STR_FILE, LC4_X, LC4_Y, LC4_Z, friction_values=[0.01_dp, 0.05_dp])
 
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, str_file)
@@ -1724,8 +1519,7 @@ contains
       q_high_friction = q1(longculverts(2)%flowlinks(1))
       call f90_expect_true(q_low_friction > 0.0_dp, cstr("low-friction discharge should be positive"))
       call f90_expect_true(q_high_friction > 0.0_dp, cstr("high-friction discharge should be positive"))
-      call f90_expect_true(q_high_friction < q_low_friction, &
-                           cstr("higher Manning friction should produce less discharge"))
+      call f90_expect_true(q_high_friction < q_low_friction, cstr("higher Manning friction should produce less discharge"))
       call default_longculverts()
 
    end subroutine test_4pt_friction_higher_value_reduces_discharge
@@ -1745,7 +1539,7 @@ contains
 
       integer :: iresult, i, L1, L2, L3
 
-      call setup_4pt_model(iresult)
+      call setup_two_row_longculvert_model("test_lc4pt", LC4_X, LC4_Y, LC4_Z, iresult)
       call f90_assert_eq(iresult, DFM_NOERR, cstr("model init must succeed"))
       call f90_assert_eq(longculverts(1)%numlinks, 3, cstr("4-point culvert should have 3 links"))
 
@@ -1760,10 +1554,8 @@ contains
       call f90_expect_true(q1(L1) > 0.0_dp, cstr("discharge at link 1 should be positive"))
       ! In steady state, Q should be equal across all links (continuity).
       ! After a few timesteps it wont be perfectly steady, but should be close enough (15%)
-      call f90_expect_near(q1(L1), q1(L2), 0.15_dp * abs(q1(L1)), &
-                           cstr("discharge at links 1 and 2 should be similar (continuity)"))
-      call f90_expect_near(q1(L2), q1(L3), 0.15_dp * abs(q1(L2)), &
-                           cstr("discharge at links 2 and 3 should be similar (continuity)"))
+      call f90_expect_near(q1(L1), q1(L2), 0.15_dp * abs(q1(L1)), cstr("discharge at links 1 and 2 should be similar (continuity)"))
+      call f90_expect_near(q1(L2), q1(L3), 0.15_dp * abs(q1(L2)), cstr("discharge at links 2 and 3 should be similar (continuity)"))
 
       call default_longculverts()
    end subroutine test_4pt_flow_continuity_across_links
@@ -1786,7 +1578,7 @@ contains
       character(len=*), parameter :: STR_FILE = "test_lc_convert_4pt_str.ini"
       character(len=256) :: mdu_file = "test_lc_convert_4pt.mdu"
 
-      call create_structure_file_4pt(STR_FILE)
+      call create_longculvert_structure_file(STR_FILE, LC4_X, LC4_Y, LC4_Z)
       call create_two_row_netfile(NET_FILE)
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
       call convertlongculverts(mdu_file, STR_FILE, NET_FILE)
@@ -1805,10 +1597,8 @@ contains
       call f90_expect_true(q1(L1) < 0.0_dp, cstr("discharge at link 1 should be negative"))
       ! In steady state, Q should be equal across all links (continuity).
       ! After a few timesteps it wont be perfectly steady, but should be close enough (15%)
-      call f90_expect_near(-q1(L1), q1(L2), 0.15_dp * abs(q1(L1)), &
-                           cstr("discharge at links 1 and 2 should be similar (continuity)"))
-      call f90_expect_near(q1(L2), q1(L3), 0.15_dp * abs(q1(L2)), &
-                           cstr("discharge at links 2 and 3 should be similar (continuity)"))
+      call f90_expect_near(-q1(L1), q1(L2), 0.15_dp * abs(q1(L1)), cstr("discharge at links 1 and 2 should be similar (continuity)"))
+      call f90_expect_near(q1(L2), q1(L3), 0.15_dp * abs(q1(L2)), cstr("discharge at links 2 and 3 should be similar (continuity)"))
 
       call default_longculverts()
    end subroutine test_4pt_flow_continuity_converted
@@ -1848,7 +1638,7 @@ contains
       call f90_assert_eq(ierr, 0, cstr("Net file with 1D branch creation should succeed"))
 
       ! Create structure file with a 4-point long culvert
-      call create_structure_file_4pt(STR_FILE)
+      call create_longculvert_structure_file(STR_FILE, LC4_X, LC4_Y, LC4_Z)
 
       call create_mdu_file(mdu_file, NET_FILE, STR_FILE)
       call init_two_culvert_scenario(MDU_FILE, iresult)
@@ -2110,8 +1900,7 @@ contains
       ierr = nf90_put_att(ncid, varid_m1d, 'node_dimension', 'mesh1d_nNodes')
       ierr = nf90_put_att(ncid, varid_m1d, 'edge_dimension', 'mesh1d_nEdges')
       ierr = nf90_put_att(ncid, varid_m1d, 'edge_node_connectivity', 'mesh1d_edge_nodes')
-      ierr = nf90_put_att(ncid, varid_m1d, 'node_coordinates', &
-                          'mesh1d_node_branch mesh1d_node_offset mesh1d_node_x mesh1d_node_y')
+      ierr = nf90_put_att(ncid, varid_m1d, 'node_coordinates', 'mesh1d_node_branch mesh1d_node_offset mesh1d_node_x mesh1d_node_y')
       ierr = nf90_put_att(ncid, varid_m1d, 'edge_coordinates', 'mesh1d_edge_branch mesh1d_edge_offset')
       ierr = nf90_put_att(ncid, varid_m1d, 'node_id', 'mesh1d_node_id')
       ierr = nf90_put_att(ncid, varid_m1d, 'node_long_name', 'mesh1d_node_long_name')
@@ -2234,8 +2023,7 @@ contains
       netfile_local = "converted_"//trim(netfile)
       call findcells(0)
       call find1dcells()
-      call unc_write_net(netfile_local, janetcell=1, janetbnd=1, jaidomain=0, &
-                         jaiglobal_s=0, md_ident=md_ident) ! Save net bnds to prevent unnecessary open bnds
+      call unc_write_net(netfile_local, janetcell=1, janetbnd=1, jaidomain=0, jaiglobal_s=0, md_ident=md_ident) ! Save net bnds to prevent unnecessary open bnds
       md_netfile = netfile_local
       mdufile_local = "converted_"//mdufile
       md_structurefile = "converted_"//structurefile

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_converter.f90
@@ -2811,7 +2811,7 @@ contains
          twx = 1
          twy = 2
          twp = 3
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          twp = 1
       case ('windx')
          twx = 1

--- a/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
+++ b/src/utils_lgpl/ec_module/packages/ec_module/src/ec_support.f90
@@ -365,7 +365,7 @@ contains
          ncstdnames(1) = 'surface_downward_eastward_stress'
          ncvarnames(2) = 'tauv' ! northward wind stress
          ncstdnames(2) = 'surface_downward_northward_stress'
-      case ('airpressure', 'atmosphericpressure')
+      case ('airpressure')
          allocate (ncvarnames(1))
          allocate (ncstdnames(1))
          ncvarnames(1) = 'msl' ! mean sea-level pressure


### PR DESCRIPTION
# What was done 

Cherry picked the following three "merges" to main (really they were squashed and fast-forward merged, so easy cherry pickings)

- https://github.com/Deltares/Delft3D/pull/1250 Keep com file on NcFormat 3 (classic)
- https://github.com/Deltares/Delft3D/pull/1235 determine long culvert orientation based on flownodes, not netnodes.
- https://github.com/Deltares/Delft3D/pull/1226 map atmosphericpressure ext-alias to airPressure for bc support (#1226)
 

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
