### PR TITLE
Update the TestBench cases maxRunTimes based on the test case maximum runtime over the last 100 runs from teamcity

### DIFF
--- a/test/deltares_testbench/configs/dimr/dimr_dflowfm_full_scale_models_win64.xml
+++ b/test/deltares_testbench/configs/dimr/dimr_dflowfm_full_scale_models_win64.xml
@@ -255,6 +255,7 @@
     </testCase>
     <testCase name="e02_f150_c31_pudong-1d" ref="dimr_default">
       <path version="DVC">e02_dflowfm/f150_1d2d_acceptance_urban/c31_pudong-1d/dimr_model</path>
+      <maxRunTime>660</maxRunTime>
       <checks>
         <file name="dflowfm/DFM_OUTPUT_FlowFM/FlowFM_map.nc" type="netCDF">
           <parameters>
@@ -307,6 +308,7 @@
     </testCase>
     <testCase name="e02_f150_c34_additional_flow_analysis" ref="dimr_default">
       <path version="DVC">e02_dflowfm/f150_1d2d_acceptance_urban/c34_additional_flow_analysis/dimr_model</path>
+      <maxRunTime>480</maxRunTime>
       <checks>
         <file name="dflowfm/DFM_OUTPUT_FlowFM/FlowFM_map.nc" type="netCDF">
           <parameters>

--- a/test/deltares_testbench/configs/dimr/dimr_dflowfm_mormerge_lnx64.xml
+++ b/test/deltares_testbench/configs/dimr/dimr_dflowfm_mormerge_lnx64.xml
@@ -175,7 +175,7 @@
     </testCase>
     <testCase name="e123_f02_c01_trench_VanRijn1993_mormerge_e02_f22_c01" ref="dflowfm_default">
       <path version="DVC">e123_dflowfm-mormerge/f02_mergedtuser/c01_trench_VanRijn1993_mormerge_e02_f22_c01</path>
-
+      <maxRunTime>360</maxRunTime>
       <programs>
         <program ref="mormerge">
           <workingDirectory>merge</workingDirectory>
@@ -215,7 +215,6 @@
     </testCase>
     <testCase name="e123_f01_c02_trench_VanRijn1993_mormerge_parallel" ref="dflowfm_default">
       <path version="DVC">e123_dflowfm-mormerge/f01_general/c02_trench_VanRijn1993_mormerge_parallel</path>
-
       <maxRunTime>900</maxRunTime>
       <programs>
         <program ref="mormerge">

--- a/test/deltares_testbench/configs/dimr/dimr_dflowfm_mormerge_win64.xml
+++ b/test/deltares_testbench/configs/dimr/dimr_dflowfm_mormerge_win64.xml
@@ -160,7 +160,7 @@
     </testCase>
     <testCase name="e123_f02_c01_trench_VanRijn1993_mormerge_e02_f22_c01" ref="dflowfm_default">
       <path version="DVC">e123_dflowfm-mormerge/f02_mergedtuser/c01_trench_VanRijn1993_mormerge_e02_f22_c01</path>
-
+      <maxRunTime>360</maxRunTime>
       <programs>
         <program ref="mormerge">
           <workingDirectory>merge</workingDirectory>

--- a/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dpart_structured.xml
+++ b/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dpart_structured.xml
@@ -479,6 +479,7 @@ e05_f03_zlayers_c14_oil                   e05_part/f03_zlayers/c14_oil
         </testCase>
         <testCase name="e05_f03_zlayers_c02_tracer" ref="part_default">
                 <path version="DVC">e05_part/f03_zlayers/c02_tracer</path>
+                <maxRunTime>360</maxRunTime>
                 <checks>
                         <file name="tracer_outside.out" type="NUMBERTEXT">
                                 <skipline>|</skipline>
@@ -529,6 +530,7 @@ e05_f03_zlayers_c14_oil                   e05_part/f03_zlayers/c14_oil
         </testCase>
         <testCase name="e05_f03_zlayers_c11_oil" ref="part_default">
                 <path version="DVC">e05_part/f03_zlayers/c11_oil</path>
+                <maxRunTime>540</maxRunTime>
                 <checks>
                         <file name="oil_outside.out" type="NUMBERTEXT">
                                 <skipline>|</skipline>
@@ -603,6 +605,7 @@ e05_f03_zlayers_c14_oil                   e05_part/f03_zlayers/c14_oil
         </testCase>
         <testCase name="e05_f03_zlayers_c12_oil" ref="part_default">
                 <path version="DVC">e05_part/f03_zlayers/c12_oil</path>
+                <maxRunTime>540</maxRunTime>
                 <checks>
                         <file name="oil_outside.out" type="NUMBERTEXT">
                                 <skipline>|</skipline>
@@ -677,6 +680,7 @@ e05_f03_zlayers_c14_oil                   e05_part/f03_zlayers/c14_oil
         </testCase>
         <testCase name="e05_f03_zlayers_c13_oil" ref="part_default">
                 <path version="DVC">e05_part/f03_zlayers/c13_oil</path>
+                <maxRunTime>540</maxRunTime>
                 <checks>
                         <file name="oil_outside.out" type="NUMBERTEXT">
                                 <skipline>|</skipline>
@@ -751,6 +755,7 @@ e05_f03_zlayers_c14_oil                   e05_part/f03_zlayers/c14_oil
         </testCase>
         <testCase name="e05_f03_zlayers_c14_oil" ref="part_default">
                 <path version="DVC">e05_part/f03_zlayers/c14_oil</path>
+                <maxRunTime>540</maxRunTime>
                 <checks>
                         <file name="oil_outside.out" type="NUMBERTEXT">
                                 <skipline>|</skipline>

--- a/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dwaq.xml
+++ b/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dwaq.xml
@@ -1,7 +1,7 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
   <testCase name="e03_f02_c04_statistics" ref="dwaq_default">
     <path version="DVC">e03_waq/f02_hongkong/c04_statistics</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>960</maxRunTime>
     <checks>
       <file name="group2-test004.ada" type="NEFIS">
         <parameters name="DELWAQ_RESULTS">
@@ -45,6 +45,7 @@
   </testCase>
   <testCase name="e03_f02_c01_eutrophication" ref="dwaq_default">
     <path version="DVC">e03_waq/f02_hongkong/c01_eutrophication</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="group2-test001.ada" type="NEFIS">
         <parameters name="DELWAQ_RESULTS">
@@ -2410,6 +2411,7 @@
   </testCase>
   <testCase name="e03_f01_c38_test038" ref="dwaq_default">
     <path version="DVC">e03_waq/f01_general/c38_test038</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="f34_dynamo.ada" type="NEFIS">
         <parameters name="DELWAQ_RESULTS">

--- a/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dwaq_dpart_combination.xml
+++ b/test/deltares_testbench/configs/dwaq_dpart/include/test_configs/dwaq_dpart_combination.xml
@@ -2,7 +2,7 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
   <testCase name="e03_f18_c01_sigma_layers" ref="dwaq_default">
     <path version="DVC">e03_waq/f18_waq_part_combined_run/c01_sigma_layers</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <!-- NOTE: no relative tolerance! The combination does not give the right insight at the moment -->
       <!-- Absolute values are fairly small -->
@@ -59,7 +59,7 @@
   </testCase>
   <testCase name="e03_f18_c01a_sigma_layers_track_vs_alone" ref="dwaq_default">
     <path version="DVC">e03_waq/f18_waq_part_combined_run/c01a_sigma_layers_track_vs_alone</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <!-- NOTE: the reference here is a run with delpar alone, delwaq takeover time was increased beyond the time of the run -->
       <file name="trk-prt01.dat" type="NEFIS">

--- a/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow.xml
@@ -414,7 +414,7 @@
   </testCase>
   <testCase name="e01_f01_c26-abudhabi" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f01_general/c26-abudhabi</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="trih-ove.dat" type="NEFIS">
         <parameters name="his-series">
@@ -513,8 +513,7 @@
   </testCase>
   <testCase name="e01_f01_c30-64bit" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f01_general/c30-64bit</path>
-      <maxRunTime>1020</maxRunTime>
-
+    <maxRunTime>2460</maxRunTime>
     <checks>
       <file name="trih-zd10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -921,7 +920,7 @@
   </testCase>
   <testCase name="e01_f03_c03-disch" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f03_original/c03-disch</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-p01.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1091,8 +1090,7 @@
   </testCase>
   <testCase name="e01_f03_c13-foumod_scs" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f03_original/c13-foumod_scs</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-test_foumod.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1534,7 +1532,6 @@
   <testCase name="e01_f06_c10-bijker" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f06_ols/c10-bijker</path>
     <maxRunTime>600</maxRunTime>
-
     <checks>
       <file name="trih-t10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1554,7 +1551,7 @@
   </testCase>
   <testCase name="e01_f06_c11-rijn1993" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f06_ols/c11-rijn1993</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-t10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1574,7 +1571,7 @@
   </testCase>
   <testCase name="e01_f06_c12-vanrijn_temp" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f06_ols/c12-vanrijn_temp</path>
-    <maxRunTime>480</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-T01.dat" type="NEFIS">
         <parameters name="his-series">
@@ -2260,7 +2257,7 @@
   </testCase>
   <testCase name="e01_f10_c29-z_ini" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f10_dd/c29-z_ini</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-scadd.dat" type="NEFIS">
         <parameters name="his-series">
@@ -2439,6 +2436,7 @@
   </testCase>
   <testCase name="e01_f11_c09-q09" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f11_qhqtot/c09-q09</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-q09.dat" type="NEFIS">
         <parameters name="his-series">
@@ -2458,6 +2456,7 @@
   </testCase>
   <testCase name="e01_f11_c10-q10" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f11_qhqtot/c10-q10</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-q10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -2477,7 +2476,7 @@
   </testCase>
   <testCase name="e01_f11_c11-qtot" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f11_qhqtot/c11-qtot</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-cp2D.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3341,8 +3340,7 @@
   </testCase>
   <testCase name="e01_f22_c01-graded" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f22_graded/c01-graded</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1140</maxRunTime>
     <checks>
       <file name="trih-fhy.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3534,8 +3532,7 @@
   </testCase>
   <testCase name="e01_f25_c03-estuarium_equid" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f25_bottfric_2D_3D/c03-estuarium_equid</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="trih-est.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3555,8 +3552,7 @@
   </testCase>
   <testCase name="e01_f25_c04-estuarium_log" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f25_bottfric_2D_3D/c04-estuarium_log</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1800</maxRunTime>
     <checks>
       <file name="trih-est.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3616,7 +3612,7 @@
   </testCase>
   <testCase name="e01_f26_c01-vRijn84" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f26_dunes/c01-vRijn84</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="trih-t13.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3772,6 +3768,7 @@
   </testCase>
   <testCase name="e01_f27_c01-temperature_sigma_1layer" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c01-temperature_sigma_1layer</path>
+    <maxRunTime>660</maxRunTime>
     <checks>
       <file name="trih-tts.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3793,6 +3790,7 @@
   </testCase>
   <testCase name="e01_f27_c02-temperature_sigma_10layers" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c02-temperature_sigma_10layers</path>
+    <maxRunTime>960</maxRunTime>
     <checks>
       <file name="trih-tts.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3814,6 +3812,7 @@
   </testCase>
   <testCase name="e01_f27_c03-temperature_z_1layer" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c03-temperature_z_1layer</path>
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="trih-ttz.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3835,6 +3834,7 @@
   </testCase>
   <testCase name="e01_f27_c04-temperature_z_10layers" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c04-temperature_z_10layers</path>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-ttz.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3913,8 +3913,7 @@
   </testCase>
   <testCase name="e01_f27_c25-z_upper_pierce_slope_limiter" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c25-z_upper_pierce_slope_limiter</path>
-      <maxRunTime>3000</maxRunTime>
-
+    <maxRunTime>3720</maxRunTime>
     <checks>
       <file name="trih-b11.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3956,7 +3955,7 @@
   </testCase>
   <testCase name="e01_f27_c27-turb_bound_z" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c27-turb_bound_z</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-Stal-2dv_15.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3976,7 +3975,7 @@
   </testCase>
   <testCase name="e01_f27_c28-turb_bound_z_ydir" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f27_zmodel_updates/c28-turb_bound_z_ydir</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-Stal-2dv_20.dat" type="NEFIS">
         <parameters name="his-series">
@@ -3996,7 +3995,7 @@
   </testCase>
   <testCase name="e01_f28_c01-fluff_test" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c01-fluff_test</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-tst.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4022,7 +4021,7 @@
   </testCase>
   <testCase name="e01_f28_c02-fluff_type1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c02-fluff_type1</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-chan_fluff1.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4048,7 +4047,7 @@
   </testCase>
   <testCase name="e01_f28_c03-fluff_type2" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c03-fluff_type2</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4074,7 +4073,7 @@
   </testCase>
   <testCase name="e01_f28_c04-fluff_type2_spacevardepeff" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c04-fluff_type2_spacevardepeff</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2_depeff.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4100,7 +4099,7 @@
   </testCase>
   <testCase name="e01_f28_c05-fluff_2layers_type1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c05-fluff_2layers_type1</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff1.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4126,7 +4125,7 @@
   </testCase>
   <testCase name="e01_f28_c06-fluff_2layers_type2" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c06-fluff_2layers_type2</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4152,6 +4151,7 @@
   </testCase>
   <testCase name="e01_f29_c01-trench-subsidence" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c01-trench-subsidence</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4173,6 +4173,7 @@
   </testCase>
   <testCase name="e01_f29_c02-trench-subsidence_s1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c02-trench-subsidence_s1</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4194,6 +4195,7 @@
   </testCase>
   <testCase name="e01_f29_c03-trench-uplift" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c03-trench-uplift</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4215,6 +4217,7 @@
   </testCase>
   <testCase name="e01_f29_c04-trench-uplift_s1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c04-trench-uplift_s1</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4236,6 +4239,7 @@
   </testCase>
   <testCase name="e01_f29_c05-tsunami-banda-aceh_original_model" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c05-tsunami-banda-aceh_original_model</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-tsu5d.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4255,6 +4259,7 @@
   </testCase>
   <testCase name="e01_f29_c06-tsunami-banda-aceh_instant_uplift" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c06-tsunami-banda-aceh_instant_uplift</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-tsu5d.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4274,6 +4279,7 @@
   </testCase>
   <testCase name="e01_f29_c07-tsunami-banda-aceh_instant_4areas" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c07-tsunami-banda-aceh_instant_4areas</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-tsu5d.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4293,6 +4299,7 @@
   </testCase>
   <testCase name="e01_f29_c08-tsunami-banda-aceh_slow_4areas" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c08-tsunami-banda-aceh_slow_4areas</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-tsu5d.dat" type="NEFIS">
         <parameters name="his-series">
@@ -4590,7 +4597,7 @@
   </testCase>
   <testCase name="e01_f50_c31200_Standing-wave_x" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f50_validation_analytical/c31200_Standing-wave_x</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="trim-3d_wav_x.dat" type="NEFIS">
         <parameters name="map-series">
@@ -4603,6 +4610,7 @@
   </testCase>
   <testCase name="e01_f50_c31201_Standing-wave_y" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f50_validation_analytical/c31201_Standing-wave_y</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="trim-3d_wav_y.dat" type="NEFIS">
         <parameters name="map-series">
@@ -4615,6 +4623,7 @@
   </testCase>
   <testCase name="e01_f50_c31202_Standing-wave_xy" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f50_validation_analytical/c31202_Standing-wave_xy</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trim-3d_wav_xy.dat" type="NEFIS">
         <parameters name="map-series">
@@ -4987,7 +4996,7 @@
   </testCase>
   <testCase name="e01_f51_c32800_Two_dimensional_dambreak_july2007_wet" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f51_validation_laboratory/c32800_Two_dimensional_dambreak_july2007_wet</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="trim-2Ddbw.dat" type="NEFIS">
         <parameters name="map-series">
@@ -5000,7 +5009,7 @@
   </testCase>
   <testCase name="e01_f51_c32801_Two_dimensional_dambreak_july2007_dry" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f51_validation_laboratory/c32801_Two_dimensional_dambreak_july2007_dry</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trim-2Ddbd.dat" type="NEFIS">
         <parameters name="map-series">
@@ -5048,7 +5057,7 @@
   </testCase>
   <testCase name="e01_f52_c33101-Curved_back_channel_Curvilinear_3D" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33101-Curved_back_channel_Curvilinear_3D</path>
-
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="trih-bend.dat" type="NEFIS">
         <parameters name="his-series">
@@ -5068,7 +5077,7 @@
   </testCase>
   <testCase name="e01_f52_c33120-Curved_back_channel_Rectangular_2DH" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33120-Curved_back_channel_Rectangular_2DH</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-rect_2DH.dat" type="NEFIS">
         <parameters name="his-series">
@@ -5090,7 +5099,7 @@
   </testCase>
   <testCase name="e01_f52_c33121-Curved_back_channel_Rectangular_3D" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33121-Curved_back_channel_Rectangular_3D</path>
-
+    <maxRunTime>1320</maxRunTime>
     <checks>
       <file name="trih-rect_3D.dat" type="NEFIS">
         <parameters name="his-series">
@@ -5172,7 +5181,7 @@
   </testCase>
   <testCase name="e01_f52_c33800-Wind-over-a-schematized-lake" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33800-Wind-over-a-schematized-lake</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-v03.dat" type="NEFIS">
         <parameters name="his-series">
@@ -5210,7 +5219,7 @@
   </testCase>
   <testCase name="e01_f52_c33900-Tsunami_Okushiri_cyclic" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33900-Tsunami_Okushiri_cyclic</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-qc9.dat" type="NEFIS">
         <parameters name="his-series">
@@ -5230,6 +5239,7 @@
   </testCase>
   <testCase name="e01_f52_c33901-Tsunami_Okushiri_flood" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f52_validation_schematic/c33901-Tsunami_Okushiri_flood</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-q09.dat" type="NEFIS">
         <parameters name="his-series">

--- a/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel.xml
@@ -162,7 +162,7 @@
   </testCase>
   <testCase name="e01_f01_c26-abudhabi" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f01_general/c26-abudhabi</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="trih-ove.dat" type="NEFIS">
         <parameters name="his-series">
@@ -261,8 +261,7 @@
   </testCase>
   <testCase name="e01_f01_c30-64bit" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f01_general/c30-64bit</path>
-      <maxRunTime>1020</maxRunTime>
-
+    <maxRunTime>2460</maxRunTime>
     <checks>
       <file name="trih-zd10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -727,7 +726,7 @@
   </testCase>
   <testCase name="e01_f06_c12-vanrijn_temp" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f06_ols/c12-vanrijn_temp</path>
-      <maxRunTime>540</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="trih-T01.dat" type="NEFIS">
         <parameters name="his-series">
@@ -847,6 +846,7 @@
   </testCase>
   <testCase name="e01_f11_c09-q09" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f11_qhqtot/c09-q09</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-q09.dat" type="NEFIS">
         <parameters name="his-series">
@@ -866,6 +866,7 @@
   </testCase>
   <testCase name="e01_f11_c10-q10" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f11_qhqtot/c10-q10</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-q10.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1136,8 +1137,7 @@
   </testCase>
   <testCase name="e01_f25_c03-estuarium_equid" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f25_bottfric_2D_3D/c03-estuarium_equid</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="trih-est.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1157,8 +1157,7 @@
   </testCase>
   <testCase name="e01_f25_c04-estuarium_log" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f25_bottfric_2D_3D/c04-estuarium_log</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1800</maxRunTime>
     <checks>
       <file name="trih-est.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1199,7 +1198,7 @@
   </testCase>
   <testCase name="e01_f28_c01-fluff_test" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c01-fluff_test</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="trih-tst.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1225,7 +1224,7 @@
   </testCase>
   <testCase name="e01_f28_c02-fluff_type1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c02-fluff_type1</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-chan_fluff1.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1251,7 +1250,7 @@
   </testCase>
   <testCase name="e01_f28_c03-fluff_type2" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c03-fluff_type2</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1277,7 +1276,7 @@
   </testCase>
   <testCase name="e01_f28_c04-fluff_type2_spacevardepeff" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c04-fluff_type2_spacevardepeff</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2_depeff.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1303,7 +1302,7 @@
   </testCase>
   <testCase name="e01_f28_c05-fluff_2layers_type1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c05-fluff_2layers_type1</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff1.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1329,7 +1328,7 @@
   </testCase>
   <testCase name="e01_f28_c06-fluff_2layers_type2" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f28_fluff/c06-fluff_2layers_type2</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="trih-chan_fluff2.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1355,6 +1354,7 @@
   </testCase>
   <testCase name="e01_f29_c01-trench-subsidence" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c01-trench-subsidence</path>
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1378,6 +1378,7 @@
   </testCase>
   <testCase name="e01_f29_c02-trench-subsidence_s1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c02-trench-subsidence_s1</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1401,6 +1402,7 @@
   </testCase>
   <testCase name="e01_f29_c03-trench-uplift" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c03-trench-uplift</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">
@@ -1424,6 +1426,7 @@
   </testCase>
   <testCase name="e01_f29_c04-trench-uplift_s1" ref="flow2d3d_default">
     <path version="DVC">e01_d3dflow/f29_subsidence/c04-trench-uplift_s1</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="trih-flu.dat" type="NEFIS">
         <parameters name="his-series">

--- a/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel_red.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_hp_cases_flow_parallel_red.xml
@@ -400,6 +400,7 @@
 		</testCase>
 		<testCase name="e01_f29_c05-tsunami-banda-aceh_original_model" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c05-tsunami-banda-aceh_original_model</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -421,6 +422,7 @@
 		</testCase>
 		<testCase name="e01_f29_c06-tsunami-banda-aceh_instant_uplift" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c06-tsunami-banda-aceh_instant_uplift</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -442,6 +444,7 @@
 		</testCase>
 		<testCase name="e01_f29_c07-tsunami-banda-aceh_instant_4areas" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c07-tsunami-banda-aceh_instant_4areas</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -463,6 +466,7 @@
 		</testCase>
 		<testCase name="e01_f29_c08-tsunami-banda-aceh_slow_4areas" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c08-tsunami-banda-aceh_slow_4areas</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">

--- a/test/deltares_testbench/configs/include/delft3d4_sp_cases.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_sp_cases.xml
@@ -202,8 +202,7 @@
 		</testCase>
 		<testCase name="e01_f01_c30-64bit" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f01_general/c30-64bit</path>
-      <maxRunTime>1020</maxRunTime>
-			
+			<maxRunTime>2460</maxRunTime>
 			<checks>
 				<file name="trih-zd10.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -740,7 +739,7 @@
 		</testCase>
 		<testCase name="e01_f06_c10-bijker" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f06_ols/c10-bijker</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-t10.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -760,7 +759,7 @@
 		</testCase>
 		<testCase name="e01_f06_c11-rijn1993" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f06_ols/c11-rijn1993</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-t10.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -780,8 +779,7 @@
 		</testCase>
 		<testCase name="e01_f06_c12-vanrijn_temp" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f06_ols/c12-vanrijn_temp</path>
-      <maxRunTime>540</maxRunTime>
-			
+			<maxRunTime>900</maxRunTime>
 			<checks>
 				<file name="trih-T01.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -1356,7 +1354,7 @@
 		</testCase>
 		<testCase name="e01_f11_c09-q09" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f11_qhqtot/c09-q09</path>
-			
+			<maxRunTime>360</maxRunTime>
 			<checks>
 				<file name="trih-q09.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -1376,7 +1374,7 @@
 		</testCase>
 		<testCase name="e01_f11_c10-q10" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f11_qhqtot/c10-q10</path>
-			
+			<maxRunTime>360</maxRunTime>
 			<checks>
 				<file name="trih-q10.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -1937,8 +1935,7 @@
 		</testCase>
 		<testCase name="e01_f25_c04-estuarium_log" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f25_bottfric_2D_3D/c04-estuarium_log</path>
-      <maxRunTime>900</maxRunTime>
-			
+			<maxRunTime>1800</maxRunTime>
 			<checks>
 				<file name="trih-est.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2019,8 +2016,7 @@
 		</testCase>
 		<testCase name="e01_f27_c27-turb_bound_z" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c27-turb_bound_z</path>
-      <maxRunTime>900</maxRunTime>
-			
+			<maxRunTime>900</maxRunTime>
 			<checks>
 				<file name="trih-Stal-2dv_15.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2040,7 +2036,7 @@
 		</testCase>
 		<testCase name="e01_f27_c28-turb_bound_z_ydir" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c28-turb_bound_z_ydir</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-Stal-2dv_20.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2060,7 +2056,7 @@
 		</testCase>
 		<testCase name="e01_f28_c02-fluff_type1" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c02-fluff_type1</path>
-			
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-chan_fluff1.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2086,7 +2082,7 @@
 		</testCase>
 		<testCase name="e01_f28_c03-fluff_type2" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c03-fluff_type2</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-chan_fluff2.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2112,7 +2108,7 @@
 		</testCase>
 		<testCase name="e01_f28_c04-fluff_type2_spacevardepeff" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c04-fluff_type2_spacevardepeff</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-chan_fluff2_depeff.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2138,7 +2134,7 @@
 		</testCase>
 		<testCase name="e01_f28_c06-fluff_2layers_type2" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c06-fluff_2layers_type2</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-chan_fluff2.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -2424,7 +2420,7 @@
 		</testCase>
 		<testCase name="e01_f50_c31202_Standing-wave_xy" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f50_validation_analytical/c31202_Standing-wave_xy</path>
-			
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trim-3d_wav_xy.dat" type="NEFIS">
 					<parameters name="map-series">

--- a/test/deltares_testbench/configs/include/delft3d4_sp_cases_red.xml
+++ b/test/deltares_testbench/configs/include/delft3d4_sp_cases_red.xml
@@ -384,7 +384,7 @@
 		</testCase>
 		<testCase name="e01_f01_c26-abudhabi" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f01_general/c26-abudhabi</path>
-			
+			<maxRunTime>420</maxRunTime>
 			<checks>
 				<file name="trih-ove.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -699,7 +699,7 @@
 		</testCase>
 		<testCase name="e01_f03_c03-disch" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f03_original/c03-disch</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-p01.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -869,8 +869,7 @@
 		</testCase>
 		<testCase name="e01_f03_c13-foumod_scs" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f03_original/c13-foumod_scs</path>
-			
-      <maxRunTime>900</maxRunTime>
+			<maxRunTime>900</maxRunTime>
 			<checks>
 				<file name="trih-test_foumod.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -3551,7 +3550,7 @@
 		</testCase>
 		<testCase name="e01_f10_c29-z_ini" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f10_dd/c29-z_ini</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-scadd.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -3652,8 +3651,7 @@
 		</testCase>
 		<testCase name="e01_f11_c11-qtot" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f11_qhqtot/c11-qtot</path>
-      <maxRunTime>900</maxRunTime>
-			
+			<maxRunTime>900</maxRunTime>
 			<checks>
 				<file name="trih-cp2D.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4321,8 +4319,7 @@
 		</testCase>
 		<testCase name="e01_f22_c01-graded" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f22_graded/c01-graded</path>
-      <maxRunTime>720</maxRunTime>
-			
+			<maxRunTime>1140</maxRunTime>
 			<checks>
 				<file name="trih-fhy.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4422,8 +4419,7 @@
 		</testCase>
 		<testCase name="e01_f25_c03-estuarium_equid" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f25_bottfric_2D_3D/c03-estuarium_equid</path>
-      <maxRunTime>900</maxRunTime>
-			
+			<maxRunTime>1260</maxRunTime>
 			<checks>
 				<file name="trih-est.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4483,7 +4479,7 @@
 		</testCase>
 		<testCase name="e01_f26_c01-vRijn84" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f26_dunes/c01-vRijn84</path>
-			
+			<maxRunTime>420</maxRunTime>
 			<checks>
 				<file name="trih-t13.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4639,7 +4635,7 @@
 		</testCase>
 		<testCase name="e01_f27_c01-temperature_sigma_1layer" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c01-temperature_sigma_1layer</path>
-			
+			<maxRunTime>660</maxRunTime>
 			<checks>
 				<file name="trih-tts.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4661,7 +4657,7 @@
 		</testCase>
 		<testCase name="e01_f27_c02-temperature_sigma_10layers" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c02-temperature_sigma_10layers</path>
-			
+			<maxRunTime>960</maxRunTime>
 			<checks>
 				<file name="trih-tts.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4683,7 +4679,7 @@
 		</testCase>
 		<testCase name="e01_f27_c03-temperature_z_1layer" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c03-temperature_z_1layer</path>
-			
+			<maxRunTime>720</maxRunTime>
 			<checks>
 				<file name="trih-ttz.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4705,7 +4701,7 @@
 		</testCase>
 		<testCase name="e01_f27_c04-temperature_z_10layers" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c04-temperature_z_10layers</path>
-			
+			<maxRunTime>900</maxRunTime>
 			<checks>
 				<file name="trih-ttz.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -4979,8 +4975,7 @@
 		</testCase>
 		<testCase name="e01_f27_c25-z_upper_pierce_slope_limiter" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f27_zmodel_updates/c25-z_upper_pierce_slope_limiter</path>
-      <maxRunTime>3000</maxRunTime>
-			
+			<maxRunTime>3720</maxRunTime>
 			<checks>
 				<file name="trih-b11.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5002,7 +4997,7 @@
 		</testCase>
 		<testCase name="e01_f28_c01-fluff_test" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c01-fluff_test</path>
-			
+			<maxRunTime>360</maxRunTime>
 			<checks>
 				<file name="trih-tst.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5028,7 +5023,7 @@
 		</testCase>
 		<testCase name="e01_f28_c05-fluff_2layers_type1" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f28_fluff/c05-fluff_2layers_type1</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-chan_fluff1.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5054,6 +5049,7 @@
 		</testCase>
 		<testCase name="e01_f29_c01-trench-subsidence" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c01-trench-subsidence</path>
+			<maxRunTime>600</maxRunTime>
 			<checks>
 				<file name="trih-flu.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5075,6 +5071,7 @@
 		</testCase>
 		<testCase name="e01_f29_c02-trench-subsidence_s1" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c02-trench-subsidence_s1</path>
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-flu.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5096,6 +5093,7 @@
 		</testCase>
 		<testCase name="e01_f29_c03-trench-uplift" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c03-trench-uplift</path>
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-flu.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5117,6 +5115,7 @@
 		</testCase>
 		<testCase name="e01_f29_c04-trench-uplift_s1" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c04-trench-uplift_s1</path>
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-flu.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5138,6 +5137,7 @@
 		</testCase>
 		<testCase name="e01_f29_c05-tsunami-banda-aceh_original_model" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c05-tsunami-banda-aceh_original_model</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5157,6 +5157,7 @@
 		</testCase>
 		<testCase name="e01_f29_c06-tsunami-banda-aceh_instant_uplift" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c06-tsunami-banda-aceh_instant_uplift</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5176,6 +5177,7 @@
 		</testCase>
 		<testCase name="e01_f29_c07-tsunami-banda-aceh_instant_4areas" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c07-tsunami-banda-aceh_instant_4areas</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5195,6 +5197,7 @@
 		</testCase>
 		<testCase name="e01_f29_c08-tsunami-banda-aceh_slow_4areas" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f29_subsidence/c08-tsunami-banda-aceh_slow_4areas</path>
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trih-tsu5d.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5321,7 +5324,7 @@
 		</testCase>
 		<testCase name="e01_f50_c31200_Standing-wave_x" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f50_validation_analytical/c31200_Standing-wave_x</path>
-			
+			<maxRunTime>600</maxRunTime>
 			<checks>
 				<file name="trim-3d_wav_x.dat" type="NEFIS">
 					<parameters name="map-series">
@@ -5334,7 +5337,7 @@
 		</testCase>
 		<testCase name="e01_f50_c31201_Standing-wave_y" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f50_validation_analytical/c31201_Standing-wave_y</path>
-			
+			<maxRunTime>600</maxRunTime>
 			<checks>
 				<file name="trim-3d_wav_y.dat" type="NEFIS">
 					<parameters name="map-series">
@@ -5877,7 +5880,7 @@
 		</testCase>
 		<testCase name="e01_f51_c32800_Two_dimensional_dambreak_july2007_wet" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f51_validation_laboratory/c32800_Two_dimensional_dambreak_july2007_wet</path>
-			
+			<maxRunTime>420</maxRunTime>
 			<checks>
 				<file name="trim-2Ddbw.dat" type="NEFIS">
 					<parameters name="map-series">
@@ -5890,7 +5893,7 @@
 		</testCase>
 		<testCase name="e01_f51_c32801_Two_dimensional_dambreak_july2007_dry" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f51_validation_laboratory/c32801_Two_dimensional_dambreak_july2007_dry</path>
-			
+			<maxRunTime>480</maxRunTime>
 			<checks>
 				<file name="trim-2Ddbd.dat" type="NEFIS">
 					<parameters name="map-series">
@@ -5938,7 +5941,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33101-Curved_back_channel_Curvilinear_3D" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f52_validation_schematic/c33101-Curved_back_channel_Curvilinear_3D</path>
-			
+			<maxRunTime>720</maxRunTime>
 			<checks>
 				<file name="trih-bend.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -5998,7 +6001,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33120-Curved_back_channel_Rectangular_2DH" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f52_validation_schematic/c33120-Curved_back_channel_Rectangular_2DH</path>
-			
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-rect_2DH.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -6020,7 +6023,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33121-Curved_back_channel_Rectangular_3D" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f52_validation_schematic/c33121-Curved_back_channel_Rectangular_3D</path>
-			
+			<maxRunTime>1320</maxRunTime>
 			<checks>
 				<file name="trih-rect_3D.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -6246,7 +6249,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33800-Wind-over-a-schematized-lake" ref="flow2d3d_default">
 			<path version="2024-01-08T09:40:00">e01_d3dflow/f52_validation_schematic/c33800-Wind-over-a-schematized-lake</path>
-			
+			<maxRunTime>360</maxRunTime>
 			<checks>
 				<file name="trih-v03.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -6284,7 +6287,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33900-Tsunami_Okushiri_cyclic" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f52_validation_schematic/c33900-Tsunami_Okushiri_cyclic</path>
-			
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-qc9.dat" type="NEFIS">
 					<parameters name="his-series">
@@ -6304,7 +6307,7 @@
 		</testCase>
 		<testCase name="e01_f52_c33901-Tsunami_Okushiri_flood" ref="flow2d3d_default">
 			<path version="2024-01-08T09:50:00">e01_d3dflow/f52_validation_schematic/c33901-Tsunami_Okushiri_flood</path>
-			
+			<maxRunTime>540</maxRunTime>
 			<checks>
 				<file name="trih-q09.dat" type="NEFIS">
 					<parameters name="his-series">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_1d_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_1d_all_cases.xml
@@ -77,7 +77,7 @@
   </testCase>
   <testCase name="e02_f010_c102_T3_refined_noCustomPoints" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f010_structures/c102_custompoints_dambreak/T3_refined_noCustomPoints</path>
-      <maxRunTime>540</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Dambreak_refinedGRID_noWLpoints/Dambreak_refinedGRID_noWLpoints_map.nc" type="netCDF">
         <parameters>
@@ -96,7 +96,7 @@
   </testCase>
   <testCase name="e02_f010_c102_T4_refined_customPoints" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f010_structures/c102_custompoints_dambreak/T4_refined_customPoints</path>
-      <maxRunTime>540</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Dambreak_refinedGRID_customWLpoints/Dambreak_refinedGRID_customWLpoints_map.nc" type="netCDF">
         <parameters>
@@ -559,6 +559,7 @@
   </testCase>
   <testCase name="e02_f105_c02_tabulated-profile" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f105_cross-sections/c02_tabulated-profile</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Flow1D/Flow1D_map.nc" type="netCDF">
         <parameters>
@@ -580,6 +581,7 @@
   </testCase>
   <testCase name="e02_f105_c03_zw-closed-egg-profile" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f105_cross-sections/c03_zw-closed-egg-profile</path>
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Flow1D/Flow1D_map.nc" type="netCDF">
         <parameters>
@@ -781,6 +783,7 @@
   </testCase>
   <testCase name="e02_f105_c19_timedependent_roughness" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f105_cross-sections/c19_timedependent_roughness</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_FlowFM/FlowFM_map.nc" type="netCDF">
         <parameters>
@@ -794,6 +797,7 @@
   </testCase>
   <testCase name="e02_f105_c41_YZ-profile-with-storage-nodes" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f105_cross-sections/c41_YZ-profile-with-storage-nodes</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_Flow1D/Flow1D_map.nc" type="netCDF">
         <parameters>
@@ -1336,6 +1340,7 @@
   </testCase>
   <testCase name="e02_f107_c03_Coarse1D_Fine2D_Rural_Embedded_Links" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f107_1d2d_validation/c03_Coarse1D_Fine2D_Rural_Embedded_Links</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="DFM_OUTPUT_1D2D/1D2D_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_3d_cases.xml
@@ -319,7 +319,7 @@
   </testCase>
   <testCase name="e02_f019_c040_vertical_mixing_layer_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f019_transport/c040_vertical_mixing_layer_3d</path>
-
+    <maxRunTime>660</maxRunTime>
     <checks>
       <file name="dflowfmoutput/sp_his.nc" type="netCDF">
         <parameters>
@@ -757,7 +757,7 @@
   </testCase>
   <testCase name="e02_f021_c001_bedwithobstacle_anticreep" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c001_bedwithobstacle_anticreep</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
         <parameters>
@@ -771,7 +771,7 @@
   </testCase>
   <testCase name="e02_f021_c002_slopingbed_anticreep" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c002_slopingbed_anticreep</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
         <parameters>
@@ -785,7 +785,7 @@
   </testCase>
   <testCase name="e02_f021_c003_slopingbed_anticreep_z" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c003_slopingbed_anticreep_z</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
         <parameters>
@@ -799,7 +799,7 @@
   </testCase>
   <testCase name="e02_f021_c004_slopingbed_anticreep_z_sigma" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c004_slopingbed_anticreep_z_sigma</path>
-
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
         <parameters>
@@ -813,7 +813,7 @@
   </testCase>
   <testCase name="e02_f021_c101_bedwithobstacle_anticreep_nonequi_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c101_bedwithobstacle_anticreep_nonequi_3d</path>
-
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfmoutput/sigma_map.nc" type="netCDF">
         <parameters>
@@ -827,7 +827,7 @@
   </testCase>
   <testCase name="e02_f021_c102_slopingbed_anticreep_nonequi_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f021_anti-creep/c102_slopingbed_anticreep_nonequi_3d</path>
-
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfmoutput/anticreep01_map.nc" type="netCDF">
         <parameters>
@@ -841,8 +841,7 @@
   </testCase>
   <testCase name="e02_f025_c011_bendcase_structured_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f025_secondary_flow_hydrodynamics/c011_bendcase_structured_3d</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfmoutput/smallbend_map.nc" type="netCDF">
         <parameters>
@@ -881,7 +880,7 @@
   </testCase>
   <testCase name="e02_f090_c011_san_francisco_bay_3d" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f090_validation_realworld/c011_san_francisco_bay_3d</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>1080</maxRunTime>
     <checks>
       <file name="dflowfmoutput/historical_WY2011_map.nc" type="netCDF">
         <parameters>
@@ -1042,7 +1041,7 @@
   </testCase>
   <testCase name="e02_f208_c010_gate_sub_3Dsigma" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c010_gate_sub_3Dsigma</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatesub_3Dsigma_his.nc" type="netCDF">
         <parameters>
@@ -1068,8 +1067,7 @@
   </testCase>
   <testCase name="e02_f208_c012_gate_sub_3Dzsigma1" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c012_gate_sub_3Dzsigma1</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatesub_3Dzsigma1_his.nc" type="netCDF">
         <parameters>
@@ -1082,8 +1080,7 @@
   </testCase>
   <testCase name="e02_f208_c013_gate_sub_3Dzsigma2" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c013_gate_sub_3Dzsigma2</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatesub_3Dzsigma2_his.nc" type="netCDF">
         <parameters>
@@ -1096,8 +1093,7 @@
   </testCase>
   <testCase name="e02_f208_c014_gate_free_3Dsigma" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c014_gate_free_3Dsigma</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1020</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatefree_3Dsigma_his.nc" type="netCDF">
         <parameters>
@@ -1110,8 +1106,7 @@
   </testCase>
   <testCase name="e02_f208_c015_gate_free_3Dz" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c015_gate_free_3Dz</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1020</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatefree_3Dz_his.nc" type="netCDF">
         <parameters>
@@ -1124,8 +1119,7 @@
   </testCase>
   <testCase name="e02_f208_c016_gate_free_3Dzsigma1" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c016_gate_free_3Dzsigma1</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatefree_3Dzsigma1_his.nc" type="netCDF">
         <parameters>
@@ -1138,8 +1132,7 @@
   </testCase>
   <testCase name="e02_f208_c017_gate_free_3Dzsigma2" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c017_gate_free_3Dzsigma2</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/gatefree_3Dzsigma2_his.nc" type="netCDF">
         <parameters>
@@ -1204,7 +1197,7 @@
   </testCase>
   <testCase name="e02_f208_c022_sill_free_3Dsigma" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c022_sill_free_3Dsigma</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/weirfree_3Dsigma_his.nc" type="netCDF">
         <parameters>
@@ -1217,8 +1210,7 @@
   </testCase>
   <testCase name="e02_f208_c023_sill_free_3Dz" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c023_sill_free_3Dz</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>960</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/weirfree_3Dz_his.nc" type="netCDF">
         <parameters>
@@ -1231,8 +1223,7 @@
   </testCase>
   <testCase name="e02_f208_c024_sill_free_3Dzsigma1" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c024_sill_free_3Dzsigma1</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/weirfree_3Dzsigma1_his.nc" type="netCDF">
         <parameters>
@@ -1245,8 +1236,7 @@
   </testCase>
   <testCase name="e02_f208_c025_sill_free_3Dzsigma2" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f208_3D_hydraulic_structures/c025_sill_free_3Dzsigma2</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1260</maxRunTime>
     <checks>
       <file name="dflowfm/dflowfmoutput/weirfree_3Dzsigma2_his.nc" type="netCDF">
         <parameters>
@@ -1948,6 +1938,7 @@
   </testCase>
   <testCase name="e02_f203_c093_chezy_trachytopes_ebb_flood_dependent_3D" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f203_3D_trachytopes/c093_chezy_trachytopes_ebb_flood_dependent_3D</path>
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="dflowfmoutput/tt3_his.nc" type="netCDF">
         <parameters>
@@ -2051,7 +2042,7 @@
   </testCase>
   <testCase name="e02_f211_c003_bubblescreens_nieuwemeer_zsigma" ref="dflowfm_config">
     <path version="DVC">e02_dflowfm/f211_3D_bubblescreens/c003_bubblescreens_nieuwemeer_zsigma</path>
-
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="output/NieuweMeer_zsigma_his.nc" type="netCDF">
         <parameters>
@@ -2067,7 +2058,7 @@
   </testCase>
   <testCase name="e02_f211_c04_bubblescreen_edge_z" ref="dflowfm_config">
     <path version="DVC">e02_dflowfm/f211_bubblescreens/c04_bubblescreen_edge_z</path>
-
+    <maxRunTime>1020</maxRunTime>
     <checks>
       <file name="output/SimpleBucket_his.nc" type="netCDF">
         <parameters>
@@ -2078,7 +2069,7 @@
   </testCase>
   <testCase name="e02_f211_c05_bubblescreen_edge_sigma" ref="dflowfm_config">
     <path version="DVC">e02_dflowfm/f211_bubblescreens/c05_bubblescreen_edge_sigma</path>
-
+    <maxRunTime>1080</maxRunTime>
     <checks>
       <file name="output/SimpleBucket_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_all_but_validation_cases.xml
@@ -1802,7 +1802,7 @@
   </testCase>
   <testCase name="e02_f006_c012_spatially_varying_dicoww" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f006_external_forcing/c012_spatially_varying_dicoww</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="output/spatial_dicoww_his.nc" type="netcdf">
         <parameters>
@@ -2999,7 +2999,7 @@
   </testCase>
   <testCase name="e02_f009_c036_zandloper10m_channelaspect_perpsupergrid" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f009_weirs/c036_zandloper10m_channelaspect_perpsupergrid</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="dflowfmoutput/channel_aspect_perp_supergrid_his.nc" type="netCDF">
         <parameters>
@@ -3228,7 +3228,7 @@
   </testCase>
   <testCase name="e02_f010_c011_gate_free" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c011_gate_free</path>
-    <maxRunTime>540</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -3279,7 +3279,7 @@
   </testCase>
   <testCase name="e02_f010_c021_gate_free_ini_newkeywords" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c021_gate_free_ini_newkeywords</path>
-    <maxRunTime>540</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -5661,7 +5661,7 @@
   </testCase>
   <testCase name="e02_f022_c21_boundary_condition_icond2" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c21_boundary_condition_icond2</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5681,7 +5681,7 @@
   </testCase>
   <testCase name="e02_f022_c22_boundary_condition_icond2_constant" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c22_boundary_condition_icond2_constant</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5701,7 +5701,7 @@
   </testCase>
   <testCase name="e02_f022_c23_boundary_condition_icond3" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c23_boundary_condition_icond3</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5721,7 +5721,7 @@
   </testCase>
   <testCase name="e02_f022_c24_boundary_condition_icond3_constant" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c24_boundary_condition_icond3_constant</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5741,7 +5741,7 @@
   </testCase>
   <testCase name="e02_f022_c25_boundary_condition_icond4" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c25_boundary_condition_icond4</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5761,7 +5761,7 @@
   </testCase>
   <testCase name="e02_f022_c26_boundary_condition_icond4_graded" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c26_boundary_condition_icond4_graded</path>
-
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5781,7 +5781,7 @@
   </testCase>
   <testCase name="e02_f022_c27_boundary_condition_icond4_none" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c27_boundary_condition_icond4_none</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5801,7 +5801,7 @@
   </testCase>
   <testCase name="e02_f022_c28_boundary_condition_icond2_graded" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c28_boundary_condition_icond2_graded</path>
-
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5849,7 +5849,7 @@
   </testCase>
   <testCase name="e02_f022_c31_curvebend_spiral_mor_Bedup" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c31_curvebend_spiral_mor_Bedup</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="dflowfmoutput/smallbend_map.nc" type="netCDF">
         <parameters>
@@ -5954,7 +5954,7 @@
   </testCase>
   <testCase name="e02_f022_c53_curvebend_spiral_mor_Unstr" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c53_curvebend_spiral_mor_Unstr</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/c30smallbendUnstr_map.nc" type="netCDF">
         <parameters>
@@ -5982,7 +5982,7 @@
   </testCase>
   <testCase name="e02_f022_c55_curvebend_spiral_mor_Bedup_Unstr" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c55_curvebend_spiral_mor_Bedup_Unstr</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1140</maxRunTime>
     <checks>
       <file name="dflowfmoutput/c31smallbendUnstr_map.nc" type="netCDF">
         <parameters>
@@ -6110,7 +6110,7 @@
   </testCase>
   <testCase name="e02_f022_c70_boundary_condition_icond0" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c70_boundary_condition_icond0</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -6130,7 +6130,7 @@
   </testCase>
   <testCase name="e02_f022_c71_boundary_condition_icond1" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c71_boundary_condition_icond1</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -6150,7 +6150,7 @@
   </testCase>
   <testCase name="e02_f022_c72_boundary_condition_icond4_graded_linear" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c72_boundary_condition_icond4_graded_linear</path>
-
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -6170,7 +6170,7 @@
   </testCase>
   <testCase name="e02_f022_c73_boundary_condition_icond6" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c73_boundary_condition_icond6</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -6190,7 +6190,7 @@
   </testCase>
   <testCase name="e02_f022_c74_boundary_condition_icond7" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c74_boundary_condition_icond7</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -6278,6 +6278,7 @@
   </testCase>
   <testCase name="e02_f022_c95_extrapolate_bedlevel" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c95_extrapolate_bedlevel</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/r_map.nc" type="netCDF">
         <parameters>
@@ -7018,6 +7019,7 @@
   </testCase>
   <testCase name="e02_f037_c72_with_summerdike" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f037_mor1d_tabulated_crosssections/c72_with_summerdike</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/c72_his.nc" type="netCDF">
         <parameters>
@@ -7490,8 +7492,7 @@
   </testCase>
   <testCase name="e02_f422_c05_migratinghump" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c05_migratinghump</path>
-
-      <maxRunTime>1500</maxRunTime>
+    <maxRunTime>2520</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/hump_19920831_114000_rst.nc" type="netCDF">
         <parameters>
@@ -7905,7 +7906,7 @@
   </testCase>
   <testCase name="e02_f422_c21_boundary_condition_icond2" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c21_boundary_condition_icond2</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -7931,7 +7932,7 @@
   </testCase>
   <testCase name="e02_f422_c22_boundary_condition_icond2_constant" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c22_boundary_condition_icond2_constant</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -7957,7 +7958,7 @@
   </testCase>
   <testCase name="e02_f422_c23_boundary_condition_icond3" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c23_boundary_condition_icond3</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -7983,7 +7984,7 @@
   </testCase>
   <testCase name="e02_f422_c24_boundary_condition_icond3_constant" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c24_boundary_condition_icond3_constant</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8009,7 +8010,7 @@
   </testCase>
   <testCase name="e02_f422_c25_boundary_condition_icond4" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c25_boundary_condition_icond4</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8035,7 +8036,7 @@
   </testCase>
   <testCase name="e02_f422_c26_boundary_condition_icond4_graded" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c26_boundary_condition_icond4_graded</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8061,7 +8062,7 @@
   </testCase>
   <testCase name="e02_f422_c27_boundary_condition_icond4_none" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c27_boundary_condition_icond4_none</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8087,7 +8088,7 @@
   </testCase>
   <testCase name="e02_f422_c28_boundary_condition_icond2_graded" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c28_boundary_condition_icond2_graded</path>
-
+    <maxRunTime>600</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8163,7 +8164,7 @@
   </testCase>
   <testCase name="e02_f422_c31_curvebend_spiral_mor_Bedup" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c31_curvebend_spiral_mor_Bedup</path>
-
+    <maxRunTime>960</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/smallbend_20010101_014000_rst.nc" type="netCDF">
         <parameters>
@@ -8293,7 +8294,7 @@
   </testCase>
   <testCase name="e02_f422_c48_trench_EH_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c48_trench_EH_Unstr</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/t02Unstr_20160803_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8371,8 +8372,7 @@
   </testCase>
   <testCase name="e02_f422_c51_bedslope_effect_slope022_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c51_bedslope_effect_slope022_Unstr</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>2880</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_unstr_20010101_002000_rst.nc" type="netCDF">
         <parameters>
@@ -8424,7 +8424,7 @@
   </testCase>
   <testCase name="e02_f422_c53_curvebend_spiral_mor_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c53_curvebend_spiral_mor_Unstr</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/c30smallbendUnstr_20010101_002000_rst.nc" type="netCDF">
         <parameters>
@@ -8474,8 +8474,7 @@
   </testCase>
   <testCase name="e02_f422_c55_curvebend_spiral_mor_Bedup_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c55_curvebend_spiral_mor_Bedup_Unstr</path>
-
-      <maxRunTime>1500</maxRunTime>
+    <maxRunTime>1680</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/c31smallbendUnstr_20010101_014000_rst.nc" type="netCDF">
         <parameters>
@@ -8835,7 +8834,7 @@
   </testCase>
   <testCase name="e02_f422_c70_boundary_condition_icond0" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c70_boundary_condition_icond0</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8861,7 +8860,7 @@
   </testCase>
   <testCase name="e02_f422_c71_boundary_condition_icond1" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c71_boundary_condition_icond1</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8887,7 +8886,7 @@
   </testCase>
   <testCase name="e02_f422_c72_boundary_condition_icond4_graded_linear" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c72_boundary_condition_icond4_graded_linear</path>
-
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8913,7 +8912,7 @@
   </testCase>
   <testCase name="e02_f422_c73_boundary_condition_icond6" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c73_boundary_condition_icond6</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -8939,7 +8938,7 @@
   </testCase>
   <testCase name="e02_f422_c74_boundary_condition_icond7" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c74_boundary_condition_icond7</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_20151101_001000_rst.nc" type="netCDF">
         <parameters>
@@ -9433,7 +9432,7 @@
   </testCase>
   <testCase name="e02_f422_c95_extrapolate_bedlevel" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c95_extrapolate_bedlevel</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/r_20000101_040000_rst.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_3D.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_3D.xml
@@ -2,8 +2,7 @@
   <!-- ======================================================================== -->
   <testCase name="e105_f06_c071_generalstructure_door_closing_at_sill_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c071_generalstructure_door_closing_at_sill_3Dsigma</path>
-      <maxRunTime>1200</maxRunTime>
-
+    <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
         <parameters>
@@ -22,8 +21,7 @@
   </testCase>
   <testCase name="e105_f06_c074_generalstructure_door_closing_at_sill_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c074_generalstructure_door_closing_at_sill_3Dz</path>
-      <maxRunTime>1200</maxRunTime>
-
+    <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
         <parameters>
@@ -42,8 +40,7 @@
   </testCase>
   <testCase name="e105_f06_c077_generalstructure_door_closing_at_sill_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c077_generalstructure_door_closing_at_sill_3Dz_sigma</path>
-      <maxRunTime>1200</maxRunTime>
-
+    <maxRunTime>1200</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="netCDF">
         <parameters>
@@ -62,7 +59,7 @@
   </testCase>
   <testCase name="e105_f06_c072__generalstructure_lowering_open_door_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c072_generalstructure_lowering_open_door_3Dsigma</path>
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1380</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -81,7 +78,7 @@
   </testCase>
   <testCase name="e105_f06_c075__generalstructure_lowering_open_door_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c075_generalstructure_lowering_open_door_3Dz</path>
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1440</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -100,7 +97,7 @@
   </testCase>
   <testCase name="e105_f06_c078__generalstructure_lowering_open_door_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c078_generalstructure_lowering_open_door_3Dz_sigma</path>
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1440</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="netCDF">
         <parameters>
@@ -119,7 +116,7 @@
   </testCase>
   <testCase name="e105_f06_c073_generalstructure_lowering_closed_door_3Dsigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c073_generalstructure_lowering_closed_door_3Dsigma</path>
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1380</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>
@@ -138,7 +135,7 @@
   </testCase>
   <testCase name="e105_f06_c076_generalstructure_lowering_closed_door_3Dz" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c076_generalstructure_lowering_closed_door_3Dz</path>
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1440</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>
@@ -157,8 +154,7 @@
   </testCase>
   <testCase name="e105_f06_c079_generalstructure_lowering_closed_door_3Dz_sigma" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f06_3D_RTC/c079_generalstructure_lowering_closed_door_3Dz_sigma</path>
-
-      <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1380</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_general.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_drtc_general.xml
@@ -45,7 +45,7 @@
   </testCase>
   <testCase name="e105_f01_c072_generalstructure_lowering_open_door" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c072_generalstructure_lowering_open_door</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="NETCDF">
         <parameters>
@@ -62,7 +62,7 @@
   </testCase>
   <testCase name="e105_f01_c073_generalstructure_lowering_closed_door" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c073_generalstructure_lowering_closed_door</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="NETCDF">
         <parameters>
@@ -96,6 +96,7 @@
   </testCase>
   <testCase name="e105_f01_c076_gate_lowering_open_door" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c076_gate_lowering_open_door</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="NETCDF">
         <parameters>
@@ -112,6 +113,7 @@
   </testCase>
   <testCase name="e105_f01_c077_gate_lowering_closed_door" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c077_gate_lowering_closed_door</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="NETCDF">
         <parameters>
@@ -128,7 +130,7 @@
   </testCase>
   <testCase name="e105_f01_c081_generalstructure_door_closing_at_sill_v2" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c081_generalstructure_door_closing_at_sill_v2</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>960</maxRunTime>
     <checks>
       <file name="dflowfm/output/t2_his.nc" type="NETCDF">
         <parameters>
@@ -145,7 +147,7 @@
   </testCase>
   <testCase name="e105_f01_c082_generalstructure_lowering_open_door_v2" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c082_generalstructure_lowering_open_door_v2</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/output/t3_his.nc" type="NETCDF">
         <parameters>
@@ -162,7 +164,7 @@
   </testCase>
   <testCase name="e105_f01_c083_generalstructure_lowering_closed_door_v2" ref="dimr_trunk">
     <path version="DVC">e105_dflowfm-drtc/f01_general/c083_generalstructure_lowering_closed_door_v2</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="dflowfm/output/t4_his.nc" type="NETCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves.xml
@@ -93,6 +93,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c01" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c01-validation_3.1.6/dfm</path>
+    <maxRunTime>360</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/fff_map.nc" type="NETCDF">
@@ -114,7 +115,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c02" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c02-FriesianInlet_schematic/dfm</path>
-    <maxRunTime>480</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -136,8 +137,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c03" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c03-FriesianInlet_realistic/dfm</path>
-      <maxRunTime>900</maxRunTime>
-
+    <maxRunTime>1020</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/r17_map.nc" type="NETCDF">
@@ -159,7 +159,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c05" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c05-california/dfm</path>
-      <maxRunTime>480</maxRunTime>
+    <maxRunTime>660</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/cca_map.nc" type="NETCDF">
@@ -181,7 +181,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f02_c06" ref="dimr_trunk">
     <path version="DVC">e100_dflowfm-dwaves/f02_delft3d_cases/c06-loosdrecht/dfm</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1080</maxRunTime>
     <checks>
       <file name="fm/dflowfmoutput/loo_map.nc" type="NETCDF">
         <parameters>
@@ -249,7 +249,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c01" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c01-ti_com_dtuser_default</path>
-      <maxRunTime>480</maxRunTime>
+    <maxRunTime>780</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -271,7 +271,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c02" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c02-ti_com_10xdtuser</path>
-
+    <maxRunTime>540</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -293,7 +293,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c03" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c03-ti_com_10xdtuser_tcoms_tcome</path>
-
+    <maxRunTime>540</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -315,7 +315,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c04" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c04-comtimevector</path>
-
+    <maxRunTime>540</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">
@@ -337,7 +337,7 @@
   <!-- ======================================================================== -->
   <testCase name="e100_f09_c05" ref="dimr_noconfig">
     <path version="DVC">e100_dflowfm-dwaves/f09_comwrite_intervals/c05-ti_com_dtuser_in_mdu</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>660</maxRunTime>
     <!-- seconds -->
     <checks>
       <file name="fm/dflowfmoutput/f34_map.nc" type="NETCDF">

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves_parallel_c01.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_dwaves_parallel_c01.xml
@@ -1,6 +1,7 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
   <testCase name="e100_f10_c01_fm3_wave1_omp" ref="dimr">
     <path version="DVC">e100_dflowfm-dwaves/f10_parallel/c01_fm3_wave1_omp</path>
+    <maxRunTime>360</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_hydfile_cases_lnx64.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_hydfile_cases_lnx64.xml
@@ -176,6 +176,7 @@
   </testCase>
   <testCase name="e02_f029_c400_bubblescreen_box_model" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c400_bubblescreen_box_model</path>
+    <maxRunTime>1020</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
         <arguments>
@@ -218,6 +219,7 @@
   </testCase>
   <testCase name="e02_f029_c401_bubblescreen_nieuwe_meer" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c401_bubblescreen_nieuwe_meer</path>
+    <maxRunTime>1020</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_hydfile_cases_win64.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_hydfile_cases_win64.xml
@@ -175,6 +175,7 @@
   </testCase>
   <testCase name="e02_f029_c400_bubblescreen_box_model" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c400_bubblescreen_box_model</path>
+    <maxRunTime>1020</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
         <arguments>
@@ -217,6 +218,7 @@
   </testCase>
   <testCase name="e02_f029_c401_bubblescreen_nieuwe_meer" ref="dimr_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c401_bubblescreen_nieuwe_meer</path>
+    <maxRunTime>1020</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_oldext_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_oldext_cases.xml
@@ -1920,7 +1920,7 @@
   </testCase>
   <testCase name="e02_f010_c011_oldext_gate_free" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c011_oldext_gate_free</path>
-      <maxRunTime>450</maxRunTime>
+    <maxRunTime>450</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -2007,7 +2007,7 @@
   </testCase>
   <testCase name="e02_f010_c021_oldext_gate_free_ini_newkeywords" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f010_structures/c021_oldext_gate_free_ini_newkeywords</path>
-      <maxRunTime>450</maxRunTime>
+    <maxRunTime>450</maxRunTime>
     <checks>
       <file name="dflowfmoutput/gatefree_his.nc" type="netCDF">
         <parameters>
@@ -3834,7 +3834,7 @@
   </testCase>
   <testCase name="e02_f022_c26_oldext_boundary_condition_icond4_graded" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c26_oldext_boundary_condition_icond4_graded</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -3874,7 +3874,7 @@
   </testCase>
   <testCase name="e02_f022_c28_oldext_boundary_condition_icond2_graded" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c28_oldext_boundary_condition_icond2_graded</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -4056,7 +4056,6 @@
   <testCase name="e02_f022_c55_oldext_curvebend_spiral_mor_Bedup_Unstr" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c55_oldext_curvebend_spiral_mor_Bedup_Unstr</path>
     <maxRunTime>600</maxRunTime>
-
     <checks>
       <file name="dflowfmoutput/c31smallbendUnstr_map.nc" type="netCDF">
         <parameters>
@@ -4224,7 +4223,7 @@
   </testCase>
   <testCase name="e02_f022_c72_oldext_boundary_condition_icond4_graded_linear" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c72_oldext_boundary_condition_icond4_graded_linear</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/str_his.nc" type="netCDF">
         <parameters>
@@ -5068,8 +5067,7 @@
   </testCase>
   <testCase name="e02_f422_c05_oldext_migratinghump" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c05_oldext_migratinghump</path>
-
-      <maxRunTime>1500</maxRunTime>
+    <maxRunTime>1500</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/hump_19920831_114000_rst.nc" type="netCDF">
         <parameters>
@@ -5741,7 +5739,7 @@
   </testCase>
   <testCase name="e02_f422_c31_oldext_curvebend_spiral_mor_Bedup" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c31_oldext_curvebend_spiral_mor_Bedup</path>
-
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/smallbend_20010101_014000_rst.nc" type="netCDF">
         <parameters>
@@ -5949,7 +5947,7 @@
   </testCase>
   <testCase name="e02_f422_c51_oldext_bedslope_effect_slope022_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c51_oldext_bedslope_effect_slope022_Unstr</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1380</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/str_unstr_20010101_002000_rst.nc" type="netCDF">
         <parameters>
@@ -6051,7 +6049,7 @@
   </testCase>
   <testCase name="e02_f422_c55_oldext_curvebend_spiral_mor_Bedup_Unstr" ref="dflowfm_restart">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c55_oldext_curvebend_spiral_mor_Bedup_Unstr</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/c31smallbendUnstr_20010101_014000_rst.nc" type="netCDF">
         <parameters>
@@ -6179,7 +6177,7 @@
   </testCase>
   <testCase name="e02_f422_c60_oldext_thindams" ref="dflowfm_restart_platform">
     <path version="DVC">e02_dflowfm/f422_morphology_2D_restart/c60_oldext_thindams</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="main/dflowfmoutput/dams_sed_20010101_002000_rst.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel.xml
@@ -88,6 +88,7 @@
   </testCase>
   <testCase name="e02_f012_c0325" ref="dimr">
     <path version="DVC">e02_dflowfm/f012_inout/c0325_alloutrealistic_f12_e02_3dom_classmap</path>
+    <maxRunTime>540</maxRunTime>
     <checks>
       <file name="dflowfmoutput/classmap_0000.nc" type="NETCDF">
         <parameters>
@@ -155,7 +156,7 @@
   </testCase>
   <testCase name="e02_f014_c001_trench_EH_par_crs" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c001_trench_EH_par_crs</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <programs>
       <program ref="dflowfm" seq="1">
         <arguments>
@@ -181,6 +182,7 @@
   </testCase>
   <testCase name="e02_f014_c041_westerscheldt_structures" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c041_westerscheldt_structures</path>
+    <maxRunTime>420</maxRunTime>
     <programs>
       <program ref="dflowfm" seq="1">
         <arguments>
@@ -206,7 +208,7 @@
   </testCase>
   <testCase name="e02_f014_c042_dad_2dredge1dump_layered_bed_par" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c042_dad_2dredge1dump_layered_bed_par</path>
-    <maxRunTime>480</maxRunTime>
+    <maxRunTime>660</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>
@@ -260,7 +262,7 @@
   <!-- </testCase> -->
   <testCase name="e02_f014_c101_icg7" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c101_guayas_model_icgsolver7</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>
@@ -405,6 +407,7 @@
   <!-- </testCase> -->
   <testCase name="e02_f014_c150" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c150_longculvert_parallel</path>
+    <maxRunTime>360</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>
@@ -428,6 +431,7 @@
   </testCase>
   <testCase name="e02_f014_c151_convert_old_longculverts_before_partitioning" ref="generic">
     <path version="DVC">e02_dflowfm/f014_parallel/c151_convert_old_longculverts_before_partitioning</path>
+    <maxRunTime>420</maxRunTime>
     <programs>
       <program ref="dflowfm">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_lnx64_singularity.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_lnx64_singularity.xml
@@ -62,6 +62,7 @@
     </testCase>
     <testCase name="e02_f012_c0325" ref="sif_dimr">
         <path version="2025-10-15T15:07:12.409000">e02_dflowfm/f012_inout/c0325_alloutrealistic_f12_e02_3dom_classmap</path>
+        <maxRunTime>540</maxRunTime>
         <programs>
           <program ref="execute_singularity">
             <arguments>
@@ -186,6 +187,7 @@
     </testCase>
     <testCase name="e02_f014_c041_westerscheldt_structures" ref="sif_dimr">
       <path version="2026-03-17T10:15:49.591000">e02_dflowfm/f014_parallel/c041_westerscheldt_structures</path>
+      <maxRunTime>420</maxRunTime>
       <programs>
         <program ref="execute_singularity" seq="1">
           <arguments>
@@ -257,8 +259,7 @@
             </file>
         </checks>
     </testCase>
-    <testCase name="e02_f014_c101_icg7" ref="sif_dimr">
-      <maxRunTime>900</maxRunTime>
+    <testCase name="e02_f014_c101_icg7" ref="sif_dimr">        <maxRunTime>900</maxRunTime>
         <path version="2025-10-15T15:07:16.919000">e02_dflowfm/f014_parallel/c101_guayas_model_icgsolver7</path>
         <programs>
           <program ref="execute_singularity">
@@ -345,6 +346,7 @@
     </testCase>
     <testCase name="e02_f014_c201" ref="sif_dimr">
         <path version="2024-01-11T16:40:00">e02_dflowfm/f014_parallel/c201_genstruc_partition</path>
+        <maxRunTime>480</maxRunTime>
         <programs>
           <program ref="execute_singularity">
             <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_lnx64_singularity.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_lnx64_singularity.xml
@@ -259,8 +259,9 @@
             </file>
         </checks>
     </testCase>
-    <testCase name="e02_f014_c101_icg7" ref="sif_dimr">        <maxRunTime>900</maxRunTime>
+    <testCase name="e02_f014_c101_icg7" ref="sif_dimr">
         <path version="2025-10-15T15:07:16.919000">e02_dflowfm/f014_parallel/c101_guayas_model_icgsolver7</path>
+        <maxRunTime>900</maxRunTime>
         <programs>
           <program ref="execute_singularity">
             <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_memory_intensive.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_parallel_memory_intensive.xml
@@ -4,6 +4,7 @@
     -->
   <testCase name="e02_f014_c201" ref="dimr">
     <path version="DVC">e02_dflowfm/f014_parallel/c201_genstruc_partition</path>
+    <maxRunTime>480</maxRunTime>
     <programs>
       <program ref="dimr">
         <arguments>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_processes.xml
@@ -251,6 +251,7 @@
   </testCase>
   <testCase name="e02_f030_c003_westernscheldt_dynamo_2D" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c003_westernscheldt_dynamo_2D</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/westernscheldt_map.nc" type="netCDF">
         <parameters>
@@ -369,6 +370,7 @@
   </testCase>
   <testCase name="e02_f030_c004_westernscheldt_noproc_2D" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c004_westernscheldt_noproc_2D</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/westernscheldt_map.nc" type="netCDF">
         <parameters>
@@ -735,7 +737,7 @@
   </testCase>
   <testCase name="e02_f030_c013_westernscheldt_dynamo_2D_restart" ref="dflowfm_platform_specific_refs_restart">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c013_westernscheldt_dynamo_2D_restart</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/westernscheldt_restart_map.nc" type="netCDF">
         <parameters>
@@ -1381,6 +1383,7 @@
   </testCase>
   <testCase name="e02_f030_c109_westernscheldt_dynamo_2D_statistics" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c109_westernscheldt_dynamo_2D_statistics</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/westernscheldt_map.nc" type="netCDF">
         <parameters>
@@ -1480,7 +1483,7 @@
   </testCase>
   <testCase name="e02_f030_c201_parallel_mba_sink_source" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c201_parallel_mba_sink_source</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>1140</maxRunTime>
     <programs>
       <program ref="dimr_plain" seq="1">
         <arguments>
@@ -1526,7 +1529,7 @@
   </testCase>
   <testCase name="e02_f030_c202_parallel_dredge_dump" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c202_parallel_dredge_dump</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>1260</maxRunTime>
     <programs>
       <program ref="dimr_plain" seq="1">
         <arguments>
@@ -1596,7 +1599,7 @@
   </testCase>
   <testCase name="e02_f030_c401_Course_tracers" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c401_Course_tracers</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>
@@ -1625,7 +1628,7 @@
   </testCase>
   <testCase name="e02_f030_c402_Course_bacteria" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f030_water_quality_processes/c402_Course_bacteria</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>720</maxRunTime>
     <checks>
       <file name="Computation/DFM_OUTPUT_westerscheldt01/westerscheldt01_map.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_wanda.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_wanda.xml
@@ -2,6 +2,7 @@
   <!-- ======================================================================== -->
   <testCase name="e121_f02_c01_sequential" ref="dimr_trunk">
     <path version="DVC">e121_dflowfm_wanda/f02_turbines/c01_sequential</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dhydro/DFM_OUTPUT_TurbineTest/TurbineTest_map.nc" type="NETCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling.xml
@@ -613,6 +613,7 @@
   </testCase>
   <testCase name="e02_f029_c024_laterals_3D_s_3dom" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c024_laterals_3D_s_3dom</path>
+    <maxRunTime>420</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
         </program>
@@ -699,6 +700,7 @@
   </testCase>
   <testCase name="e02_f029_c025_laterals_3D_z_3dom" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c025_laterals_3D_z_3dom</path>
+    <maxRunTime>420</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
         </program>
@@ -786,7 +788,7 @@
   <!-- MULTIDOMAIN WORKFLOW -->
   <testCase name="e02_f029_c101_westerschelde_2d_three_domains" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c101_westerschelde_2d_3dom</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1200</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
         </program>
@@ -872,7 +874,7 @@
   </testCase>
   <testCase name="e02_f029_c102_westerschelde_3d_s_three_domains" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c102_westerschelde_3d_s_3dom</path>
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>1500</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
         </program>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_1D2D.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_1D2D.xml
@@ -2304,6 +2304,7 @@
   </testCase>
   <testCase name="e02_f029_c606_Universal_Weir_WAQ" ref="dwaq_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c606_Universal_Weir_WAQ</path>
+    <maxRunTime>480</maxRunTime>
     <programs>
       <program ref="dimr_waq" seq="1">
           </program>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_aggregation.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_aggregation.xml
@@ -3,6 +3,7 @@
   <!-- ONLINE AGGREGATION, ONE DOMAIN -->
   <testCase name="e02_f029_c201_hyd_file_westerschelde_3d_s_hag" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c201_westerschelde_3d_s_hag</path>
+    <maxRunTime>600</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
     </program>
@@ -280,6 +281,7 @@
   </testCase>
   <testCase name="e02_f029_c205_hyd_file_westerschelde_3d_z_hag" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c205_westerschelde_3d_z_hag</path>
+    <maxRunTime>720</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
     </program>
@@ -348,6 +350,7 @@
   </testCase>
   <testCase name="e02_f029_c206_hyd_file_westerschelde_3d_z_vag" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c206_westerschelde_3d_z_vag</path>
+    <maxRunTime>480</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
     </program>
@@ -416,6 +419,7 @@
   </testCase>
   <testCase name="e02_f029_c207_hyd_file_westerschelde_3d_z_hvag" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c207_westerschelde_3d_z_hvag</path>
+    <maxRunTime>480</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
     </program>
@@ -485,6 +489,7 @@
   <!-- ONLINE AGGREGATION, THREE DOMAINS -->
   <testCase name="e02_f029_c301_hyd_file_westerschelde_3d_s_hag_3dom" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c301_westerschelde_3d_s_hag_3dom</path>
+    <maxRunTime>660</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
     </program>
@@ -559,6 +564,7 @@
   </testCase>
   <testCase name="e02_f029_c302_hyd_file_westerschelde_3d_s_vag_3dom" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c302_westerschelde_3d_s_vag_3dom</path>
+    <maxRunTime>540</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
     </program>
@@ -633,6 +639,7 @@
   </testCase>
   <testCase name="e02_f029_c303_hyd_file_westerschelde_3d_s_hvag_3dom" ref="dflowfm_platform_specific_refs">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c303_westerschelde_3d_s_hvag_3dom</path>
+    <maxRunTime>420</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
     </program>
@@ -781,6 +788,7 @@
   </testCase>
   <testCase name="e02_f029_c305_hyd_file_westerschelde_3d_z_hag_3dom" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c305_westerschelde_3d_z_hag_3dom</path>
+    <maxRunTime>360</maxRunTime>
     <programs>
       <program ref="dimr-mpi" seq="1">
     </program>

--- a/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_structures.xml
+++ b/test/deltares_testbench/configs/include/dimr_dflowfm_waq_coupling_structures.xml
@@ -1,6 +1,7 @@
 <testCases xmlns="http://schemas.deltares.nl/deltaresTestbench_v3">
   <testCase name="e02_f029_c205_hyd_file_westerschelde_3d_z_hag_structures" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f029_hyd_file/c205_westerschelde_3d_z_hag_structures</path>
+    <maxRunTime>360</maxRunTime>
     <programs>
       <program ref="dimr" seq="1">
     </program>

--- a/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dmorphology_validation_cases.xml
@@ -27,8 +27,7 @@
   </testCase>
   <testCase name="e02_f022_c106_flow_wave_morpho_straightcoast" ref="platform_specific">
     <path version="DVC">e02_dflowfm/f022_morphology_2D/c106_flow_wave_morpho_straightcoast</path>
-
-      <maxRunTime>1500</maxRunTime>
+    <maxRunTime>1500</maxRunTime>
     <checks>
       <file name="fm/output/FlowFM_map.nc" type="netCDF">
         <parameters>
@@ -59,6 +58,7 @@
   </testCase>
   <testCase name="e02_f039_c01_sedimentationtest" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f039_morphology_3d/c01_sedimentationtest</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/massbal_1frac_map.nc" type="netCDF">
         <parameters>
@@ -131,6 +131,7 @@
   </testCase>
   <testCase name="e02_f039_c07_sediment_ini_3d_uniform_polygon" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f039_morphology_3d/c07_sediment_ini_3d_uniform_polygon</path>
+    <maxRunTime>480</maxRunTime>
     <checks>
       <file name="dflowfmoutput/massbal_1frac_his.nc" type="netCDF">
         <parameters>
@@ -169,6 +170,7 @@
   </testCase>
   <testCase name="e02_f039_c10_sediment_ini_3d_verticalsigmaprofile" ref="dflowfm_default">
     <path version="DVC">e02_dflowfm/f039_morphology_3d/c10_sediment_ini_3d_verticalsigmaprofile</path>
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="dflowfmoutput/massbal_1frac_his.nc" type="netCDF">
         <parameters>

--- a/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
+++ b/test/deltares_testbench/configs/include/dimr_dwaves_all_cases.xml
@@ -184,8 +184,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f02_c05_windfields" ref="dimr_trunk">
     <path version="DVC">e04_wave/f02-windfields/c05</path>
-
-      <maxRunTime>900</maxRunTime>
+    <maxRunTime>900</maxRunTime>
     <checks>
       <file name="wavm-grw.nc" type="NETCDF">
         <parameters>
@@ -199,8 +198,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f02_c06_windfields" ref="dimr_noconf">
     <path version="DVC">e04_wave/f02-windfields/c06</path>
-
-      <maxRunTime>1500</maxRunTime>
+    <maxRunTime>1500</maxRunTime>
     <checks>
       <file name="wavm-osaka.nc" type="NETCDF">
         <parameters>
@@ -298,7 +296,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f04_c06" ref="dimr_trunk">
     <path version="DVC">e04_wave/f04-general/c06</path>
-
+    <maxRunTime>420</maxRunTime>
     <checks>
       <file name="wavm-grw.nc" type="NETCDF">
         <parameters>
@@ -325,7 +323,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f04_c08" ref="dimr_trunk">
     <path version="DVC">e04_wave/f04-general/c08_missing_gridvalue</path>
-
+    <maxRunTime>360</maxRunTime>
     <checks>
       <file name="wavm-Waves.nc" type="NETCDF">
         <parameters>
@@ -378,7 +376,7 @@
   </testCase>
   <testCase name="e04_f05_c03_nest" ref="dimr_trunk">
     <path version="DVC">e04_wave/f05-nest/c03_nest_xymiss</path>
-    <maxRunTime>600</maxRunTime>
+    <maxRunTime>660</maxRunTime>
     <checks>
       <file name="wavm-waves-overall_cut_v0.nc" type="NETCDF">
         <parameters>
@@ -455,7 +453,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f09_c02_SWANDCSM" ref="dimr_trunk">
     <path version="DVC">e04_wave/f09-SWANDCSM/c02</path>
-    <maxRunTime>1800</maxRunTime>
+    <maxRunTime>2340</maxRunTime>
     <checks>
       <file name="wavm-Waves.nc" type="NETCDF">
         <parameters>
@@ -469,7 +467,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f09_c03_SWANDCSM" ref="dimr_trunk">
     <path version="DVC">e04_wave/f09-SWANDCSM/c03</path>
-    <maxRunTime>1500</maxRunTime>
+    <maxRunTime>1620</maxRunTime>
     <checks>
       <file name="wavm-Waves.nc" type="NETCDF">
         <parameters>
@@ -497,7 +495,7 @@
   <!-- ======================================================================== -->
   <testCase name="e04_f09_c05_SWANDCSM" ref="dimr_trunk">
     <path version="DVC">e04_wave/f09-SWANDCSM/c05</path>
-    <maxRunTime>1200</maxRunTime>
+    <maxRunTime>1800</maxRunTime>
     <checks>
       <file name="wavm-Waves.nc" type="NETCDF">
         <parameters>


### PR DESCRIPTION
# What was done 

I used the CSV file from Robin's testbench statistics, found here:
https://dpcbuild.deltares.nl/repository/download/Temporary_PersonalBuildsRobin_Delft3DBranch_TestbenchTimeoutReport/7856119:id/timeout-report/cases.csv

This file contains the maximum run times over the last 100 runs of every test case on teamcity.
For each test case, I multiplied this maximum run time by 1.5 and rounded up to the nearest full minute. I then applied these new max run times to all of the test cases in our 'configs/' folder. I ended up having to update quite a few. I only allow `maxRunTime` upgrades to keep the diff a bit smaller.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [ ]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [ ] Tests updated \
<add testcase numbers if applicable, Issue number>
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [ ]	Not applicable 

# Issue link
