### PR TITLE
Fm/task/unst 10333 filetype extension validator

### DIFF
--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/fm_external_forcings_init.f90
@@ -963,7 +963,7 @@ contains
       use m_ec_spatial_extrapolation, only: init_spatial_extrapolation
       use m_sferic, only: jsferic
       use string_module, only: str_tolower
-      use messageHandling, only: err_flush, msgbuf
+      use messageHandling, only: err_flush, mess, msgbuf, LEVEL_INFO
       use tree_data_types, only: tree_data
       use fm_location_types, only: parse_spatial_location_type, UNC_LOC_S, UNC_LOC_U, UNC_LOC_3DV, UNC_LOC_S3D, SPATIAL_LOCATION_1D, SPATIAL_LOCATION_2D, SPATIAL_LOCATION_ALL
       use m_meteo, only: ec_addtimespacerelation, ec_gettimespacevalue_by_itemID, ecInstancePtr
@@ -1022,6 +1022,14 @@ contains
       res = validate_spatial_field_input(input, file_name, group_name, base_dir)
       if (.not. res) then
          return
+      end if
+
+      if (input%is_static_field) then
+         call mess(LEVEL_INFO, "Initializing spatial quantity '"//trim(input%quantity)//"' as an initial field from file '"// &
+                               trim(input%forcing_file)//"'.")
+      else
+         call mess(LEVEL_INFO, "Initializing spatial quantity '"//trim(input%quantity)//"' as a time-dependent forcing from file '"// &
+                               trim(input%forcing_file)//"'.")
       end if
 
       associate (quantity => input%quantity, &

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -392,7 +392,7 @@ contains
       case (SPIDERWEB)
          conflicts = ext /= '.spw'
       case (UNIFORM)
-         conflicts = .not. any(ext == [character(len=16) :: '.tim', '.tem'])
+         conflicts = .not. any(ext == [character(len=16) :: '.tim', '.tem', '.wnd'])
       case (UNIMAGDIR)
          conflicts = .not. any(ext == [character(len=16) :: '.tim', '.wnd'])
       case default

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -228,6 +228,12 @@ contains
       end if
 
       if (comparereal(input%data_value, dmiss) /= 0) then
+         if (len_trim(input%forcing_file_type) > 0 .or. len_trim(input%forcing_file) > 0) then
+            write (msgbuf, '(5a)') 'Invalid block in file ''', trimmed_file_name, ''': [', trimmed_group_name, &
+               ']. Fields ''forcingFileType'' and ''forcingFile'' cannot be combined with ''dataValue''.'
+            call err_flush()
+            return
+         end if
          input%forcing_file_type = "datavalue"
          input%filetype = DATAVALUE
       else
@@ -241,8 +247,8 @@ contains
 
          input%filetype = convert_file_type_string_to_integer(input%forcing_file_type)
          if (input%filetype == FILE_TYPE_UNKNOWN) then
-            write (msgbuf, '(7a)') 'Field ''forcingFile'' has unknown value ''', trim(input%forcing_file_type), ''' in file ''', &
-               trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''forcingFile'' has unknown value.'
+            write (msgbuf, '(7a)') 'Field ''forcingFileType'' has unknown value ''', trim(input%forcing_file_type), ''' in file ''', &
+               trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''forcingFileType'' has unknown value.'
             call err_flush()
             return
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -230,38 +230,38 @@ contains
       if (comparereal(input%data_value, dmiss) /= 0) then
          if (len_trim(input%forcing_file_type) > 0 .or. len_trim(input%forcing_file) > 0) then
             write (msgbuf, '(5a)') 'Invalid block in file ''', trimmed_file_name, ''': [', trimmed_group_name, &
-               ']. Fields ''forcingFileType'' and ''forcingFile'' cannot be combined with ''dataValue''.'
+                  ']. Fields ''dataFileType'' and ''dataFile'' cannot be combined with ''dataValue''.'
             call err_flush()
             return
          end if
          input%forcing_file_type = "datavalue"
          input%filetype = DATAVALUE
       else
-         ! ForcingFileType is required only if `dataValue` is not present.
-         ! Do all ForcingFile related validation and option setting in this branch.
+         ! dataFileType is required only if `dataValue` is not present.
+         ! Do all dataFile related validation and option setting in this branch.
          if (len_trim(input%forcing_file_type) == 0) then
-            write (msgbuf, '(5a)') 'Incomplete block in file ''', trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''forcingFileType'' is missing.'
+            write (msgbuf, '(5a)') 'Incomplete block in file ''', trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''dataFileType'' is missing.'
             call err_flush()
             return
          end if
 
          input%filetype = convert_file_type_string_to_integer(input%forcing_file_type)
          if (input%filetype == FILE_TYPE_UNKNOWN) then
-            write (msgbuf, '(7a)') 'Field ''forcingFileType'' has unknown value ''', trim(input%forcing_file_type), ''' in file ''', &
-               trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''forcingFileType'' has unknown value.'
+            write (msgbuf, '(7a)') 'Field ''dataFileType'' has unknown value ''', trim(input%forcing_file_type), ''' in file ''', &
+               trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''dataFileType'' has unknown value.'
             call err_flush()
             return
          end if
 
          if (len_trim(input%forcing_file) == 0) then
-            write (msgbuf, '(5a)') 'Incomplete block in file ''', trim(file_name), ''': [', trim(group_name), ']. Field ''forcingFile'' is missing.'
+            write (msgbuf, '(5a)') 'Incomplete block in file ''', trim(file_name), ''': [', trim(group_name), ']. Field ''dataFile'' is missing.'
             call err_flush()
             return
          end if
    
          if (file_extension_conflicts_with_type(input%forcing_file, input%filetype)) then
             write (msgbuf, '(9a)') 'Invalid block in file ''', trim(file_name), ''': [', trim(group_name), &
-               ']. forcingFile ''', trim(input%forcing_file), ''' has a file extension that conflicts with forcingFileType ''', &
+               ']. dataFile ''', trim(input%forcing_file), ''' has a file extension that conflicts with dataFileType ''', &
                trim(input%forcing_file_type), '''.'
             call err_flush()
             return
@@ -311,7 +311,7 @@ contains
                trim(input%interpolation_method), ' in block in file ''', trimmed_file_name, ''': [', trimmed_group_name, '].'
          else
             write (msgbuf, '(7a)') 'Block contains no ''interpolationMethod'' in file ''', trimmed_file_name, ''': [', trimmed_group_name, &
-               '] nor an internal value associated with given ''forcingFileType'':', trim(input%forcing_file_type), '.'
+               '] nor an internal value associated with given ''dataFileType'':', trim(input%forcing_file_type), '.'
          end if
          call err_flush()
          return

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -228,12 +228,23 @@ contains
       end if
 
       if (comparereal(input%data_value, dmiss) /= 0) then
-         if (len_trim(input%forcing_file_type) > 0 .or. len_trim(input%forcing_file) > 0) then
+         if (len_trim(input%forcing_file) > 0) then
             write (msgbuf, '(5a)') 'Invalid block in file ''', trimmed_file_name, ''': [', trimmed_group_name, &
-                  ']. Fields ''dataFileType'' and ''dataFile'' cannot be combined with ''dataValue''.'
+               ']. Fields ''dataFile'' and ''dataValue'' cannot be combined.'
             call err_flush()
             return
          end if
+
+         if (len_trim(input%forcing_file_type) > 0) then ! Filetype is optional, but if supplied must equal datavalue
+            input%filetype = convert_file_type_string_to_integer(input%forcing_file_type)
+            if (input%filetype /= DATAVALUE) then
+               write (msgbuf, '(7a)') 'Invalid block in file ''', trimmed_file_name, ''': [', trimmed_group_name, &
+                  ']. dataFileType ''', trim(input%forcing_file_type), ''' cannot be used with ''dataValue''; expected ''datavalue''.'
+               call err_flush()
+               return
+            end if
+         end if
+
          input%forcing_file_type = "datavalue"
          input%filetype = DATAVALUE
       else
@@ -249,6 +260,13 @@ contains
          if (input%filetype == FILE_TYPE_UNKNOWN) then
             write (msgbuf, '(7a)') 'Field ''dataFileType'' has unknown value ''', trim(input%forcing_file_type), ''' in file ''', &
                trimmed_file_name, ''': [', trimmed_group_name, ']. Field ''dataFileType'' has unknown value.'
+            call err_flush()
+            return
+         end if
+
+         if (input%filetype == DATAVALUE) then
+            write (msgbuf, '(5a)') 'Invalid block in file ''', trim(file_name), ''': [', trim(group_name), &
+               ']. dataFileType ''datavalue'' requires ''dataValue''.'
             call err_flush()
             return
          end if

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -328,24 +328,23 @@ contains
 
    end function validate_spatial_field_input
 
+   !> Checks whether a forcing file extension is compatible with its file type.
    function file_extension_conflicts_with_type(forcing_file, file_type) result(conflicts)
       use string_module, only: str_tolower
       use timespace_parameters, only: FIELD1D, ARCINFO, BCASCII, CURVI, GEOTIFF, NCGRID, INSIDE_POLYGON, &
                        SAMPLE => TRIANGULATION, SPIDERWEB, UNIFORM, UNIMAGDIR
-      character(len=*), intent(in) :: forcing_file
-      integer, intent(in) :: file_type
-      logical :: conflicts
+      character(len=*), intent(in) :: forcing_file !< Name of the forcing file to validate.
+      integer, intent(in) :: file_type !< File type enum returned by convert_file_type_string_to_integer.
+      logical :: conflicts !< `.true.` when the file extension is incompatible with file_type.
 
       integer :: dot_pos
       character(len=16) :: ext
 
+      ext = ''
       dot_pos = index(trim(forcing_file), '.', back=.true.)
-      if (dot_pos == 0) then
-         conflicts = .true.
-         return
+      if (dot_pos > 0) then
+         ext = str_tolower(trim(forcing_file(dot_pos:)))
       end if
-
-      ext = str_tolower(trim(forcing_file(dot_pos:)))
 
       select case (file_type)
       case (FIELD1D)

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/m_spatial_field.f90
@@ -253,7 +253,7 @@ contains
             return
          end if
    
-         if (file_extension_conflicts_with_type(input%forcing_file, input%forcing_file_type)) then
+         if (file_extension_conflicts_with_type(input%forcing_file, input%filetype)) then
             write (msgbuf, '(9a)') 'Invalid block in file ''', trim(file_name), ''': [', trim(group_name), &
                ']. forcingFile ''', trim(input%forcing_file), ''' has a file extension that conflicts with forcingFileType ''', &
                trim(input%forcing_file_type), '''.'
@@ -328,30 +328,52 @@ contains
 
    end function validate_spatial_field_input
 
-   function file_extension_conflicts_with_type(forcing_file, forcing_file_type) result(conflicts)
+   function file_extension_conflicts_with_type(forcing_file, file_type) result(conflicts)
       use string_module, only: str_tolower
+      use timespace_parameters, only: FIELD1D, ARCINFO, BCASCII, CURVI, GEOTIFF, NCGRID, INSIDE_POLYGON, &
+                       SAMPLE => TRIANGULATION, SPIDERWEB, UNIFORM, UNIMAGDIR
       character(len=*), intent(in) :: forcing_file
-      character(len=*), intent(in) :: forcing_file_type
+      integer, intent(in) :: file_type
       logical :: conflicts
 
       integer :: dot_pos
       character(len=16) :: ext
 
-      conflicts = .false.
       dot_pos = index(trim(forcing_file), '.', back=.true.)
-      if (dot_pos == 0) return
+      if (dot_pos == 0) then
+         conflicts = .true.
+         return
+      end if
 
       ext = str_tolower(trim(forcing_file(dot_pos:)))
 
-      select case (ext)
-      case ('.nc')
-         conflicts = str_tolower(trim(forcing_file_type)) /= 'netcdf'
-      case ('.tif', '.tiff')
-         conflicts = str_tolower(trim(forcing_file_type)) /= 'geotiff'
-      case ('.spw')
-         conflicts = str_tolower(trim(forcing_file_type)) /= 'spiderweb'
-      case ('.pol')
-         conflicts = str_tolower(trim(forcing_file_type)) /= 'polygon'
+      select case (file_type)
+      case (FIELD1D)
+         conflicts = ext /= '.ini'
+      case (ARCINFO)
+         conflicts = .not. any(ext == [character(len=16) :: '.asc', '.amu', '.amv', '.amp', '.amh', '.amt', '.amc', &
+                                                           '.ams', '.amr', '.sdu', '.aice', '.hice'])
+      case (BCASCII)
+         conflicts = ext /= '.bc'
+      case (CURVI)
+         conflicts = .not. any(ext == [character(len=16) :: '.amu', '.amv', '.amp', '.amh', '.amt', '.amc', '.ams', &
+                                                           '.amr', '.sdu', '.aice', '.hice', '.apwxwy', '.hac', '.tem'])
+      case (GEOTIFF)
+         conflicts = .not. any(ext == [character(len=16) :: '.tif', '.tiff'])
+      case (NCGRID)
+         conflicts = ext /= '.nc'
+      case (INSIDE_POLYGON)
+         conflicts = .not. any(ext == [character(len=16) :: '.pol', '.pli', '.pliz'])
+      case (SAMPLE)
+         conflicts = .not. any(ext == [character(len=16) :: '.xyz', '.xyb'])
+      case (SPIDERWEB)
+         conflicts = ext /= '.spw'
+      case (UNIFORM)
+         conflicts = .not. any(ext == [character(len=16) :: '.tim', '.tem'])
+      case (UNIMAGDIR)
+         conflicts = .not. any(ext == [character(len=16) :: '.tim', '.wnd'])
+      case default
+         conflicts = .true.
       end select
 
    end function file_extension_conflicts_with_type

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/time_space_parameters.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_kernel/timespace/time_space_parameters.f90
@@ -173,6 +173,8 @@ contains
          file_type = CURVI
       case ('geotiff')
          file_type = GEOTIFF
+      case ('datavalue')
+         file_type = DATAVALUE
       case ('netcdf')
          file_type = NCGRID
       case ('polygon')

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field.f90
@@ -128,6 +128,34 @@ contains
    end subroutine test_validate_file_type_extension_mismatch
    !$f90tw)
 
+   !$f90tw TESTCODE(TEST, test_init_spatial_field, test_validate_supported_file_type_extensions, test_validate_supported_file_type_extensions,
+   subroutine test_validate_supported_file_type_extensions() bind(C)
+      character(len=16), parameter :: file_types(11) = [character(len=16) :: &
+         '1dfield', 'arcinfo', 'bcascii', 'curvigrid', 'geotiff', 'netcdf', 'polygon', 'sample', 'spiderweb', 'uniform', 'unimagdir']
+      character(len=16), parameter :: extensions(11) = [character(len=16) :: &
+         '.ini', '.aice', '.bc', '.apwxwy', '.tiff', '.nc', '.pliz', '.xyb', '.spw', '.tem', '.wnd']
+      type(t_spatial_field_input) :: input
+      integer :: i
+
+      do i = 1, size(file_types)
+         call make_test_input(input, forcing_file='dummy'//trim(extensions(i)), forcing_file_type=trim(file_types(i)), &
+                              interpolation_method='linearSpaceTime')
+         call f90_expect_true(validate_spatial_field_input(input, EXT_FILENAME, GROUP_NAME, BASE_DIR), &
+                              trim(file_types(i))//' should accept '//trim(extensions(i)))
+      end do
+   end subroutine test_validate_supported_file_type_extensions
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_field, test_validate_unknown_file_extension, test_validate_unknown_file_extension,
+   subroutine test_validate_unknown_file_extension() bind(C)
+      type(t_spatial_field_input) :: input
+
+      call make_test_input(input, forcing_file='dummy.unsupported')
+      call f90_expect_false(validate_spatial_field_input(input, EXT_FILENAME, GROUP_NAME, BASE_DIR), &
+                            "validation should fail for an extension unsupported by forcingFileType")
+   end subroutine test_validate_unknown_file_extension
+   !$f90tw)
+
    !$f90tw TESTCODE(TEST, test_init_spatial_field, test_validate_nonexistent_target_mask_file, test_validate_nonexistent_target_mask_file,
    !> Specifying a targetMaskFile= that does not exist on disk must fail.
    !! The inquire() branch inside validate_spatial_field_input is never reached

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field.f90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/test/src/test_init_spatial_field.f90
@@ -2,7 +2,7 @@ module test_init_spatial_field
    use assertions_gtest
    use m_spatial_field, only: t_spatial_field_input, validate_spatial_field_input
    use m_wind, only: jaQext
-   use timespace_parameters, only: OPERAND_ADD
+   use timespace_parameters, only: DATAVALUE, OPERAND_ADD
    use unstruc_messages, only: threshold_abort
    use messagehandling, only: LEVEL_FATAL, LEVEL_WARN, GetMessageCount, GetMessage_MH, SetMessageHandling
    use m_alloc, only: realloc, reallocP
@@ -202,6 +202,52 @@ contains
 
       call f90_assert_true(success, cstr("forcing_file_type and forcing_file may be empty if data_value is supplied"))
    end subroutine test_validate_spatial_field_input__data_value
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_field,
+   !$f90tw test_validate_data_value_with_datavalue_type_succeeds, test_validate_data_value_with_datavalue_type_succeeds,
+   subroutine test_validate_data_value_with_datavalue_type_succeeds() bind(C)
+      type(t_spatial_field_input) :: input
+      logical :: success
+
+      call make_test_input(input, data_value=0.875_dp, forcing_file_type='datavalue', forcing_file='')
+
+      success = validate_spatial_field_input(input, EXT_FILENAME, GROUP_NAME, BASE_DIR)
+
+      call f90_expect_true(success, "dataValue may explicitly use dataFileType=datavalue")
+      call f90_expect_eq(input%filetype, DATAVALUE)
+   end subroutine test_validate_data_value_with_datavalue_type_succeeds
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_field,
+   !$f90tw test_validate_data_value_with_file_type_fails, test_validate_data_value_with_file_type_fails,
+   subroutine test_validate_data_value_with_file_type_fails() bind(C)
+      type(t_spatial_field_input) :: input
+
+      call make_test_input(input, data_value=0.875_dp, forcing_file_type="not_a_file_type", forcing_file="")
+
+      call f90_expect_false(validate_spatial_field_input(input, EXT_FILENAME, GROUP_NAME, BASE_DIR), &
+                            "dataValue cannot be combined with dataFileType")
+   end subroutine test_validate_data_value_with_file_type_fails
+   !$f90tw)
+
+   !$f90tw TESTCODE(TEST, test_init_spatial_field,
+   !$f90tw test_validate_unknown_file_type_message, test_validate_unknown_file_type_message,
+   subroutine test_validate_unknown_file_type_message() bind(C)
+      type(t_spatial_field_input) :: input
+      integer :: log_level
+      character(len=512) :: message
+
+      call make_test_input(input, forcing_file_type="not_a_file_type")
+      threshold_abort = LEVEL_FATAL
+      call SetMessageHandling(write2screen=.false., useLog=.true., reset_counters=.true.)
+
+      call f90_expect_false(validate_spatial_field_input(input, EXT_FILENAME, GROUP_NAME, BASE_DIR), &
+                            "validation should reject an unknown dataFileType")
+      call f90_expect_eq(GetMessageCount(), 1)
+      log_level = GetMessage_MH(1, message)
+      call f90_expect_true(index(message, "Field 'dataFileType' has unknown value 'not_a_file_type'") > 0)
+   end subroutine test_validate_unknown_file_type_message
    !$f90tw)
 
    !$f90tw TESTCODE(TEST, test_init_spatial_field, test_resolve_parameter_target_unknown_quantity_returns_null, test_resolve_parameter_target_unknown_quantity_returns_null,


### PR DESCRIPTION
# What was done 

<a short description with bullets> 

- add info message when initializing spatial fields
- extend file extension conflict checker based on FM user manual
- error messages now report dataFileType etc instead of forcingFileType
- vibe coded two unit tests

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
UNST-10333
