### PR TITLE
UNST-10332: Communicate 3d flow velocities from FM to preC-SUMO

### DIFF
--- a/examples/dflowfm/12_dflowfm_pre_C_SUMO/precice_config.xml
+++ b/examples/dflowfm/12_dflowfm_pre_C_SUMO/precice_config.xml
@@ -13,6 +13,7 @@
   <data:scalar name="sea_surface_height" />
   <data:scalar name="sea_floor_depth_below_geoid" />
   <data:scalar name="sea_water_potential_density" />
+  <data:vector name="flow_velocity_3d" />
   <data:scalar name="C01" />
   <data:scalar name="C02" />
   <data:scalar name="C03" />
@@ -45,6 +46,7 @@
   </mesh>
   <mesh name="fm_flow_cells_3d" dimensions="3">
     <use-data name="sea_water_potential_density" />
+    <use-data name="flow_velocity_3d" />
     <use-data name="C01" />
     <use-data name="C02" />
     <use-data name="C03" />
@@ -65,6 +67,7 @@
   </mesh>
   <mesh name="csumo_3d_nodes" dimensions="3">
     <use-data name="sea_water_potential_density" />
+    <use-data name="flow_velocity_3d" />
     <use-data name="C01" />
     <use-data name="C02" />
     <use-data name="C03" />
@@ -108,6 +111,7 @@
     <write-data name="sea_surface_height" mesh="fm_flow_cells" />
     <write-data name="sea_floor_depth_below_geoid" mesh="fm_flow_cells" />
     <write-data name="sea_water_potential_density" mesh="fm_flow_cells_3d" />
+    <write-data name="flow_velocity_3d" mesh="fm_flow_cells_3d" />
     <write-data name="C01" mesh="fm_flow_cells_3d" />
     <write-data name="C02" mesh="fm_flow_cells_3d" />
     <write-data name="C03" mesh="fm_flow_cells_3d" />
@@ -152,6 +156,7 @@
     <read-data name="sea_surface_height" mesh="csumo_2d_nodes" />
     <read-data name="sea_floor_depth_below_geoid" mesh="csumo_2d_nodes" />
     <read-data name="sea_water_potential_density" mesh="csumo_3d_nodes" />
+    <read-data name="flow_velocity_3d" mesh="csumo_3d_nodes" />
     <read-data name="C01" mesh="csumo_3d_nodes" />
     <read-data name="C02" mesh="csumo_3d_nodes" />
     <read-data name="C03" mesh="csumo_3d_nodes" />
@@ -198,6 +203,7 @@
     <exchange data="sea_surface_height" mesh="fm_flow_cells" from="fm" to="preC-SUMO" initialize="true" />
     <exchange data="sea_floor_depth_below_geoid" mesh="fm_flow_cells" from="fm" to="preC-SUMO" initialize="true" />
     <exchange data="sea_water_potential_density" mesh="fm_flow_cells_3d" from="fm" to="preC-SUMO" initialize="true" />
+    <exchange data="flow_velocity_3d" mesh="fm_flow_cells_3d" from="fm" to="preC-SUMO" initialize="true" />
     <exchange data="C01" mesh="fm_flow_cells_3d" from="fm" to="preC-SUMO" initialize="true" />
     <exchange data="C02" mesh="fm_flow_cells_3d" from="fm" to="preC-SUMO" initialize="true" />
     <exchange data="C03" mesh="fm_flow_cells_3d" from="fm" to="preC-SUMO" initialize="true" />

--- a/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
+++ b/src/engines_gpl/dflowfm/packages/dflowfm_kernel/src/dflowfm_manager/precice_adapter/adapter.F90
@@ -35,12 +35,12 @@ module precice_adapter
 
    !> Container with all quantities used by the adapter.
    type :: quantities_t
-      ! TODO: Add constituents C01..C10
       ! Writing
       type(quantity_t) :: bl = quantity_t(standard_name="sea_floor_depth_below_geoid", is_active=.true.)
       type(quantity_t) :: s1 = quantity_t(standard_name="sea_surface_height", is_active=.true.)
       type(quantity_t) :: hs = quantity_t(standard_name="sea_floor_depth_below_sea_surface", is_active=.false.)
       type(quantity_t) :: rho = quantity_t(standard_name="sea_water_potential_density", is_active=.true.)
+      type(quantity_t) :: flow_velocity_3d = quantity_t(standard_name="flow_velocity_3d", is_active=.true.)
       ! Constituents (reading and writing)
       type(quantity_t), dimension(NUM_COUPLED_CONSTITUENTS) :: constituents
       ! Reading
@@ -354,6 +354,9 @@ contains
       class(precice_adapter_t), intent(in) :: self
 
       integer :: constituent_index
+      ! Temporary flow velocity buffer [v1x,v1y,v1z, v2x, v2y, v2z, ... , vNx, vNy, vNz]
+      integer :: i
+      real(kind=c_double), dimension(:), allocatable :: flow_velocity_3d_buffer
 
       if (self%quantities%hs%is_active) then
          call precicef_write_data(self%cell_center_mesh_name, self%quantities%hs%standard_name, &
@@ -374,6 +377,19 @@ contains
          call precicef_write_data(self%cell_center_mesh_3d_name, self%quantities%rho%standard_name, &
                                   size(self%vertex_ids_3d), self%vertex_ids_3d, &
                                   potential_density, len(self%cell_center_mesh_3d_name), len(trim(self%quantities%rho%standard_name)))
+      end if
+      if (self%quantities%flow_velocity_3d%is_active) then
+         ! TODO: Actually access FM velocities. Requires to look up how to get the cell centre values.
+         ! For now: send 3,2,1 ..
+         if (.not. allocated(flow_velocity_3d_buffer)) then
+            allocate(flow_velocity_3d_buffer(size(self%cell_center_mesh_coordinates_3d)))
+            do i = 1, size(self%cell_center_mesh_coordinates_3d)
+               flow_velocity_3d_buffer(i) = 3.0 - mod(i,3)
+            end do
+         end if
+         call precicef_write_data(self%cell_center_mesh_3d_name, self%quantities%flow_velocity_3d%standard_name, &
+                                  size(self%vertex_ids_3d), self%vertex_ids_3d, &
+                                  flow_velocity_3d_buffer, len(self%cell_center_mesh_3d_name), len(trim(self%quantities%flow_velocity_3d%standard_name)))
       end if
       ! Write constituents. At the moment we support only up to NUM_COUPLED_CONSTITUENTS (=10).
       if (numconst > NUM_COUPLED_CONSTITUENTS) then

--- a/src/tools_gpl/pre_c_sumo/include/coupling_steps.hpp
+++ b/src/tools_gpl/pre_c_sumo/include/coupling_steps.hpp
@@ -28,6 +28,7 @@ namespace pre_c_sumo
     constexpr std::string_view bed_levels_id = "sea_floor_depth_below_geoid";
     constexpr std::string_view water_depth_id = "sea_floor_depth_below_sea_surface";
     constexpr std::string_view densities_id = "sea_water_potential_density";
+    constexpr std::string_view flow_velocities_id = "flow_velocity_3d";
 
     struct DiffuserMapping
     {

--- a/src/tools_gpl/pre_c_sumo/src/coupling_steps.cpp
+++ b/src/tools_gpl/pre_c_sumo/src/coupling_steps.cpp
@@ -32,8 +32,9 @@ namespace pre_c_sumo
             layers.emplace_back(FarFieldLayer{
                 // 3d.coordinates = (x1, y1, z1, x2, y2, z2, ...): skip "index_3d + i" points, then skip x and y
                 .z_coordinate = mesh_3d.coordinates[(index_3d + i) * 3 + 2],
-                .x_velocity = 0.0, // TODO: obtain from far-field data
-                .y_velocity = 0.0, // TODO: obtain from far-field data
+                // 3d.velocities = (vx1, vy1, vz1, vx2, vy2, vz2, ...): skip "index_3d + i" points, then get x and y
+                .x_velocity = mesh_3d.quantities[flow_velocities_id][(index_3d + 1) * 3 + 0],
+                .y_velocity = mesh_3d.quantities[flow_velocities_id][(index_3d + 1) * 3 + 1],
                 .density = mesh_3d.quantities[densities_id][index_3d + i],
                 .constituents = {0.0, 0.0, 0.0}, // constituents, // TODO: obtain layered data from far-field
             });

--- a/src/tools_gpl/pre_c_sumo/src/pre_c_sumo_lib.cpp
+++ b/src/tools_gpl/pre_c_sumo/src/pre_c_sumo_lib.cpp
@@ -143,6 +143,7 @@ namespace pre_c_sumo
         participant.setMeshVertices(csumo_3d_mesh.name, csumo_3d_mesh.coordinates, csumo_3d_mesh.vertex_ids);
         // Add preCICE quantity data buffers.
         csumo_3d_mesh.quantities[densities_id] = std::vector<double>(csumo_3d_mesh.number_of_nodes);
+        csumo_3d_mesh.quantities[flow_velocities_id] = std::vector<double>(csumo_3d_mesh.number_of_nodes * 3);
 
         double current_time_seconds = 0.0;
         if (!waitForNF2FFFiles(csumo_settings.value(), current_time_seconds))


### PR DESCRIPTION
# What was done 

- Added config to precice config of example 12.
- Added writing of 3D velocities (X,Y,Z) to FM 3D mesh
- Added reading of 3D velocities (X,Y,Z) from CSUMO 3D mesh
- Added writing of C-SUMO 2D (X,Y) velocities to NF fields.

# Evidence of the work done 

- [ ]	Video/figures \
<add video/figures if applicable> 
- [x]	Clear from the issue description 
- [ ]	Not applicable 

# Tests 
- [x] Tests updated \
Example 12
- [ ]	Not applicable 

# Documentation  
- [ ]	Documentation updated \
<add description of changes if applicable, Issue number> 
- [x]	Not applicable 

# Issue link
UNST-10332